### PR TITLE
Details param not working as expected

### DIFF
--- a/sanitiser/_details.js
+++ b/sanitiser/_details.js
@@ -19,12 +19,15 @@ function sanitize( req, default_value ){
 
   if (params.details !== undefined) {
     var details = params.details;
-    
+
     if (typeof params.details === 'string') {
-      details = params.details === 'true';
+      details = params.details === 'true' ||
+                params.details === '1' ||
+                params.details === 'yes' ||
+                params.details === 'y';
     }
 
-    clean.details = details === true || details === 1;  
+    clean.details = details === true || details === 1;
   } else {
     clean.details = default_value;
   }

--- a/sanitiser/_details.js
+++ b/sanitiser/_details.js
@@ -18,16 +18,7 @@ function sanitize( req, default_value ){
   }
 
   if (params.details !== undefined) {
-    var details = params.details;
-
-    if (typeof params.details === 'string') {
-      details = params.details === 'true' ||
-                params.details === '1' ||
-                params.details === 'yes' ||
-                params.details === 'y';
-    }
-
-    clean.details = details === true || details === 1;
+    clean.details = isTruthy(params.details);
   } else {
     clean.details = default_value;
   }
@@ -36,6 +27,14 @@ function sanitize( req, default_value ){
   
   return {'error':false};
 
+}
+
+function isTruthy(val) {
+  if (typeof val === 'string') {
+    return ['true', '1', 'yes', 'y'].indexOf(val) !== -1;
+  }
+
+  return val === 1 || val === true;
 }
 
 // export function

--- a/test/unit/sanitiser/reverse.js
+++ b/test/unit/sanitiser/reverse.js
@@ -137,7 +137,7 @@ module.exports.tests.sanitize_details = function(test, common) {
     });  
   });
 
-  var valid_values = [true, 'true', 1];
+  var valid_values = [true, 'true', 1, '1', 'yes', 'y'];
   valid_values.forEach(function(details) {
     test('valid details param ' + details, function(t) {
       sanitize({ input: 'test', lat: 0, lon: 0, details: details }, function( err, clean ){
@@ -154,7 +154,7 @@ module.exports.tests.sanitize_details = function(test, common) {
     });
   });
 
-  var valid_false_values = ['false', false, 0];
+  var valid_false_values = ['false', false, 0, '0', 'no', 'n'];
   valid_false_values.forEach(function(details) {
     test('test setting false explicitly ' + details, function(t) {
       sanitize({ input: 'test', lat: 0, lon: 0, details: details }, function( err, clean ){

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -278,7 +278,7 @@ module.exports.tests.sanitize_details = function(test, common) {
     });  
   });
 
-  var valid_values = ['true', true, 1];
+  var valid_values = ['true', true, 1, '1', 'yes', 'y'];
   valid_values.forEach(function(details) {
     test('valid details param ' + details, function(t) {
       sanitize({ input: 'test', lat: 0, lon: 0, details: details }, function( err, clean ){
@@ -288,7 +288,7 @@ module.exports.tests.sanitize_details = function(test, common) {
     });  
   });
 
-  var valid_false_values = ['false', false, 0];
+  var valid_false_values = ['false', false, 0, '0', 'no', 'n'];
   valid_false_values.forEach(function(details) {
     test('test setting false explicitly ' + details, function(t) {
       sanitize({ input: 'test', lat: 0, lon: 0, details: details }, function( err, clean ){


### PR DESCRIPTION
Fixes #135 

`details` can now be set to `true`, `"true"`, `1`, `"1"`, `"yes"`, `"y"` in order to receive detailed properties. 