### PR TITLE
adding all admin layers to the search query

### DIFF
--- a/config/queryAdminWeights.js
+++ b/config/queryAdminWeights.js
@@ -1,0 +1,15 @@
+/**
+ * Configurable weights that influence how, for a query with an admin value
+ * present, a match on any given admin value affects a document's overall
+ * score.
+ */
+
+module.exports = {
+  admin0: 20,
+  alpha3: 20,
+  admin1: 10,
+  admin1_abbr: 10,
+  admin2: 5,
+  locality: 1,
+  local_admin: 1
+};

--- a/query/search.js
+++ b/query/search.js
@@ -2,7 +2,8 @@
 var logger = require('../src/logger'),
     queries = require('geopipes-elasticsearch-backend').queries,
     get_layers = require('../helper/layers'),
-    sort = require('../query/sort');
+    sort = require('../query/sort'),
+    adminFieldWeights = require( '../config/queryAdminWeights' );
 
 function generate( params ){
 
@@ -39,15 +40,6 @@ function generate( params ){
    * levels (admin0 carries more weight than locality, for instance).
    */
   if (params.input_admin) {
-    var adminFieldWeights = {
-      admin0: 20,
-      alpha3: 20,
-      admin1: 10,
-      admin1_abbr: 10,
-      admin2: 5,
-      locality: 1,
-      local_admin: 1
-    };
     query.query.filtered.query.bool.should = Object.keys( adminFieldWeights ).map( function ( field ){
       var boostFactor = adminFieldWeights[ field ];
       var shouldClause = { match: { } };

--- a/query/search.js
+++ b/query/search.js
@@ -1,6 +1,7 @@
 
 var logger = require('../src/logger'),
     queries = require('geopipes-elasticsearch-backend').queries,
+    get_layers = require('../helper/layers'),
     sort = require('../query/sort');
 
 function generate( params ){
@@ -33,7 +34,7 @@ function generate( params ){
   };
   
   if (params.input_admin) {
-    var admin_fields = ['admin0', 'admin1', 'admin1_abbr', 'admin2', 'alpha3'];
+    var admin_fields = get_layers(['admin','admin1_abbr','alpha3']);
     query.query.filtered.query.bool.should = [];
 
     admin_fields.forEach(function(admin_field) {
@@ -46,6 +47,7 @@ function generate( params ){
   }
 
   query.sort = query.sort.concat(sort);
+  // console.log( JSON.stringify( query, null, 2 ) );
 
   return query;
 }

--- a/test/unit/config/queryAdminWeights.js
+++ b/test/unit/config/queryAdminWeights.js
@@ -1,0 +1,29 @@
+/**
+ * Tests for the `config/queryAdminWeights` configuration file.
+ */
+
+var queryAdminWeights = require( '../../../config/queryAdminWeights' );
+var isObject = require( 'is-object' );
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function (test, common){
+  test('interface', function (t){
+    t.ok( isObject( queryAdminWeights ), 'Module exports an object.' );
+    for( var key in queryAdminWeights ){
+      t.equal( typeof queryAdminWeights[ key ], 'number', 'Weight is a number.' );
+    }
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('queryAdminWeights: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -238,42 +238,58 @@ module.exports.tests.query = function(test, common) {
               'should': [
                 {
                   'match': {
-                    'admin1_abbr': 'usa'
+                    'admin0': {
+                      'query': 'usa',
+                      'boost': 20
+                    }
                   }
                 },
                 {
                   'match': {
-                    'alpha3': 'usa'
+                    'alpha3': {
+                      'query': 'usa',
+                      'boost': 20
+                    }
                   }
                 },
                 {
                   'match': {
-                    'admin0': 'usa'
+                    'admin1': {
+                      'query': 'usa',
+                      'boost': 10
+                    }
                   }
                 },
                 {
                   'match': {
-                    'admin1': 'usa'
+                    'admin1_abbr': {
+                      'query': 'usa',
+                      'boost': 10
+                    }
                   }
                 },
                 {
                   'match': {
-                    'admin2': 'usa'
+                    'admin2': {
+                      'query': 'usa',
+                      'boost': 5
+                    }
                   }
                 },
                 {
                   'match': {
-                    'neighborhood': 'usa'
+                    'locality': {
+                      'query': 'usa',
+                      'boost': 1
+                    }
                   }
                 },
                 {
                   'match': {
-                    'locality': 'usa'
-                  }
-                },
-                {
-                  'match': {
-                    'local_admin': 'usa'
+                    'local_admin': {
+                      'query': 'usa',
+                      'boost': 1
+                    }
                   }
                 }
               ]   

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -216,6 +216,109 @@ module.exports.tests.query = function(test, common) {
     t.deepEqual(query, expected, 'valid search query');
     t.end();
   });
+
+  test('valid query with an admin component', function(t) {
+    var query = generate({
+      input: 'test', input_admin:'usa', size: 10,
+      lat: 29.49136, lon: -82.50622,
+      layers: ['test']
+    });
+
+    var expected = {
+      'query': {
+        'filtered': {
+          'query': {
+            'bool': {
+              'must': [{ 
+                  'match': {
+                    'name.default': 'test'
+                  }
+                }
+              ],
+              'should': [
+                {
+                  'match': {
+                    'admin1_abbr': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'alpha3': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'admin0': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'admin1': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'admin2': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'neighborhood': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'locality': 'usa'
+                  }
+                },
+                {
+                  'match': {
+                    'local_admin': 'usa'
+                  }
+                }
+              ]   
+            }
+          },
+          'filter': {
+            'bool': {
+              'must': [
+                {
+                  'geo_distance': {
+                    'distance': '50km',
+                    'distance_type': 'plane',
+                    'optimize_bbox': 'indexed',
+                    '_cache': true,
+                    'center_point': {
+                      'lat': '29.49',
+                      'lon': '-82.51'
+                    }
+                  }
+                }
+              ]
+            }
+           }
+        }
+      },
+      'sort': [
+        '_score',
+        {
+          '_geo_distance': {
+            'center_point': {
+              'lat': 29.49136,
+              'lon': -82.50622
+            },
+            'order': 'asc',
+            'unit': 'km'
+          }
+        }
+      ].concat(sort.slice(1)),
+      'size': 10,
+      'track_scores': true
+    };
+    
+    t.deepEqual(query, expected, 'valid query with an admin component');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -22,7 +22,8 @@ var tests = [
   require('./query/reverse'),
   require('./helper/geojsonify'),
   require('./helper/outputSchema'),
-  require('./helper/queryMixer')
+  require('./helper/queryMixer'),
+  require('./config/queryAdminWeights')
 ];
 
 tests.map(function(t) {


### PR DESCRIPTION
Search now looks for all admin layers and boosts ```_score``` accordingly

```
[ 'admin1_abbr',
  'alpha3',
  'admin0',
  'admin1',
  'admin2',
  'neighborhood',
  'locality',
  'local_admin' ]
```

Fixes #91 