### PR TITLE
Score function

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -13,6 +13,7 @@ function setup( backend, query ){
     // backend command
     var cmd = {
       index: 'pelias',
+      searchType: 'dfs_query_then_fetch',
       body: query( req.clean )
     };
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "geojson": "^0.2.0",
     "geojson-extent": "^0.3.1",
     "geopipes-elasticsearch-backend": "git://github.com/geopipes/elasticsearch-backend#sort-scoring-function",
-    "pelias-model": "git://github.com/pelias/model#multiplier",
+    "pelias-suggester-pipeline": "git://github.com/pelias/suggester-pipeline#using-model-weights",
     "is-object": "^1.0.1",
     "pelias-esclient": "0.0.25",
     "toobusy": "^0.2.4"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "express": "^4.8.8",
     "geojson": "^0.2.0",
     "geojson-extent": "^0.3.1",
-    "geopipes-elasticsearch-backend": "git://github.com/geopipes/elasticsearch-backend#sort-scoring-function",
-    "pelias-suggester-pipeline": "git://github.com/pelias/suggester-pipeline#using-model-weights",
+    "geopipes-elasticsearch-backend": "0.0.11",
+    "pelias-suggester-pipeline": "2.0.2",
     "is-object": "^1.0.1",
     "pelias-esclient": "0.0.25",
     "toobusy": "^0.2.4"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "express": "^4.8.8",
     "geojson": "^0.2.0",
     "geojson-extent": "^0.3.1",
-    "geopipes-elasticsearch-backend": "git://github.com/geopipes/elasticsearch-backend#centroid-optional",
+    "geopipes-elasticsearch-backend": "git://github.com/geopipes/elasticsearch-backend#sort-scoring-function",
     "is-object": "^1.0.1",
     "pelias-esclient": "0.0.25",
     "toobusy": "^0.2.4"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "geojson": "^0.2.0",
     "geojson-extent": "^0.3.1",
     "geopipes-elasticsearch-backend": "git://github.com/geopipes/elasticsearch-backend#sort-scoring-function",
+    "pelias-model": "git://github.com/pelias/model#multiplier",
     "is-object": "^1.0.1",
     "pelias-esclient": "0.0.25",
     "toobusy": "^0.2.4"

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -1,6 +1,7 @@
 
 var logger = require('../src/logger'),
-    queries = require('geopipes-elasticsearch-backend').queries;
+    queries = require('geopipes-elasticsearch-backend').queries,
+    sort = require('../query/sort');
 
 function generate( params ){
 
@@ -9,7 +10,10 @@ function generate( params ){
     lon: params.lon
   };
 
-  return queries.distance( centroid, { size: params.size || 1 } );
+  var query  =  queries.distance( centroid, { size: params.size || 1 } );
+  query.sort = query.sort.concat(sort);
+
+  return query;
 }
 
 module.exports = generate;

--- a/query/search.js
+++ b/query/search.js
@@ -14,6 +14,7 @@ function generate( params ){
   } 
   
   var query = queries.distance( centroid, { size: params.size } );
+  
   if (params.bbox) {
     query = queries.bbox ( centroid, { size: params.size, bbox: params.bbox } );
   }

--- a/query/search.js
+++ b/query/search.js
@@ -1,6 +1,7 @@
 
 var logger = require('../src/logger'),
-    queries = require('geopipes-elasticsearch-backend').queries;
+    queries = require('geopipes-elasticsearch-backend').queries,
+    sort = require('../query/sort');
 
 function generate( params ){
 
@@ -27,6 +28,8 @@ function generate( params ){
       default_operator: 'OR'
     }
   };
+
+  query.sort = query.sort.concat(sort);
 
   return query;
 }

--- a/query/sort.js
+++ b/query/sort.js
@@ -4,7 +4,7 @@ var weights = require('pelias-suggester-pipeline').weights;
 module.exports = [
   {
     '_script': {
-      'file': 'population',
+      'file': population,
       'type': 'number',
       'order': 'desc'
     }

--- a/query/sort.js
+++ b/query/sort.js
@@ -1,0 +1,27 @@
+var population = 'population';
+var weights = require('pelias-model').weights;
+
+module.exports = [
+  {
+    '_script': {
+      'script': 'if (doc.containsKey(\''+ population + '\'))' +
+                ' { return doc[\'' + population + '\'].value }' +
+                ' else { return 0 }',
+      'type': 'number',
+      'order': 'desc'
+    }
+  },
+  {
+    '_script': {
+      'params': {
+        'weights': weights
+      },
+      'script': 'if (doc.containsKey(\'_type\')) { '+
+                'type=doc[\'_type\'].value; '+
+                'return ( type in weights ) ? weights[ type ] : 0 }' +
+                'else { return 0 }',
+      'type': 'number',
+      'order': 'desc'
+    }
+  }
+];

--- a/query/sort.js
+++ b/query/sort.js
@@ -4,9 +4,7 @@ var weights = require('pelias-suggester-pipeline').weights;
 module.exports = [
   {
     '_script': {
-      'script': 'if (doc.containsKey(\''+ population + '\'))' +
-                ' { return doc[\'' + population + '\'].value }' +
-                ' else { return 0 }',
+      'file': 'population',
       'type': 'number',
       'order': 'desc'
     }
@@ -16,10 +14,7 @@ module.exports = [
       'params': {
         'weights': weights
       },
-      'script': 'if (doc.containsKey(\'_type\')) { '+
-                'type=doc[\'_type\'].value; '+
-                'return ( type in weights ) ? weights[ type ] : 0 }' +
-                'else { return 0 }',
+      'file': 'weights',
       'type': 'number',
       'order': 'desc'
     }

--- a/query/sort.js
+++ b/query/sort.js
@@ -1,5 +1,5 @@
 var population = 'population';
-var weights = require('pelias-model').weights;
+var weights = require('pelias-suggester-pipeline').weights;
 
 module.exports = [
   {

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -53,7 +53,7 @@ module.exports.tests.functional_success = function(test, common) {
 
   test('functional success', function(t) {
     var backend = mockBackend( 'client/search/ok/1', function( cmd ){
-      t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias' }, 'correct backend command');
+      t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias', searchType: 'dfs_query_then_fetch' }, 'correct backend command');
     });
     var controller = setup( backend, mockQuery() );
     var res = {
@@ -78,7 +78,7 @@ module.exports.tests.functional_success = function(test, common) {
 module.exports.tests.functional_failure = function(test, common) {
   test('functional failure', function(t) {
     var backend = mockBackend( 'client/search/fail/1', function( cmd ){
-      t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias' }, 'correct backend command');
+      t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias', searchType: 'dfs_query_then_fetch' }, 'correct backend command');
     });
     var controller = setup( backend, mockQuery() );
     var next = function( message ){

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -11,9 +11,10 @@ module.exports.tests.interface = function(test, common) {
 };
 
 var sort = [
+  '_score',
   {
     '_script': {
-      'script': 'if (doc.containsKey(\'population\')) { return doc[\'population\'].value } else { return 0 }',
+      'file': 'population',
       'type': 'number',
       'order': 'desc'
     }
@@ -35,10 +36,7 @@ var sort = [
           'admin0': 2
         }
       },
-      'script': 'if (doc.containsKey(\'_type\')) { '+
-                'type=doc[\'_type\'].value; '+
-                'return ( type in weights ) ? weights[ type ] : 0 }'+
-                'else { return 0 }',
+      'file': 'weights',
       'type': 'number',
       'order': 'desc'
     }
@@ -89,7 +87,7 @@ module.exports.tests.query = function(test, common) {
             'unit': 'km'
           }
         }
-      ].concat(sort),
+      ].concat(sort.slice(1)),
       'size': 1,
       'track_scores': true
     };

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -10,6 +10,42 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
+var sort = [
+  '_score',
+  {
+    '_script': {
+      'script': 'if (doc.containsKey(\'population\')) { return doc[\'population\'].value } else { return 0 }',
+      'type': 'number',
+      'order': 'desc'
+    }
+  },
+  {
+    '_script': {
+      'params': {
+        'weights': {
+          'geoname': 0,
+          'address': 4,
+          'osmnode': 6,
+          'osmway': 6,
+          'poi-address': 8,
+          'neighborhood': 10,
+          'local_admin': 12,
+          'locality': 12,
+          'admin2': 12,
+          'admin1': 14,
+          'admin0': 2
+        }
+      },
+      'script': 'if (doc.containsKey(\'_type\')) { '+
+                'type=doc[\'_type\'].value; '+
+                'return ( type in weights ) ? weights[ type ] : 0 }'+
+                'else { return 0 }',
+      'type': 'number',
+      'order': 'desc'
+    }
+  }
+];
+
 module.exports.tests.query = function(test, common) {
   test('valid query', function(t) {
     var query = generate({
@@ -42,7 +78,7 @@ module.exports.tests.query = function(test, common) {
           }
         }
       },
-      'sort': [
+      'sort': sort.concat([
         {
           '_geo_distance': {
             'center_point': {
@@ -53,8 +89,9 @@ module.exports.tests.query = function(test, common) {
             'unit': 'km'
           }
         }
-      ],
-      'size': 1
+      ]),
+      'size': 1,
+      'track_scores': true
     };
 
     t.deepEqual(query, expected, 'valid reverse query');

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -11,7 +11,6 @@ module.exports.tests.interface = function(test, common) {
 };
 
 var sort = [
-  '_score',
   {
     '_script': {
       'script': 'if (doc.containsKey(\'population\')) { return doc[\'population\'].value } else { return 0 }',
@@ -78,7 +77,8 @@ module.exports.tests.query = function(test, common) {
           }
         }
       },
-      'sort': sort.concat([
+      'sort': [
+        '_score',
         {
           '_geo_distance': {
             'center_point': {
@@ -89,7 +89,7 @@ module.exports.tests.query = function(test, common) {
             'unit': 'km'
           }
         }
-      ]),
+      ].concat(sort),
       'size': 1,
       'track_scores': true
     };

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -1,5 +1,6 @@
 
 var generate = require('../../../query/reverse');
+var weights = require('pelias-suggester-pipeline').weights;
 
 module.exports.tests = {};
 
@@ -22,19 +23,7 @@ var sort = [
   {
     '_script': {
       'params': {
-        'weights': {
-          'geoname': 0,
-          'address': 4,
-          'osmnode': 6,
-          'osmway': 6,
-          'poi-address': 8,
-          'neighborhood': 10,
-          'local_admin': 12,
-          'locality': 12,
-          'admin2': 12,
-          'admin1': 14,
-          'admin0': 2
-        }
+        'weights': weights
       },
       'file': 'weights',
       'type': 'number',

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -1,5 +1,6 @@
 
 var generate = require('../../../query/search');
+var weights = require('pelias-suggester-pipeline').weights;
 
 module.exports.tests = {};
 
@@ -22,19 +23,7 @@ var sort = [
   {
     '_script': {
       'params': {
-        'weights': {
-          'geoname': 0,
-          'address': 4,
-          'osmnode': 6,
-          'osmway': 6,
-          'poi-address': 8,
-          'neighborhood': 10,
-          'local_admin': 12,
-          'locality': 12,
-          'admin2': 12,
-          'admin1': 14,
-          'admin0': 2
-        }
+        'weights': weights
       },
       'file': 'weights',
       'type': 'number',

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -14,7 +14,7 @@ var sort = [
   '_score',
   {
     '_script': {
-      'script': 'if (doc.containsKey(\'population\')) { return doc[\'population\'].value } else { return 0 }',
+      'file': 'population',
       'type': 'number',
       'order': 'desc'
     }
@@ -36,10 +36,7 @@ var sort = [
           'admin0': 2
         }
       },
-      'script': 'if (doc.containsKey(\'_type\')) { '+
-                'type=doc[\'_type\'].value; '+
-                'return ( type in weights ) ? weights[ type ] : 0 }'+
-                'else { return 0 }',
+      'file': 'weights',
       'type': 'number',
       'order': 'desc'
     }

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -225,7 +225,8 @@ module.exports.tests.query = function(test, common) {
            }
         }
       },
-      'sort': sort.concat([
+      'sort': [
+        '_score',
         {
           '_geo_distance': {
             'center_point': {
@@ -236,7 +237,7 @@ module.exports.tests.query = function(test, common) {
             'unit': 'km'
           }
         }
-      ]),
+      ].concat(sort.slice(1)),
       'size': 10,
       'track_scores': true
     };

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -10,6 +10,42 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
+var sort = [
+  '_score',
+  {
+    '_script': {
+      'script': 'if (doc.containsKey(\'population\')) { return doc[\'population\'].value } else { return 0 }',
+      'type': 'number',
+      'order': 'desc'
+    }
+  },
+  {
+    '_script': {
+      'params': {
+        'weights': {
+          'geoname': 0,
+          'address': 4,
+          'osmnode': 6,
+          'osmway': 6,
+          'poi-address': 8,
+          'neighborhood': 10,
+          'local_admin': 12,
+          'locality': 12,
+          'admin2': 12,
+          'admin1': 14,
+          'admin0': 2
+        }
+      },
+      'script': 'if (doc.containsKey(\'_type\')) { '+
+                'type=doc[\'_type\'].value; '+
+                'return ( type in weights ) ? weights[ type ] : 0 }'+
+                'else { return 0 }',
+      'type': 'number',
+      'order': 'desc'
+    }
+  }
+];
+
 module.exports.tests.query = function(test, common) {
   test('valid query', function(t) {
     var query = generate({
@@ -55,10 +91,11 @@ module.exports.tests.query = function(test, common) {
           }
         }
       },
-      'sort': [],
-      'size': 10
+      'sort': sort,
+      'size': 10,
+      'track_scores': true
     };
-    
+
     t.deepEqual(query, expected, 'valid search query');
     t.end();
   });
@@ -106,8 +143,9 @@ module.exports.tests.query = function(test, common) {
           }
         }
       },
-      'sort': [],
-      'size': 10
+      'sort': sort,
+      'size': 10,
+      'track_scores': true
     };
     
     t.deepEqual(query, expected, 'valid search query');
@@ -139,7 +177,9 @@ module.exports.tests.query = function(test, common) {
           }
         }
       },
-      'size': 10
+      'size': 10,
+      'sort': sort,
+      'track_scores': true
     };
     
     t.deepEqual(query, expected, 'valid search query');
@@ -185,7 +225,7 @@ module.exports.tests.query = function(test, common) {
            }
         }
       },
-      'sort': [
+      'sort': sort.concat([
         {
           '_geo_distance': {
             'center_point': {
@@ -196,8 +236,9 @@ module.exports.tests.query = function(test, common) {
             'unit': 'km'
           }
         }
-      ],
-      'size': 10
+      ]),
+      'size': 10,
+      'track_scores': true
     };
 
     t.deepEqual(query, expected, 'valid search query');

--- a/test/unit/query/sort.js
+++ b/test/unit/query/sort.js
@@ -1,0 +1,52 @@
+
+var generate = require('../../../query/sort');
+var population = 'population';
+var weights = require('pelias-suggester-pipeline').weights;
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('valid interface', function(t) {
+    t.equal(typeof generate, 'object', 'valid object');
+    t.end();
+  });
+};
+
+var expected = [
+  {
+    '_script': {
+      'file': population,
+      'type': 'number',
+      'order': 'desc'
+    }
+  },
+  {
+    '_script': {
+      'params': {
+        'weights': weights
+      },
+      'file': 'weights',
+      'type': 'number',
+      'order': 'desc'
+    }
+  }
+];
+
+module.exports.tests.query = function(test, common) {
+  test('valid part of query', function(t) {
+    var sort = generate;
+    t.deepEqual(sort, expected, 'valid sort part of the query');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('sort query ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -15,6 +15,7 @@ var tests = [
   require('./sanitiser/coarse'),
   require('./query/indeces'),
   require('./query/suggest'),
+  require('./query/sort'),
   require('./query/search'),
   require('./query/reverse'),
   require('./helper/geojsonify'),


### PR DESCRIPTION
This is the PR that deals with adding a scoring function using groovy scripts to sort []. Here's how the sorting works (in the given order)

1. _score:  all results are primarily sorted by _score computed by ES using its TF/IDF
2. _geodistance: if two or more have the same score and if the query provides geobias (lat/lon) - its sorted by the distance from the lat/lon provided.
3. population: if two or more records have the same score (and same no geodistance), population (if available) acts as a tie breaker
4. weights: if no lat/lon is provided and population is 0 for two or more records - then its weights based on the dataset the record originated from (https://github.com/pelias/suggester-pipeline/blob/master/lib/weights.js)

Added new tests, updated existing tests to work with the new queries. Package.json has been updated to use the latest elasticsearch-backend (for base queries) and suggester_pipeline (for weights)