### PR TITLE
deprecate 'type' property, see PR notes

### DIFF
--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -22,7 +22,6 @@ function search( docs ){
 
     // provide metadata to consumer
     output.id = doc._id;
-    output.type = doc._type;
     output.layer = doc._type;
 
     // map center_point

--- a/test/unit/controller/doc.js
+++ b/test/unit/controller/doc.js
@@ -24,7 +24,6 @@ module.exports.tests.functional_success = function(test, common) {
     },
     properties: {
       id: 'myid1',
-      type: 'mytype1',
       layer: 'mytype1',
       name: 'test name1',
       admin0: 'country1',
@@ -40,7 +39,6 @@ module.exports.tests.functional_success = function(test, common) {
     },
     properties: {
       id: 'myid2',
-      type: 'mytype2',
       layer: 'mytype2',
       name: 'test name2',
       admin0: 'country2',

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -25,7 +25,6 @@ module.exports.tests.functional_success = function(test, common) {
     },
     properties: {
       id: 'myid1',
-      type: 'mytype1',
       layer: 'mytype1',
       name: 'test name1',
       admin0: 'country1',
@@ -41,7 +40,6 @@ module.exports.tests.functional_success = function(test, common) {
     },
     properties: {
       id: 'myid2',
-      type: 'mytype2',
       layer: 'mytype2',
       name: 'test name2',
       admin0: 'country2',

--- a/test/unit/controller/suggest.js
+++ b/test/unit/controller/suggest.js
@@ -25,7 +25,6 @@ module.exports.tests.functional_success = function(test, common) {
     },
     properties: {
       id: 'myid1',
-      type: 'mytype1',
       layer: 'mytype1',
       name: 'test name1',
       admin0: 'country1',
@@ -41,7 +40,6 @@ module.exports.tests.functional_success = function(test, common) {
     },
     properties: {
       id: 'myid2',
-      type: 'mytype2',
       layer: 'mytype2',
       name: 'test name2',
       admin0: 'country2',

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -114,7 +114,6 @@ module.exports.tests.search = function(test, common) {
         },
         'properties': {
           'id': 'id1',
-          'type': 'type1',
           'layer': 'type1',
           'text': '\'Round Midnight Jazz and Blues Bar, test3, Angel',
           'name': '\'Round Midnight Jazz and Blues Bar',
@@ -139,7 +138,6 @@ module.exports.tests.search = function(test, common) {
         },
         'properties': {
           'id': 'id2',
-          'type': 'type2',
           'layer': 'type2',
           'text': 'Blues Cafe, test3, Smithfield',
           'name': 'Blues Cafe',
@@ -164,7 +162,6 @@ module.exports.tests.search = function(test, common) {
         },
         'properties': {
           'id': '34633854',
-          'type': 'osmway',
           'layer': 'osmway',
           'text': 'Empire State Building, Manhattan, NY',
           'name': 'Empire State Building',


### PR DESCRIPTION
This PR removes the `type` property which was deprecated back in December, for more info see:

https://github.com/mapzen/open/issues/358
https://github.com/mapzen/pelias-android-sdk/issues/6

cc/ @hkrishna 