### PR TITLE
add logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ The API ships with several convenience commands (runnable via `npm`):
   * `npm run docs`: generate API documentation
   * `npm run coverage`: generate code coverage reports
 
+## pelias-config
+The API recognizes the following properties under the top-level `api` key in your `pelias.json` config file:
+
+  * `accessLog`: (*optional*) The name of the format to use for access logs; may be any one of the
+  [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to
+  `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.
+
 ## Contributing
 
 Please fork and pull request against upstream master on a feature branch. Pretty please; provide unit tests and script

--- a/app.js
+++ b/app.js
@@ -1,7 +1,10 @@
 
 var app = require('express')();
+var peliasConfig = require( 'pelias-config' ).generate().api;
 
-app.use( require( './middleware/access_log' ) );
+if( peliasConfig.accessLog ){
+  app.use( require( './middleware/access_log' )( peliasConfig.accessLog ) );
+}
 
 /** ----------------------- middleware ----------------------- **/
 

--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 
 var app = require('express')();
 
+app.use( require( './middleware/access_log' ) );
+
 /** ----------------------- middleware ----------------------- **/
 
 app.use( require('./middleware/headers') );

--- a/middleware/500.js
+++ b/middleware/500.js
@@ -1,8 +1,8 @@
-var logger = require( '../src/logger' );
+var logger = require( 'pelias-logger' ).get( 'middleware-500' );
 
 // handle application errors
 function middleware(err, req, res, next) {
-  logger.error( 'Error:', err );
+  logger.error( err );
   logger.error( 'Stack trace:', err.trace );
   res.header('Cache-Control','no-cache');
   if( res.statusCode < 400 ){ res.status(500); }

--- a/middleware/500.js
+++ b/middleware/500.js
@@ -2,8 +2,7 @@ var logger = require( 'pelias-logger' ).get( 'middleware-500' );
 
 // handle application errors
 function middleware(err, req, res, next) {
-  logger.error( err );
-  logger.error( 'Stack trace:', err.trace );
+  logger.error( 'Error: `%s`. Stack trace: `%s`.', err, err.stack );
   res.header('Cache-Control','no-cache');
   if( res.statusCode < 400 ){ res.status(500); }
   res.json({ error: typeof err === 'string' ? err : 'internal server error' });

--- a/middleware/access_log.js
+++ b/middleware/access_log.js
@@ -1,14 +1,20 @@
 /**
- * Print out access logs.
+ * Create a middleware that prints access logs via pelias-logger.
  */
 
 'use strict';
 
-var peliasConfig = require( 'pelias-config' ).generate().api;
 var morgan = require( 'morgan' );
+var through = require( 'through2' );
+var peliasLogger = require( 'pelias-logger' ).get( 'api' );
 
-module.exports = peliasConfig.accessLog ?
-  morgan( peliasConfig.accessLog ) :
-  function noop(req, res, next){
-    next();
-  };
+function createAccessLogger( logFormat ){
+  return morgan( logFormat, {
+    stream: through( function write( ln, _, next ){
+      peliasLogger.info( ln.toString().trim() );
+      next();
+    })
+  });
+}
+
+module.exports = createAccessLogger;

--- a/middleware/access_log.js
+++ b/middleware/access_log.js
@@ -1,0 +1,14 @@
+/**
+ * Print out access logs.
+ */
+
+'use strict';
+
+var peliasConfig = require( 'pelias-config' ).generate().api;
+var morgan = require( 'morgan' );
+
+module.exports = peliasConfig.accessLog ?
+  morgan( peliasConfig.accessLog ) :
+  function noop(req, res, next){
+    next();
+  };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "is-object": "^1.0.1",
     "markdown": "0.5.0",
     "pelias-esclient": "0.0.25",
+    "pelias-logger": "^0.0.8",
     "morgan": "1.5.2",
     "pelias-config": "^0.1.4",
     "pelias-suggester-pipeline": "2.0.2"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "markdown": "0.5.0",
     "pelias-esclient": "0.0.25",
     "pelias-logger": "^0.0.8",
+    "through2": "0.6.5",
     "morgan": "1.5.2",
     "pelias-config": "^0.1.4",
     "pelias-suggester-pipeline": "2.0.2"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "through2": "0.6.5",
     "morgan": "1.5.2",
     "pelias-config": "^0.1.4",
+    "microtime": "1.4.0",
     "pelias-suggester-pipeline": "2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "is-object": "^1.0.1",
     "markdown": "0.5.0",
     "pelias-esclient": "0.0.25",
+    "morgan": "1.5.2",
+    "pelias-config": "^0.1.4",
     "pelias-suggester-pipeline": "2.0.2"
   },
   "devDependencies": {

--- a/query/search.js
+++ b/query/search.js
@@ -1,10 +1,8 @@
 
-var logger = require('../src/logger'),
-    queries = require('geopipes-elasticsearch-backend').queries,
+var queries = require('geopipes-elasticsearch-backend').queries,
     sort = require('../query/sort');
 
 function generate( params ){
-
   var centroid = null;
 
   if ( params.lat && params.lon ){

--- a/query/suggest.js
+++ b/query/suggest.js
@@ -1,6 +1,5 @@
 
-var logger = require('../src/logger'),
-    get_layers = require('../helper/layers');
+var get_layers = require('../helper/layers');
 
 // Build pelias suggest query
 function generate( params, query_mixer, fuzziness ){
@@ -69,7 +68,6 @@ function generate( params, query_mixer, fuzziness ){
   }
   
   
-  // logger.log( 'cmd', JSON.stringify( cmd.cmd, null, 2 ) );
   return cmd.cmd;
 
 }

--- a/sanitiser/coarse.js
+++ b/sanitiser/coarse.js
@@ -1,6 +1,5 @@
 
-var logger = require('../src/logger'),
-    _sanitize = require('../sanitiser/_sanitize'),
+var _sanitize = require('../sanitiser/_sanitize'),
     sanitizers = {
       input: require('../sanitiser/_input'),
       size: require('../sanitiser/_size'),

--- a/sanitiser/doc.js
+++ b/sanitiser/doc.js
@@ -1,6 +1,5 @@
 
-var logger = require('../src/logger'),
-    _sanitize = require('../sanitiser/_sanitize'),
+var _sanitize = require('../sanitiser/_sanitize'),
     sanitizers = {
       id: require('../sanitiser/_id'),
       details: require('../sanitiser/_details')

--- a/sanitiser/search.js
+++ b/sanitiser/search.js
@@ -1,6 +1,5 @@
 
-var logger = require('../src/logger'),
-    _sanitize = require('../sanitiser/_sanitize'),
+var _sanitize = require('../sanitiser/_sanitize'),
     sanitizers = {
       input: require('../sanitiser/_input'),
       size: require('../sanitiser/_size'),

--- a/sanitiser/suggest.js
+++ b/sanitiser/suggest.js
@@ -1,6 +1,5 @@
 
-var logger = require('../src/logger'),
-    _sanitize = require('../sanitiser/_sanitize'),
+var _sanitize = require('../sanitiser/_sanitize'),
     sanitizers = {
       input: require('../sanitiser/_input'),
       size: require('../sanitiser/_size'),

--- a/service/mget.js
+++ b/service/mget.js
@@ -11,6 +11,9 @@
 
 **/
 
+var peliasLogger = require( 'pelias-logger' ).get( 'service/mget' );
+var microtime = require( 'microtime' );
+
 function service( backend, query, cb ){
 
   // backend command
@@ -20,8 +23,10 @@ function service( backend, query, cb ){
     }
   };
   
+  var startTime = microtime.nowDouble();
   // query new backend
   backend().client.mget( cmd, function( err, data ){
+    peliasLogger.verbose( 'time elasticsearch query took:', microtime.nowDouble() - startTime );
 
     // handle backend errors
     if( err ){ return cb( err ); }

--- a/service/search.js
+++ b/service/search.js
@@ -5,10 +5,15 @@
 
 **/
 
+var peliasLogger = require( 'pelias-logger' ).get( 'service/search' );
+var microtime = require( 'microtime' );
+
 function service( backend, cmd, cb ){
   
+  var startTime = microtime.nowDouble();
   // query new backend
   backend().client.search( cmd, function( err, data ){
+    peliasLogger.verbose( 'time elasticsearch query took:', microtime.nowDouble() - startTime );
 
     // handle backend errors
     if( err ){ return cb( err ); }

--- a/service/suggest.js
+++ b/service/suggest.js
@@ -4,10 +4,15 @@
   cmd can be any valid ES suggest command
 
 **/
+var peliasLogger = require( 'pelias-logger' ).get( 'service/suggest' );
+
+var microtime = require( 'microtime' );
 
 function service( backend, cmd, cb ){
   // query new backend
+  var startTime = microtime.nowDouble();
   backend().client.suggest( cmd, function( err, data ){
+    peliasLogger.verbose( 'time elasticsearch query took:', microtime.nowDouble() - startTime );
     // handle backend errors
     if( err ){ return cb( err ); }
     

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,5 +1,0 @@
-module.exports = {
-  log: console.log.bind( console ),
-  warn: console.warn.bind( console ),
-  error: console.error.bind( console )
-};


### PR DESCRIPTION
  * replace `src/logger` with direct use of `pelias-logger`
  * add access-logging with the [morgan](https://github.com/expressjs/morgan/) package, with a format configurable in `pelias.json`
  * log the time taken per elasticsearch request (inside every `service/*.js` file)

fixes #8 