### PR TITLE
refactor reverse query

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -1,31 +1,15 @@
-var logger = require('../src/logger');
 
-// Build pelias search query
+var logger = require('../src/logger'),
+    queries = require('geopipes-elasticsearch-backend').queries;
+
 function generate( params ){
 
-  var cmd = {
-    "query":{
-      "filtered" : {
-        "query" : {
-          "match_all" : {}
-        },
-        "filter" : {
-          "geo_distance" : {
-            "distance" : "1km",
-            "center_point" : {
-              "lat": params.lat,
-              "lon": params.lon
-            }
-          }
-        }
-      }
-    },
-    "size": 1
+  var centroid = {
+    lat: params.lat,
+    lon: params.lon
   };
 
-  // logger.log( 'cmd', JSON.stringify( cmd, null, 2 ) );
-  return cmd;
-
+  return queries.distance( centroid, { size: 1 } );
 }
 
 module.exports = generate;

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -15,26 +15,48 @@ module.exports.tests.query = function(test, common) {
     var query = generate({
       lat: 29.49136, lon: -82.50622
     });
+    
     var expected = {
-      query:{
-        filtered : {
-          query : {
-              match_all : {}
+      'query': {
+        'filtered': {
+          'query': {
+            'match_all': {}
           },
-          filter : {
-              geo_distance : {
-                  distance : '1km',
-                  center_point : {
-                    lat: 29.49136, 
-                    lon: -82.50622
+          'filter': {
+            'bool': {
+              'must': [
+                {
+                  'geo_distance': {
+                    'distance': '50km',
+                    'distance_type': 'plane',
+                    'optimize_bbox': 'indexed',
+                    '_cache': true,
+                    'center_point': {
+                      'lat': '29.49',
+                      'lon': '-82.51'
+                    }
                   }
-              }
+                }
+              ]
+            }
           }
         }
       },
-      size: 1
+      'sort': [
+        {
+          '_geo_distance': {
+            'center_point': {
+              'lat': 29.49136,
+              'lon': -82.50622
+            },
+            'order': 'asc',
+            'unit': 'km'
+          }
+        }
+      ],
+      'size': 1
     };
-    
+
     t.deepEqual(query, expected, 'valid reverse query');
     t.end();
   });


### PR DESCRIPTION
refactor reverse query to be simpler and based off the tested queries in the `geopipes-elasticsearch-backend` module.

when testing at my current lat/lon it produced better results than the previous query implementation; most likely due to the `sort`.
