### PR TITLE
add logging for elasticsearch query execution time

### DIFF
--- a/service/search.js
+++ b/service/search.js
@@ -18,6 +18,9 @@ function service( backend, cmd, cb ){
     // handle backend errors
     if( err ){ return cb( err ); }
 
+    // log total ms elasticsearch reported the query took to execute
+    peliasLogger.verbose( 'time elasticsearch reported:', data.took / 1000 );
+
     // map returned documents
     var docs = [];
     if( data && data.hits && data.hits.total && Array.isArray(data.hits.hits)){


### PR DESCRIPTION
simply added another log line to compare the time reported by the `microtome` benchmark.
the numbers can be quite different, because one includes the connection time and time taken by the client lib and our own js code.

```bash
listening on 3100
2015-05-20T13:32:21.978Z - verbose: [service/search] time elasticsearch query took: 0.055706024169921875
2015-05-20T13:32:21.979Z - verbose: [service/search] time elasticsearch reported: 0.029
2015-05-20T13:32:21.993Z - info: [api] 127.0.0.1 - - [20/May/2015:13:32:21 +0000] "GET /search?input=ab HTTP/1.1" 200 2956
2015-05-20T13:32:29.696Z - verbose: [service/search] time elasticsearch query took: 0.0701751708984375
2015-05-20T13:32:29.696Z - verbose: [service/search] time elasticsearch reported: 0.062
2015-05-20T13:32:29.703Z - info: [api] 127.0.0.1 - - [20/May/2015:13:32:29 +0000] "GET /search?input=ab HTTP/1.1" 200 2956
2015-05-20T13:32:41.834Z - verbose: [service/search] time elasticsearch query took: 0.03359699249267578
2015-05-20T13:32:41.834Z - verbose: [service/search] time elasticsearch reported: 0.026
2015-05-20T13:32:41.837Z - info: [api] 127.0.0.1 - - [20/May/2015:13:32:41 +0000] "GET /search?input=ab HTTP/1.1" 200 2956
2015-05-20T13:32:45.142Z - verbose: [service/search] time elasticsearch query took: 0.022921085357666016
2015-05-20T13:32:45.142Z - verbose: [service/search] time elasticsearch reported: 0.02
2015-05-20T13:32:45.146Z - info: [api] 127.0.0.1 - - [20/May/2015:13:32:45 +0000] "GET /search?input=ab HTTP/1.1" 200 2956
2015-05-20T13:32:49.050Z - verbose: [service/search] time elasticsearch query took: 0.039009809494018555
2015-05-20T13:32:49.050Z - verbose: [service/search] time elasticsearch reported: 0.037
2015-05-20T13:32:49.059Z - info: [api] 127.0.0.1 - - [20/May/2015:13:32:49 +0000] "GET /search?input=ab HTTP/1.1" 200 2956
```