### PR TITLE
Reverse categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
+coverage
+.idea
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 .idea
 *.log
+reports

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: node_js
 script: "npm run unit"
 node_js:
   - "0.10"
+addons:
+  code_climate:
+    repo_token: a98bd9004512c8caf44e5cb2b3586d01baf190ee069ec0b731b451fc9966e639
+after_script:
+  - codeclimate < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,3 @@ language: node_js
 script: "npm run unit"
 node_js:
   - "0.10"
-addons:
-  code_climate:
-    repo_token: a98bd9004512c8caf44e5cb2b3586d01baf190ee069ec0b731b451fc9966e639
-after_script:
-  - codeclimate < coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # API
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/pelias/api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[![Code Climate](https://codeclimate.com/github/pelias/api/badges/gpa.svg)](https://codeclimate.com/github/pelias/api)
-
-[![Test Coverage](https://codeclimate.com/github/pelias/api/badges/coverage.svg)](https://codeclimate.com/github/pelias/api)
-
 Pelias RESTful API
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # API
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/pelias/api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+[![Code Climate](https://codeclimate.com/github/pelias/api/badges/gpa.svg)](https://codeclimate.com/github/pelias/api)
+
+[![Test Coverage](https://codeclimate.com/github/pelias/api/badges/coverage.svg)](https://codeclimate.com/github/pelias/api)
+
 Pelias RESTful API
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ $ npm test
 $ npm run docs
 ```
 
+### Code Coverage
+
+```bash
+$ npm run coverage
+```
+
 ### Continuous Integration
 
 Travis tests every release against node version `0.10`

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "npm run unit",
+    "test": "npm run unit && npm run coverage",
     "unit": "node test/unit/run.js | tap-spec",
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
+    "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",
     "docs": "rm -r docs; cd test/ciao; node ../../node_modules/ciao/bin/ciao -c ../ciao.json . -d ../../docs"
   },
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "ciao": "^0.3.4",
+    "istanbul": "^0.3.13",
     "jshint": "^2.5.6",
     "nsp": "^0.3.0",
     "precommit-hook": "^1.0.7",

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -20,15 +20,9 @@ function generate( params ){
 }
 
 function addCategoriesFilter( query, categories ) {
-  query.query.filtered.query = {
-    match: {
-      category: {
-        query: categories.join(' '),
-        analyzer: 'standard',
-        operator: 'or'
-      }
-    }
-  };
+  query.query.filtered.filter.bool.must.push({
+    terms: { category: categories }
+  });
 }
 
 module.exports = generate;

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -1,7 +1,6 @@
 
-var logger = require('../src/logger'),
-    queries = require('geopipes-elasticsearch-backend').queries,
-    sort = require('../query/sort');
+var queries = require('geopipes-elasticsearch-backend').queries,
+    sort = require('./sort');
 
 function generate( params ){
 
@@ -13,7 +12,23 @@ function generate( params ){
   var query  =  queries.distance( centroid, { size: params.size || 1 } );
   query.sort = query.sort.concat(sort);
 
+  if ( params.categories && params.categories.length > 0 ) {
+    addCategoriesFilter( query, params.categories );
+  }
+
   return query;
+}
+
+function addCategoriesFilter( query, categories ) {
+  query.query.filtered.query = {
+    match: {
+      category: {
+        query: categories.join(' '),
+        analyzer: 'standard',
+        operator: 'or'
+      }
+    }
+  };
 }
 
 module.exports = generate;

--- a/sanitiser/_categories.js
+++ b/sanitiser/_categories.js
@@ -1,0 +1,38 @@
+
+var isObject = require('is-object');
+
+// validate inputs, convert types and apply defaults
+function sanitize( req ){
+
+  var clean = req.clean || {};
+  var params= req.query;
+
+  // ensure the input params are a valid object
+  if( !isObject( params ) ){
+    params = {};
+  }
+
+  // default case (no categories specified in GET params)
+  if('string' !== typeof params.categories || !params.categories.length){
+    clean.categories = [];
+  }
+  else {
+    // parse GET params
+    clean.categories = params.categories.split(',')
+      .map(function (cat) {
+        return cat.toLowerCase().trim(); // lowercase inputs
+      })
+      .filter( function( cat ) {
+        return ( cat.length > 0 );
+      });
+  }
+
+  // pass validated params to next middleware
+  req.clean = clean;
+
+  return { 'error': false };
+
+}
+
+// export function
+module.exports = sanitize;

--- a/sanitiser/reverse.js
+++ b/sanitiser/reverse.js
@@ -1,6 +1,5 @@
 
-var logger = require('../src/logger'),
-    _sanitize = require('../sanitiser/_sanitize'),
+var _sanitize = require('../sanitiser/_sanitize'),
     sanitiser = {
       latlonzoom: function( req ) {
         var geo = require('../sanitiser/_geo');
@@ -10,6 +9,10 @@ var logger = require('../src/logger'),
       size: function( req ) {
         var size = require('../sanitiser/_size');
         return size(req, 1);
+      },
+      categories: function ( req ) {
+        var categories = require('../sanitiser/_categories');
+        return categories(req);
       }
     };
 

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -120,13 +120,7 @@ module.exports.tests.query = function(test, common) {
       'query': {
         'filtered': {
           'query': {
-            'match': {
-              'category': {
-                'query': 'food education entertainment',
-                'analyzer': 'standard',
-                'operator': 'or'
-              }
-            }
+            'match_all': {}
           },
           'filter': {
             'bool': {
@@ -141,6 +135,11 @@ module.exports.tests.query = function(test, common) {
                       'lat': '29.49',
                       'lon': '-82.51'
                     }
+                  }
+                },
+                {
+                  'terms': {
+                    'category': params.categories
                   }
                 }
               ]

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -111,6 +111,72 @@ module.exports.tests.query = function(test, common) {
     });
     t.end();
   });
+
+  test('valid query with categories', function(t) {
+    var params = { lat: 29.49136, lon: -82.50622, categories: ['food', 'education', 'entertainment'] };
+    var query = generate(params);
+
+    var expected = {
+      'query': {
+        'filtered': {
+          'query': {
+            'match': {
+              'category': {
+                'query': 'food education entertainment',
+                'analyzer': 'standard',
+                'operator': 'or'
+              }
+            }
+          },
+          'filter': {
+            'bool': {
+              'must': [
+                {
+                  'geo_distance': {
+                    'distance': '50km',
+                    'distance_type': 'plane',
+                    'optimize_bbox': 'indexed',
+                    '_cache': true,
+                    'center_point': {
+                      'lat': '29.49',
+                      'lon': '-82.51'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      'sort': [
+        '_score',
+        {
+          '_geo_distance': {
+            'center_point': {
+              'lat': 29.49136,
+              'lon': -82.50622
+            },
+            'order': 'asc',
+            'unit': 'km'
+          }
+        }
+      ].concat(sort.slice(1)),
+      'size': 1,
+      'track_scores': true
+    };
+
+    t.deepEqual(query, expected, 'valid reverse query with categories');
+
+    // test different sizes
+    var sizes = [1,2,10,undefined,null];
+    sizes.forEach( function(size) {
+      params.size = size;
+      query = generate(params);
+      expected.size = size ? size : 1;
+      t.deepEqual(query, expected, 'valid reverse query for size: '+ size);
+    });
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/sanitiser/reverse.js
+++ b/test/unit/sanitiser/reverse.js
@@ -8,7 +8,8 @@ var suggest  = require('../../../sanitiser/reverse'),
                       layers: [ 'geoname', 'osmnode', 'osmway', 'admin0', 'admin1', 'admin2', 'neighborhood', 
                                 'locality', 'local_admin', 'osmaddress', 'openaddresses' ], 
                       lon: 0,
-                      size: 1
+                      size: 1,
+                      categories: []
                     },
     sanitize = function(query, cb) { _sanitize({'query':query}, cb); };
 
@@ -195,6 +196,45 @@ module.exports.tests.sanitize_layers = function(test, common) {
     var alias_layers = ['geoname','osmnode','osmway','admin0','admin1','admin2','neighborhood','locality','local_admin'];
     sanitize({ layers: 'poi,admin', input: 'test', lat: 0, lon: 0 }, function( err, clean ){
       t.deepEqual(clean.layers, alias_layers, 'all layers found (no duplicates)');
+      t.end();
+    });
+  });
+};
+
+module.exports.tests.sanitize_categories = function(test, common) {
+  var queryParams = { input: 'test', lat: 0, lon: 0 };
+  test('unspecified', function(t) {
+    queryParams.categories = undefined;
+    sanitize(queryParams, function( err, clean ){
+      t.deepEqual(clean.categories, defaultClean.categories, 'default to empty categories array');
+      t.end();
+    });
+  });
+  test('single category', function(t) {
+    queryParams.categories = 'food';
+    sanitize(queryParams, function( err, clean ){
+      t.deepEqual(clean.categories, ['food'], 'category set');
+      t.end();
+    });
+  });
+  test('multiple categories', function(t) {
+    queryParams.categories = 'food,education,nightlife';
+    sanitize(queryParams, function( err, clean ){
+      t.deepEqual(clean.categories, ['food', 'education', 'nightlife'], 'categories set');
+      t.end();
+    });
+  });
+  test('whitespace and empty strings', function(t) {
+    queryParams.categories = 'food, , nightlife ,';
+    sanitize(queryParams, function( err, clean ){
+      t.deepEqual(clean.categories, ['food', 'nightlife'], 'categories set');
+      t.end();
+    });
+  });
+  test('all empty strings', function(t) {
+    queryParams.categories = ', ,  ,';
+    sanitize(queryParams, function( err, clean ){
+      t.deepEqual(clean.categories, defaultClean.categories, 'empty strings filtered out');
       t.end();
     });
   });


### PR DESCRIPTION
Add `categories` parameter to `/reverse` endpoint. Expected values are comma-separated strings. The categories specified should come from the supported category taxonomy to surface results.

The query will `or` all specified categories and results will be sorted by proximity to `lat,lon` as done in all other `/reverse` query cases.