### PR TITLE
display all admin fields

### DIFF
--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -69,9 +69,14 @@ function search( docs ){
     output.name = doc.name.default;
 
     // map admin values
+    if( doc.alpha3 ){ output.alpha3 = doc.alpha3; }
     if( doc.admin0 ){ output.admin0 = doc.admin0; }
     if( doc.admin1 ){ output.admin1 = doc.admin1; }
+    if( doc.admin1_abbr ){ output.admin1_abbr = doc.admin1_abbr; }
     if( doc.admin2 ){ output.admin2 = doc.admin2; }
+    if( doc.local_admin ){ output.local_admin = doc.local_admin; }
+    if( doc.locality ){ output.locality = doc.locality; }
+    if( doc.neighborhood ){ output.neighborhood = doc.neighborhood; }
 
     // map suggest output
     if( doc.suggest && doc.suggest.output ){

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -88,9 +88,14 @@ module.exports.tests.search = function(test, common) {
         "street": "Liverpool Road",
         "zip": "N1 0RW"
       },
+      "alpha3": "GBR",
       "admin0": "United Kingdom",
       "admin1": "Islington",
+      "admin1_abbr": "ISL",
       "admin2": "Angel",
+      "local_admin": "test1",
+      "locality": "test2",
+      "neighborhood": "test3",
       "suggest": {
         "input": [
           "'round midnight jazz and blues bar"
@@ -111,9 +116,14 @@ module.exports.tests.search = function(test, common) {
         "lat": "51.517806",
         "lon": "-0.101795"
       },
+      "alpha3": "GBR",
       "admin0": "United Kingdom",
       "admin1": "City And County Of The City Of London",
+      "admin1_abbr": "COL",
       "admin2": "Smithfield",
+      "local_admin": "test1",
+      "locality": "test2",
+      "neighborhood": "test3",
       "suggest": {
         "input": [
           "blues cafe"
@@ -142,9 +152,14 @@ module.exports.tests.search = function(test, common) {
         "properties": {
           "text": "'Round Midnight Jazz and Blues Bar, Angel, United Kingdom",
           "name": "'Round Midnight Jazz and Blues Bar",
+          "alpha3": "GBR",
           "admin0": "United Kingdom",
           "admin1": "Islington",
-          "admin2": "Angel"
+          "admin1_abbr": "ISL",
+          "admin2": "Angel",
+          "local_admin": "test1",
+          "locality": "test2",
+          "neighborhood": "test3",
         }
       },
       {
@@ -159,9 +174,14 @@ module.exports.tests.search = function(test, common) {
         "properties": {
           "text": "Blues Cafe, Smithfield, United Kingdom",
           "name": "Blues Cafe",
+          "alpha3": "GBR",
           "admin0": "United Kingdom",
           "admin1": "City And County Of The City Of London",
-          "admin2": "Smithfield"
+          "admin1_abbr": "COL",
+          "admin2": "Smithfield",
+          "local_admin": "test1",
+          "locality": "test2",
+          "neighborhood": "test3",
         }
       }
     ]


### PR DESCRIPTION
display all admin fields as per:

https://github.com/mapzen/pelias-openstreetmap/pull/14
https://github.com/pelias/schema/pull/17

eg:

``` javascript
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [
          -73.9983442,
          40.7383652
        ]
      },
      "properties": {
        "name": "Hack Manhattan",
        "alpha3": "USA",
        "admin0": "United States",
        "admin1": "New York",
        "admin1_abbr": "NY",
        "admin2": "New York",
        "local_admin": "Manhattan",
        "locality": "New York",
        "neighborhood": "Union Square",
        "text": "Hack Manhattan, Manhattan, NY"
      }
    }
  ],
  "date": 1412337550448
}
```
