### PR TITLE
Address alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "geojson": "^0.2.0",
     "geojson-extent": "^0.3.1",
     "geopipes-elasticsearch-backend": "0.0.8",
+    "is-object": "^1.0.1",
     "pelias-esclient": "0.0.25",
     "toobusy": "^0.2.4"
   },

--- a/query/indeces.js
+++ b/query/indeces.js
@@ -8,5 +8,6 @@ module.exports = [
   'admin0',
   'admin1',
   'admin2',
-  'neighborhood'
+  'neighborhood',
+  'openaddresses'
 ];

--- a/sanitiser/_layers.js
+++ b/sanitiser/_layers.js
@@ -11,46 +11,52 @@ function sanitize( req ){
     params = {};
   }
 
-  // which layers to query
-  if('string' === typeof params.layers && params.layers.length){
-    
-    var alias_layers  = ['poi', 'admin'];
-    var alias_indeces = indeces.concat(alias_layers);
+  // default case (no layers specified in GET params)
+  if('string' !== typeof params.layers || !params.layers.length){
+    // @note: 'address' alias disabled by default feature testing completed
+    params.layers = 'poi,admin'; // default layers
+  }
 
-    var layers = params.layers.split(',').map( function( layer ){
-      return layer.toLowerCase(); // lowercase inputs
-    });
-    for( var x=0; x<layers.length; x++ ){
-      if( -1 === alias_indeces.indexOf( layers[x] ) ){
-        return {
-          'error': true,
-          'message': 'invalid param \'layer\': must be one or more of ' + alias_indeces.join(',') 
-        };
-      }
+  // decide which layers can be queried
+  var alias_layers  = ['poi', 'admin', 'address'];
+  var alias_indeces = indeces.concat(alias_layers);
+
+  // parse GET params
+  var layers = params.layers.split(',').map( function( layer ){
+    return layer.toLowerCase(); // lowercase inputs
+  });
+
+  // validate layer names
+  for( var x=0; x<layers.length; x++ ){
+    if( -1 === alias_indeces.indexOf( layers[x] ) ){
+      return {
+        'error': true,
+        'message': 'invalid param \'layer\': must be one or more of ' + alias_indeces.join(',')
+      };
     }
-    var expand_aliases = function(alias, layers, layer_indeces) {
-      var alias_index  = layers.indexOf(alias);
-      if (alias_index !== -1 ) {
-        layers.splice(alias_index, 1);
-        layers = layers.concat(layer_indeces);
-      }
-      return layers;
-    };
-
-    layers = expand_aliases('poi',   layers, ['geoname','osmnode','osmway']);
-    layers = expand_aliases('admin', layers, ['admin0','admin1','admin2','neighborhood']);
-    
-    // de-dup
-    layers = layers.filter(function(item, pos) {
-      return layers.indexOf(item) === pos;
-    });
-
-    clean.layers = layers;
-  }
-  else {
-    clean.layers = indeces; // default (all layers)
   }
 
+  // expand aliases
+  var expand_aliases = function(alias, layers, layer_indeces) {
+    var alias_index  = layers.indexOf(alias);
+    if (alias_index !== -1 ) {
+      layers.splice(alias_index, 1);
+      layers = layers.concat(layer_indeces);
+    }
+    return layers;
+  };
+
+  layers = expand_aliases('poi',   layers, ['geoname','osmnode','osmway']);
+  layers = expand_aliases('admin', layers, ['admin0','admin1','admin2','neighborhood']);
+  layers = expand_aliases('address', layers, ['openaddresses']);
+
+  // de-dupe
+  layers = layers.filter(function(item, pos) {
+    return layers.indexOf(item) === pos;
+  });
+
+  // pass validated params to next middleware
+  clean.layers = layers;
   req.clean = clean;
   
   return { 'error': false };

--- a/sanitiser/_layers.js
+++ b/sanitiser/_layers.js
@@ -15,7 +15,7 @@ function sanitize( req ){
 
   // default case (no layers specified in GET params)
   if('string' !== typeof params.layers || !params.layers.length){
-    // @note: 'address' alias disabled by default feature testing completed
+    // @note: 'address' alias disabled by default until feature testing completed
     params.layers = 'poi,admin'; // default layers
   }
 

--- a/sanitiser/_layers.js
+++ b/sanitiser/_layers.js
@@ -1,4 +1,6 @@
-var indeces = require('../query/indeces');
+
+var isObject = require('is-object'),
+    indeces = require('../query/indeces');
 
 // validate inputs, convert types and apply defaults
 function sanitize( req ){
@@ -7,7 +9,7 @@ function sanitize( req ){
   var params= req.query;
 
   // ensure the input params are a valid object
-  if( Object.prototype.toString.call( params ) !== '[object Object]' ){
+  if( !isObject( params ) ){
     params = {};
   }
 

--- a/test/unit/query/indeces.js
+++ b/test/unit/query/indeces.js
@@ -6,7 +6,7 @@ module.exports.tests = {};
 module.exports.tests.interface = function(test, common) {
   test('valid interface', function(t) {
     t.true(Array.isArray(indeces), 'valid array');
-    t.equal(indeces.length, 7, 'valid array');
+    t.equal(indeces.length, 8, 'valid array');
     t.end();
   });
 };

--- a/test/unit/sanitiser/suggest.js
+++ b/test/unit/sanitiser/suggest.js
@@ -160,8 +160,9 @@ module.exports.tests.sanitize_layers = function(test, common) {
   });
   test('invalid layer', function(t) {
     sanitize({ layers: 'test_layer', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
-      var msg = 'invalid param \'layer\': must be one or more of geoname,osmnode,osmway,admin0,admin1,admin2,neighborhood,poi,admin';
-      t.equal(err, msg, 'invalid layer requested');
+      var msg = 'invalid param \'layer\': must be one or more of ';
+      t.true(err.match(msg), 'invalid layer requested');
+      t.true(err.length > msg.length, 'invalid error message');
       t.end();
     });
   });
@@ -179,6 +180,13 @@ module.exports.tests.sanitize_layers = function(test, common) {
       t.end();
     });
   });
+  test('address (alias) layer', function(t) {
+    var address_layers = ['openaddresses'];
+    sanitize({ layers: 'address', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
+      t.deepEqual(clean.layers, address_layers, 'address layers set');
+      t.end();
+    });
+  });
   test('poi alias layer plus regular layers', function(t) {
     var poi_layers = ['geoname','osmnode','osmway'];
     var reg_layers = ['admin0', 'admin1'];
@@ -192,6 +200,14 @@ module.exports.tests.sanitize_layers = function(test, common) {
     var reg_layers   = ['geoname', 'osmway'];
     sanitize({ layers: 'admin,geoname,osmway', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
       t.deepEqual(clean.layers, reg_layers.concat(admin_layers), 'admin + regular layers set');
+      t.end();
+    });
+  });
+  test('address alias layer plus regular layers', function(t) {
+    var address_layers = ['openaddresses'];
+    var reg_layers   = ['geoname', 'osmway'];
+    sanitize({ layers: 'address,geoname,osmway', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
+      t.deepEqual(clean.layers, reg_layers.concat(address_layers), 'address + regular layers set');
       t.end();
     });
   });


### PR DESCRIPTION
This PR starts to expose the new `address` types via the API, initially just `openaddresses` but later also `TIGER`, `openvenues` etc.

I think it's best to introduce a new `alias` for addresses, so we can turn them on/off and have query-time control over what is returned (just like the existing `poi/admin` aliases).

In this PR I've also slightly changed the way we assign `default` layers, in the past we defaulted to *all layers*, now if you fail to specify a layers param in your `GET` request it'll default to `poi,admin`.

Maybe later we can change that to include `address` but need to do some testing first.

related: https://github.com/pelias/schema/pull/36

cc/ @hkrishna 