### PR TITLE
Output generator tweaks

### DIFF
--- a/helper/outputSchema.json
+++ b/helper/outputSchema.json
@@ -7,11 +7,11 @@
   "GBR": {
     "local": ["neighborhood", "local_admin", "locality"],
     "regional": ["admin2", "admin1"],
-    "national": ["admin0", "alpha3"]
+    "national": ["alpha3", "admin0"]
   },
   "default": {
     "local": ["local_admin", "locality", "neighborhood", "admin2"],
     "regional": ["admin1_abbr", "admin1"],
-    "national": ["admin0", "alpha3"]
+    "national": ["alpha3", "admin0"]
   }
 }

--- a/helper/outputSchema.json
+++ b/helper/outputSchema.json
@@ -1,14 +1,17 @@
 {
   "USA": {
     "local": ["local_admin", "locality", "neighborhood", "admin2"],
-    "regional": ["admin1_abbr", "admin1", "admin0"]
+    "regional": ["admin1_abbr", "admin1"],
+    "national": ["alpha3", "admin0"]
   },
   "GBR": {
-    "local": ["neighborhood", "admin2", "local_admin", "locality"],
-    "regional": ["admin2","admin0","admin1"]
+    "local": ["neighborhood", "local_admin", "locality"],
+    "regional": ["admin2", "admin1"],
+    "national": ["admin0", "alpha3"]
   },
   "default": {
     "local": ["local_admin", "locality", "neighborhood", "admin2"],
-    "regional": ["admin1_abbr", "admin1", "admin0"]
+    "regional": ["admin1_abbr", "admin1"],
+    "national": ["admin0", "alpha3"]
   }
 }

--- a/test/unit/controller/doc.js
+++ b/test/unit/controller/doc.js
@@ -29,7 +29,7 @@ module.exports.tests.functional_success = function(test, common) {
       admin0: 'country1',
       admin1: 'state1',
       admin2: 'city1',
-      text: 'test name1, city1, state1'
+      text: 'test name1, city1, state1, country1'
     }
   }, {
     type: 'Feature',
@@ -44,7 +44,7 @@ module.exports.tests.functional_success = function(test, common) {
       admin0: 'country2',
       admin1: 'state2',
       admin2: 'city2',
-      text: 'test name2, city2, state2'
+      text: 'test name2, city2, state2, country2'
     }
   }];
 

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -30,7 +30,7 @@ module.exports.tests.functional_success = function(test, common) {
       admin0: 'country1',
       admin1: 'state1',
       admin2: 'city1',
-      text: 'test name1, city1, state1'
+      text: 'test name1, city1, state1, country1'
     }
   }, {
     type: 'Feature',
@@ -45,7 +45,7 @@ module.exports.tests.functional_success = function(test, common) {
       admin0: 'country2',
       admin1: 'state2',
       admin2: 'city2',
-      text: 'test name2, city2, state2'
+      text: 'test name2, city2, state2, country2'
     }
   }];
 

--- a/test/unit/controller/suggest.js
+++ b/test/unit/controller/suggest.js
@@ -30,7 +30,7 @@ module.exports.tests.functional_success = function(test, common) {
       admin0: 'country1',
       admin1: 'state1',
       admin2: 'city1',
-      text: 'test name1, city1, state1'
+      text: 'test name1, city1, state1, country1'
     }
   }, {
     type: 'Feature',
@@ -45,7 +45,7 @@ module.exports.tests.functional_success = function(test, common) {
       admin0: 'country2',
       admin1: 'state2',
       admin2: 'city2',
-      text: 'test name2, city2, state2'
+      text: 'test name2, city2, state2, country2'
     }
   }];
 

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -115,7 +115,7 @@ module.exports.tests.search = function(test, common) {
         'properties': {
           'id': 'id1',
           'layer': 'type1',
-          'text': '\'Round Midnight Jazz and Blues Bar, test3, Angel, United Kingdom',
+          'text': '\'Round Midnight Jazz and Blues Bar, test3, Angel, GBR',
           'name': '\'Round Midnight Jazz and Blues Bar',
           'alpha3': 'GBR',
           'admin0': 'United Kingdom',
@@ -139,7 +139,7 @@ module.exports.tests.search = function(test, common) {
         'properties': {
           'id': 'id2',
           'layer': 'type2',
-          'text': 'Blues Cafe, test3, Smithfield, United Kingdom',
+          'text': 'Blues Cafe, test3, Smithfield, GBR',
           'name': 'Blues Cafe',
           'alpha3': 'GBR',
           'admin0': 'United Kingdom',

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -115,7 +115,7 @@ module.exports.tests.search = function(test, common) {
         'properties': {
           'id': 'id1',
           'layer': 'type1',
-          'text': '\'Round Midnight Jazz and Blues Bar, test3, Angel',
+          'text': '\'Round Midnight Jazz and Blues Bar, test3, Angel, United Kingdom',
           'name': '\'Round Midnight Jazz and Blues Bar',
           'alpha3': 'GBR',
           'admin0': 'United Kingdom',
@@ -139,7 +139,7 @@ module.exports.tests.search = function(test, common) {
         'properties': {
           'id': 'id2',
           'layer': 'type2',
-          'text': 'Blues Cafe, test3, Smithfield',
+          'text': 'Blues Cafe, test3, Smithfield, United Kingdom',
           'name': 'Blues Cafe',
           'alpha3': 'GBR',
           'admin0': 'United Kingdom',
@@ -163,7 +163,7 @@ module.exports.tests.search = function(test, common) {
         'properties': {
           'id': '34633854',
           'layer': 'osmway',
-          'text': 'Empire State Building, Manhattan, NY',
+          'text': 'Empire State Building, Manhattan, NY, USA',
           'name': 'Empire State Building',
           'alpha3': 'USA',
           'admin0': 'United States',

--- a/test/unit/helper/outputSchema.js
+++ b/test/unit/helper/outputSchema.js
@@ -17,7 +17,7 @@ module.exports.tests.valid = function(test, common) {
   var default_schema = {
     local: ['local_admin', 'locality', 'neighborhood', 'admin2'],
     regional: ['admin1_abbr', 'admin1'],
-    national: ['admin0', 'alpha3']
+    national: ['alpha3', 'admin0']
   };
 
   var isValid = function(keys, schema) {

--- a/test/unit/helper/outputSchema.js
+++ b/test/unit/helper/outputSchema.js
@@ -13,10 +13,11 @@ module.exports.tests.interface = function(test, common) {
 };
 
 module.exports.tests.valid = function(test, common) {
-  var valid_keys = ['local_admin', 'locality', 'neighborhood', 'admin2', 'admin1_abbr', 'admin1', 'admin0'];
+  var valid_keys = ['local_admin', 'locality', 'neighborhood', 'admin2', 'admin1_abbr', 'admin1', 'admin0', 'alpha3'];
   var default_schema = {
     local: ['local_admin', 'locality', 'neighborhood', 'admin2'],
-    regional: ['admin1_abbr', 'admin1', 'admin0']
+    regional: ['admin1_abbr', 'admin1'],
+    national: ['admin0', 'alpha3']
   };
 
   var isValid = function(keys, schema) {


### PR DESCRIPTION
Does adding a 'national' key to the outputSchema make sense? Here's the argument - When Pelias used as a product with a dataset thats global (meaning more than one or two countries), doesn't it not make sense to have a national segment to the output schema. This of-course can be optional if not mentioned in ```outputSchema.json``` 

Note: This will cause a bunch of regressions in https://github.com/pelias/acceptance-tests
Fixes #46 