### PR TITLE
[DO NOT MERGE] added category sanitiser to /search and updated search query

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -46,10 +46,8 @@ function generate( params ){
 
   // add category mapping
   if (params.categories) {
-    query.query.filtered.query.bool.should.push({
-      'match': {
-        'category': params.categories
-      }
+    query.query.filtered.filter.bool.must.push({
+      terms: { category: params.categories }
     });
   }
 

--- a/query/search.js
+++ b/query/search.js
@@ -44,6 +44,15 @@ function generate( params ){
     });
   }
 
+  // add category mapping
+  if (params.categories) {
+    query.query.filtered.query.bool.should.push({
+      'match': {
+        'category': params.categories
+      }
+    });
+  }
+
   // add phrase matching query
   // note: this is required for shingle/phrase matching
   query.query.filtered.query.bool.should.push({

--- a/sanitiser/_categories.js
+++ b/sanitiser/_categories.js
@@ -27,6 +27,10 @@ function sanitize( req ){
       });
   }
 
+  if (clean.categories.length === 0) {
+    delete clean.categories;
+  }
+  
   // pass validated params to next middleware
   req.clean = clean;
 

--- a/sanitiser/search.js
+++ b/sanitiser/search.js
@@ -5,7 +5,8 @@ var _sanitize = require('../sanitiser/_sanitize'),
       size: require('../sanitiser/_size'),
       layers: require('../sanitiser/_layers'),
       details: require('../sanitiser/_details'),
-      latlonzoom: require('../sanitiser/_geo')
+      latlonzoom: require('../sanitiser/_geo'),
+      categories: require('../sanitiser/_categories')
     };
 
 var sanitize = function(req, cb) { _sanitize(req, sanitizers, cb); };

--- a/test/unit/sanitiser/reverse.js
+++ b/test/unit/sanitiser/reverse.js
@@ -9,8 +9,7 @@ var suggest  = require('../../../sanitiser/reverse'),
                                 'locality', 'local_admin', 'osmaddress', 'openaddresses' ], 
                       lon: 0,
                       size: 10,
-                      details: true,
-                      categories: []
+                      details: true
                     },
     sanitize = function(query, cb) { _sanitize({'query':query}, cb); };
 


### PR DESCRIPTION
This is part of the pair programming between me and @orangejulius (was fun!)
got tests to pass: by not setting an empty array as categories

fixes https://github.com/pelias/api/issues/128