### PR TITLE
Layers be layers not layer (typo in the error message)

### DIFF
--- a/sanitiser/_layers.js
+++ b/sanitiser/_layers.js
@@ -33,7 +33,7 @@ function sanitize( req ){
     if( -1 === alias_indeces.indexOf( layers[x] ) ){
       return {
         'error': true,
-        'message': 'invalid param \'layer\': must be one or more of ' + alias_indeces.join(',')
+        'message': 'invalid param \'layers\': must be one or more of ' + alias_indeces.join(',')
       };
     }
   }

--- a/test/unit/sanitiser/reverse.js
+++ b/test/unit/sanitiser/reverse.js
@@ -133,7 +133,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
   });
   test('invalid layer', function(t) {
     sanitize({ layers: 'test_layer', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
-      var msg = 'invalid param \'layer\': must be one or more of ';
+      var msg = 'invalid param \'layers\': must be one or more of ';
       t.true(err.match(msg), 'invalid layer requested');
       t.true(err.length > msg.length, 'invalid error message');
       t.end();

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -275,7 +275,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
   });
   test('invalid layer', function(t) {
     sanitize({ layers: 'test_layer', input: 'test' }, function( err, clean ){
-      var msg = 'invalid param \'layer\': must be one or more of ';
+      var msg = 'invalid param \'layers\': must be one or more of ';
       t.true(err.match(msg), 'invalid layer requested');
       t.true(err.length > msg.length, 'invalid error message');
       t.end();

--- a/test/unit/sanitiser/suggest.js
+++ b/test/unit/sanitiser/suggest.js
@@ -244,7 +244,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
   });
   test('invalid layer', function(t) {
     sanitize({ layers: 'test_layer', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
-      var msg = 'invalid param \'layer\': must be one or more of ';
+      var msg = 'invalid param \'layers\': must be one or more of ';
       t.true(err.match(msg), 'invalid layer requested');
       t.true(err.length > msg.length, 'invalid error message');
       t.end();


### PR DESCRIPTION
param ```layers``` should be called ```layers``` consistently across the API