### PR TITLE
Resolve #114: report runtime errors.

### DIFF
--- a/middleware/500.js
+++ b/middleware/500.js
@@ -6,7 +6,7 @@ function middleware(err, req, res, next) {
   logger.error( 'Stack trace:', err.trace );
   res.header('Cache-Control','no-cache');
   if( res.statusCode < 400 ){ res.status(500); }
-  res.json({ error: err.toString() });
+  res.json({ error: 'internal server error' });
 }
 
 module.exports = middleware;

--- a/middleware/500.js
+++ b/middleware/500.js
@@ -1,9 +1,12 @@
+var logger = require( '../src/logger' );
 
 // handle application errors
 function middleware(err, req, res, next) {
+  logger.error( 'Error:', err );
+  logger.error( 'Stack trace:', err.trace );
   res.header('Cache-Control','no-cache');
   if( res.statusCode < 400 ){ res.status(500); }
-  res.json({ error: err });
+  res.json({ error: err.toString() });
 }
 
 module.exports = middleware;


### PR DESCRIPTION
```
middleware/500.js
	-Add code to the 500 catchall middleware to report errors to
	stdout/stderr.
	-Also, stringify the error via `.toString()` before passing it
	to `res.json()`, since otherwise an empty object appears to be
	returned.
```