### PR TITLE
filter /suggest and /search by category

### DIFF
--- a/query/category_filter.js
+++ b/query/category_filter.js
@@ -1,0 +1,16 @@
+/**
+ * Inject the logic for filtering results by category into an elasticsearch
+ * query.
+ */
+
+'use strict';
+
+module.exports = function ( query, params ){
+  if( params.categories && params.categories.length > 0 ){
+    query.query.filtered.filter.bool.must.push({
+      terms: {
+        category: params.categories
+      }
+    });
+  }
+};

--- a/query/search.js
+++ b/query/search.js
@@ -1,5 +1,6 @@
 
 var queries = require('geopipes-elasticsearch-backend').queries,
+    categoryFilter = require('./category_filter'),
     sort = require('../query/sort');
 
 function generate( params ){
@@ -44,7 +45,7 @@ function generate( params ){
   }
 
   query.sort = query.sort.concat( sort( params ) );
-
+  categoryFilter( query, params );
   return query;
 }
 

--- a/sanitiser/search.js
+++ b/sanitiser/search.js
@@ -5,6 +5,7 @@ var _sanitize = require('../sanitiser/_sanitize'),
       size: require('../sanitiser/_size'),
       layers: require('../sanitiser/_layers'),
       details: require('../sanitiser/_details'),
+      categories: require('./_categories'),
       latlonzoom: require('../sanitiser/_geo')
     };
 

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -195,6 +195,32 @@ module.exports.tests.query = function(test, common) {
     t.deepEqual(query, expected, 'valid search query');
     t.end();
   });
+
+  test('valid query with categories', function(t) {
+    var query = generate({
+      input: 'test',
+      size: 10,
+      lat: 29.49136,
+      lon: -82.50622,
+      bbox: {
+        top: 47.47,
+        right: -61.84,
+        bottom: 11.51,
+        left: -103.16
+      },
+      layers: ['test'],
+      categories: ['narwhal', 'foobar']
+    });
+
+    var expected = createExpectedQuery();
+    expected.query.filtered.filter.bool.must.push({
+      terms: {
+        category: ['narwhal', 'foobar']
+      }
+    });
+    t.deepEqual(query, expected, 'valid search query');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -110,6 +110,7 @@ function createExpectedQuery(){
     'track_scores': true
   };
 }
+
 module.exports.tests.query = function(test, common) {
   test('valid query', function(t) {
     var query = generate({
@@ -150,31 +151,8 @@ module.exports.tests.query = function(test, common) {
       layers: ['test']
     });
 
-    var expected = {
-      'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'must': [{ 
-                  'match': {
-                    'name.default': 'test'
-                  }
-                }
-              ]   
-            }
-          },
-          'filter': {
-            'bool': {
-              'must': []
-            }
-          }
-        }
-      },
-      'size': 10,
-      'sort': sort,
-      'track_scores': true
-    };
-    
+    var expected = createExpectedQuery();
+    expected.query.filtered.filter.bool.must = [];
     t.deepEqual(query, expected, 'valid search query');
     t.end();
   });
@@ -186,55 +164,33 @@ module.exports.tests.query = function(test, common) {
       layers: ['test']
     });
 
-    var expected = {
-      'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'must': [{ 
-                  'match': {
-                    'name.default': 'test'
-                  }
-                }
-              ]   
-            }
+    var expected = createExpectedQuery();
+    expected.query.filtered.filter.bool.must = [{
+      'geo_distance': {
+        'distance': '50km',
+        'distance_type': 'plane',
+        'optimize_bbox': 'indexed',
+        '_cache': true,
+        'center_point': {
+          'lat': '29.49',
+          'lon': '-82.51'
+        }
+      }
+    }];
+    expected.sort.shift();
+    expected.sort.unshift(
+      '_score',
+      {
+        '_geo_distance': {
+          'center_point': {
+            'lat': 29.49136,
+            'lon': -82.50622
           },
-          'filter': {
-            'bool': {
-              'must': [
-                {
-                  'geo_distance': {
-                    'distance': '50km',
-                    'distance_type': 'plane',
-                    'optimize_bbox': 'indexed',
-                    '_cache': true,
-                    'center_point': {
-                      'lat': '29.49',
-                      'lon': '-82.51'
-                    }
-                  }
-                }
-              ]
-            }
-           }
+          'order': 'asc',
+          'unit': 'km'
         }
-      },
-      'sort': [
-        '_score',
-        {
-          '_geo_distance': {
-            'center_point': {
-              'lat': 29.49136,
-              'lon': -82.50622
-            },
-            'order': 'asc',
-            'unit': 'km'
-          }
-        }
-      ].concat(sort.slice(1)),
-      'size': 10,
-      'track_scores': true
-    };
+      }
+    );
 
     t.deepEqual(query, expected, 'valid search query');
     t.end();

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -16,62 +16,62 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
-var sort = [
-  '_score',
-  {
-    '_script': {
-      'file': admin_boost,
-      'type': 'number',
-      'order': 'desc'
-    }
-  },
-  {
-    '_script': {
-      'file': population,
-      'type': 'number',
-      'order': 'desc'
-    }
-  },
-  {
-    '_script': {
-      'file': popularity,
-      'type': 'number',
-      'order': 'desc'
-    }
-  },
-  {
-    '_script': {
-      'params': {
-        'category_weights': category_weights
-      },
-      'file': category,
-      'type': 'number',
-      'order': 'desc'
-    }
-  },
-  {
-    '_script': {
-      'params': {
-        'weights': weights
-      },
-      'file': 'weights',
-      'type': 'number',
-      'order': 'desc'
-    }
-  },
-  {
-    '_script': {
-      'params': {
-        'input': 'test'
-      },
-      'file': 'exact_match',
-      'type': 'number',
-      'order': 'desc'
-    }
-  }
-];
-
 function createExpectedQuery(){
+  var sort = [
+    '_score',
+    {
+      '_script': {
+        'file': admin_boost,
+        'type': 'number',
+        'order': 'desc'
+      }
+    },
+    {
+      '_script': {
+        'file': population,
+        'type': 'number',
+        'order': 'desc'
+      }
+    },
+    {
+      '_script': {
+        'file': popularity,
+        'type': 'number',
+        'order': 'desc'
+      }
+    },
+    {
+      '_script': {
+        'params': {
+          'category_weights': category_weights
+        },
+        'file': category,
+        'type': 'number',
+        'order': 'desc'
+      }
+    },
+    {
+      '_script': {
+        'params': {
+          'weights': weights
+        },
+        'file': 'weights',
+        'type': 'number',
+        'order': 'desc'
+      }
+    },
+    {
+      '_script': {
+        'params': {
+          'input': 'test'
+        },
+        'file': 'exact_match',
+        'type': 'number',
+        'order': 'desc'
+      }
+    }
+  ];
+
   return {
     'query': {
       'filtered': {

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -71,44 +71,45 @@ var sort = [
   }
 ];
 
-var expected = {
-  'query': {
-    'filtered': {
-      'query': {
-        'bool': {
-          'must': [{ 
-              'match': {
-                'name.default': 'test'
+function createExpectedQuery(){
+  return {
+    'query': {
+      'filtered': {
+        'query': {
+          'bool': {
+            'must': [{ 
+                'match': {
+                  'name.default': 'test'
+                }
               }
-            }
-          ]   
-        }
-      },
-      'filter': {
-        'bool': {
-          'must': [
-            {
-              'geo_bounding_box': {
-                'center_point': {
-                  'top': '47.47',
-                  'right': '-61.84',
-                  'bottom':'11.51',
-                  'left': '-103.16'
-                },
-                '_cache': true,
-                'type': 'indexed'
+            ]   
+          }
+        },
+        'filter': {
+          'bool': {
+            'must': [
+              {
+                'geo_bounding_box': {
+                  'center_point': {
+                    'top': '47.47',
+                    'right': '-61.84',
+                    'bottom':'11.51',
+                    'left': '-103.16'
+                  },
+                  '_cache': true,
+                  'type': 'indexed'
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       }
-    }
-  },
-  'sort': sort,
-  'size': 10,
-  'track_scores': true
-};
-
+    },
+    'sort': sort,
+    'size': 10,
+    'track_scores': true
+  };
+}
 module.exports.tests.query = function(test, common) {
   test('valid query', function(t) {
     var query = generate({
@@ -123,7 +124,7 @@ module.exports.tests.query = function(test, common) {
       layers: ['test']
     });
 
-    t.deepEqual(query, expected, 'valid search query');
+    t.deepEqual(query, createExpectedQuery(), 'valid search query');
     t.end();
   });
 
@@ -139,7 +140,7 @@ module.exports.tests.query = function(test, common) {
       layers: ['test']
     });
     
-    t.deepEqual(query, expected, 'valid search query');
+    t.deepEqual(query, createExpectedQuery(), 'valid search query');
     t.end();
   });
 

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -8,6 +8,7 @@ var search  = require('../../../sanitiser/search'),
                       layers: [ 'geoname', 'osmnode', 'osmway', 'admin0', 'admin1', 'admin2', 'neighborhood', 
                                 'locality', 'local_admin', 'osmaddress', 'openaddresses' ], 
                       size: 10,
+                      categories: [],
                       details: true
                     },
     sanitize = function(query, cb) { _sanitize({'query':query}, cb); };


### PR DESCRIPTION
Add support for a `categories` param to the `/search` and `/suggest` endpoints.

fix #128 