### PR TITLE
Analyzing the query to find admin values

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -33,7 +33,7 @@ function generate( params ){
   };
   
   if (params.input_admin) {
-    var admin_fields = ['admin0', 'admin1', 'alpha3'];
+    var admin_fields = ['admin0', 'admin1', 'admin1_abbr', 'admin2', 'alpha3'];
     query.query.filtered.query.bool.should = [];
 
     admin_fields.forEach(function(admin_field) {

--- a/query/search.js
+++ b/query/search.js
@@ -22,12 +22,28 @@ function generate( params ){
 
   // add search condition to distance query
   query.query.filtered.query = {
-    query_string : {
-      query: params.input,
-      fields: ['name.default'],
-      default_operator: 'OR'
+    'bool': {
+      'must': [{ 
+          'match': {
+            'name.default': params.input
+          }
+        }
+      ]   
     }
   };
+  
+  if (params.input_admin) {
+    var admin_fields = ['admin0', 'admin1', 'alpha3'];
+    query.query.filtered.query.bool.should = [];
+
+    admin_fields.forEach(function(admin_field) {
+      var match = {};
+      match[admin_field] = params.input_admin;
+      query.query.filtered.query.bool.should.push({
+         'match': match
+      });
+    });
+  }
 
   query.sort = query.sort.concat(sort);
 

--- a/sanitiser/_input.js
+++ b/sanitiser/_input.js
@@ -3,6 +3,7 @@ function sanitize( req ){
   
   req.clean = req.clean || {};
   var params= req.query;
+  var delim = ',';
 
   // ensure the input params are a valid object
   if( Object.prototype.toString.call( params ) !== '[object Object]' ){
@@ -16,7 +17,16 @@ function sanitize( req ){
       'message': 'invalid param \'input\': text length, must be >0'
     };
   }
+  
   req.clean.input = params.input;
+
+  // for admin matching during query time
+  // split 'flatiron, new york, ny' into 'flatiron' and ' new york, ny'
+  var delim_index = params.input.indexOf(delim);
+  if ( delim_index !== -1 ) {
+    req.clean.input = params.input.substring(0, delim_index);
+    req.clean.input_admin = params.input.substring(delim_index +1);
+  }
 
   return { 'error': false };
 

--- a/sanitiser/_input.js
+++ b/sanitiser/_input.js
@@ -25,7 +25,7 @@ function sanitize( req ){
   var delim_index = params.input.indexOf(delim);
   if ( delim_index !== -1 ) {
     req.clean.input = params.input.substring(0, delim_index);
-    req.clean.input_admin = params.input.substring(delim_index +1);
+    req.clean.input_admin = params.input.substring(delim_index + 1).trim();
   }
 
   return { 'error': false };

--- a/sanitiser/_input.js
+++ b/sanitiser/_input.js
@@ -21,7 +21,7 @@ function sanitize( req ){
   req.clean.input = params.input;
 
   // for admin matching during query time
-  // split 'flatiron, new york, ny' into 'flatiron' and ' new york, ny'
+  // split 'flatiron, new york, ny' into 'flatiron' and 'new york, ny'
   var delim_index = params.input.indexOf(delim);
   if ( delim_index !== -1 ) {
     req.clean.input = params.input.substring(0, delim_index);

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -61,12 +61,13 @@ module.exports.tests.query = function(test, common) {
       'query': {
         'filtered': {
           'query': {
-            'query_string': {
-              'query': 'test',
-              'fields': [
-                'name.default'
-              ],
-              'default_operator': 'OR'
+            'bool': {
+              'must': [{ 
+                  'match': {
+                    'name.default': 'test'
+                  }
+                }
+              ]   
             }
           },
           'filter': {
@@ -113,12 +114,13 @@ module.exports.tests.query = function(test, common) {
       'query': {
         'filtered': {
           'query': {
-            'query_string': {
-              'query': 'test',
-              'fields': [
-                'name.default'
-              ],
-              'default_operator': 'OR'
+            'bool': {
+              'must': [{ 
+                  'match': {
+                    'name.default': 'test'
+                  }
+                }
+              ]   
             }
           },
           'filter': {
@@ -159,12 +161,13 @@ module.exports.tests.query = function(test, common) {
       'query': {
         'filtered': {
           'query': {
-            'query_string': {
-              'query': 'test',
-              'fields': [
-                'name.default'
-              ],
-              'default_operator': 'OR'
+            'bool': {
+              'must': [{ 
+                  'match': {
+                    'name.default': 'test'
+                  }
+                }
+              ]   
             }
           },
           'filter': {
@@ -194,12 +197,13 @@ module.exports.tests.query = function(test, common) {
       'query': {
         'filtered': {
           'query': {
-            'query_string': {
-              'query': 'test',
-              'fields': [
-                'name.default'
-              ],
-              'default_operator': 'OR'
+            'bool': {
+              'must': [{ 
+                  'match': {
+                    'name.default': 'test'
+                  }
+                }
+              ]   
             }
           },
           'filter': {

--- a/test/unit/sanitiser/suggest.js
+++ b/test/unit/sanitiser/suggest.js
@@ -2,6 +2,7 @@
 var suggest  = require('../../../sanitiser/suggest'),
     _sanitize = suggest.sanitize,
     middleware = suggest.middleware,
+    delim = ',',
     defaultError = 'invalid param \'input\': text length, must be >0',
     defaultClean =  { input: 'test', 
                       lat:0,
@@ -46,6 +47,29 @@ module.exports.tests.sanitize_input = function(test, common) {
       sanitize({ input: input, lat: 0, lon: 0 }, function( err, clean ){
         var expected = JSON.parse(JSON.stringify( defaultClean ));
         expected.input = input;
+        t.equal(err, undefined, 'no error');
+        t.deepEqual(clean, expected, 'clean set correctly (' + input + ')');
+      });
+    });
+    t.end();
+  });
+};
+
+module.exports.tests.sanitize_input_with_delim = function(test, common) {
+  var inputs = [ 'a,bcd', '123 main st, admin1', ',,,', ' ' ];
+
+  test('valid inputs with a comma', function(t) {  
+    inputs.forEach( function( input ){
+      sanitize({ input: input, lat: 0, lon: 0 }, function( err, clean ){
+        var expected = JSON.parse(JSON.stringify( defaultClean ));
+        expected.input = input;
+
+        var delim_index = input.indexOf(delim);
+        if (delim_index!==-1) {
+          expected.input = input.substring(0, input.indexOf(delim));
+          expected.input_admin = input.substring(delim_index + 1).trim();
+        }
+
         t.equal(err, undefined, 'no error');
         t.deepEqual(clean, expected, 'clean set correctly (' + input + ')');
       });


### PR DESCRIPTION
this is based off of #67 branch. 

This PR experiments with splitting the input query string on a comma delim and modifying the query to match on a few admin fields. 

If the input query string is ```chelsea, new york``` with this change, chelsea in new york will be higher ranked than ```chelsea, london``` for example.

This branch is currently deployed to pelias.dev and you can see the difference [chelsea,New York](http://rawgit.com/pelias/demo/two-servers/index.html#loc=12,40.7253,-73.9806&q=chelsea,New York&t=fine&gb=off) vs [chelsea](http://rawgit.com/pelias/demo/two-servers/index.html#loc=12,40.7253,-73.9806&q=chelsea&t=fine&gb=off)

The reason it only works when you type ```New York``` without a space after comma is because all admin fields are [keyword](https://github.com/pelias/schema/blob/master/mappings/partial/admin.json#L3-L4) analyzed. 

There is a pull request in pelias/schema that changes the schema to accommodate this. But for now, it still works in pelias.dev.mapzen.com as a proof of concept. Check it out

fixes pelias/schema#42
fixes pelias/pelias#43