### PR TITLE
Adding 408: request timeout response

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,6 +52,7 @@ app.get( '/reverse', sanitisers.reverse.middleware, controllers.search(undefined
 /** ----------------------- error middleware ----------------------- **/
 
 app.use( require('./middleware/404') );
+app.use( require('./middleware/408') );
 app.use( require('./middleware/500') );
 
 module.exports = app;

--- a/middleware/408.js
+++ b/middleware/408.js
@@ -2,7 +2,7 @@
 // handle time out errors
 function middleware(err, req, res, next) {
   res.header('Cache-Control','no-cache');
-  if( res.statusCode === 408 ){ 
+  if( res.statusCode === 408 || (err.message.toLowerCase().indexOf('request timeout') !== -1) ){ 
   	res.status(408); 
   	res.json({ error: err && typeof err.message === 'string' ? err.message : 'request time out' });
   } else {

--- a/middleware/408.js
+++ b/middleware/408.js
@@ -1,0 +1,9 @@
+
+// handle time out errors
+function middleware(err, req, res, next) {
+  res.header('Cache-Control','no-cache');
+  if( res.statusCode === 408 ){ res.status(408); }
+  res.json({ error: typeof err === 'string' ? err : 'request time out' });
+}
+
+module.exports = middleware;

--- a/middleware/408.js
+++ b/middleware/408.js
@@ -2,8 +2,12 @@
 // handle time out errors
 function middleware(err, req, res, next) {
   res.header('Cache-Control','no-cache');
-  if( res.statusCode === 408 ){ res.status(408); }
-  res.json({ error: typeof err === 'string' ? err : 'request time out' });
+  if( res.statusCode === 408 ){ 
+  	res.status(408); 
+  	res.json({ error: err && typeof err.message === 'string' ? err.message : 'request time out' });
+  } else {
+  	next(err);
+  }
 }
 
 module.exports = middleware;

--- a/middleware/500.js
+++ b/middleware/500.js
@@ -5,7 +5,7 @@ function middleware(err, req, res, next) {
   logger.error( 'Error: `%s`. Stack trace: `%s`.', err, err.stack );
   res.header('Cache-Control','no-cache');
   if( res.statusCode < 400 ){ res.status(500); }
-  res.json({ error: typeof err === 'string' ? err : 'internal server error' });
+  res.json({ error: err && typeof err.message === 'string' ? err.message : 'internal server error' });
 }
 
 module.exports = middleware;


### PR DESCRIPTION
API should be able to handle 408 status codes upon request timeout. 