### PR TITLE
phrase slop query modifications

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -102,7 +102,10 @@ function generate( params ){
   // add search condition to distance query
   query.query.filtered.query.bool.must.push({ 
     'match': {
-      'name.default': input
+      'name.default': {
+        'query': input,
+        'analyzer': 'peliasOneEdgeGram'
+      }
     }
   });
 
@@ -110,7 +113,12 @@ function generate( params ){
   // note: this is required for shingle/phrase matching
   query.query.filtered.query.bool.should.push({
     'match': {
-      'phrase.default': input
+      'phrase.default': {
+        'query': input,
+        'analyzer': 'peliasPhrase',
+        'type': 'phrase',
+        'slop': 2
+      }
     }
   });
 

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -80,12 +80,20 @@ var expected = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': 'test'
+              'name.default': {
+                'query': 'test',
+                'analyzer': 'peliasOneEdgeGram'
+              }
             }
           }],
           'should': [{
             'match': {
-              'phrase.default': 'test'
+              'phrase.default': {
+                'query': 'test',
+                'analyzer': 'peliasPhrase',
+                'type': 'phrase',
+                'slop': 2
+              }
             }
           }]
         }
@@ -162,12 +170,20 @@ module.exports.tests.query = function(test, common) {
             'bool': {
               'must': [{
                 'match': {
-                  'name.default': 'test'
+                  'name.default': {
+                    'query': 'test',
+                    'analyzer': 'peliasOneEdgeGram'
+                  }
                 }
               }],
               'should': [{
                 'match': {
-                  'phrase.default': 'test'
+                  'phrase.default': {
+                    'query': 'test',
+                    'analyzer': 'peliasPhrase',
+                    'type': 'phrase',
+                    'slop': 2
+                  }
                 }
               }]
             }
@@ -202,12 +218,20 @@ module.exports.tests.query = function(test, common) {
             'bool': {
               'must': [{
                 'match': {
-                  'name.default': 'test'
+                  'name.default': {
+                    'query': 'test',
+                    'analyzer': 'peliasOneEdgeGram'
+                  }
                 }
               }],
               'should': [{
                 'match': {
-                  'phrase.default': 'test'
+                  'phrase.default': {
+                    'query': 'test',
+                    'analyzer': 'peliasPhrase',
+                    'type': 'phrase',
+                    'slop': 2
+                  }
                 }
               }]
             }
@@ -260,7 +284,10 @@ module.exports.tests.query = function(test, common) {
              'must': [
                {
                  'match': {
-                   'name.default': '123 main st'
+                   'name.default': {
+                     'query': '123 main st',
+                     'analyzer': 'peliasOneEdgeGram'
+                   }
                  }
                }
              ],
@@ -292,7 +319,12 @@ module.exports.tests.query = function(test, common) {
                },
                {
                  'match': {
-                   'phrase.default': '123 main st'
+                   'phrase.default': {
+                     'query': '123 main st',
+                     'analyzer': 'peliasPhrase',
+                     'type': 'phrase',
+                     'slop': 2
+                   }
                  }
                }
              ]
@@ -409,7 +441,10 @@ module.exports.tests.query = function(test, common) {
              'must': [
                {
                  'match': {
-                   'name.default': 'soho grand'
+                   'name.default': {
+                     'query': 'soho grand',
+                     'analyzer': 'peliasOneEdgeGram'
+                   }
                  }
                }
              ],
@@ -441,7 +476,12 @@ module.exports.tests.query = function(test, common) {
                },
                {
                  'match': {
-                   'phrase.default': 'soho grand'
+                   'phrase.default': {
+                     'query': 'soho grand',
+                     'analyzer': 'peliasPhrase',
+                     'type': 'phrase',
+                     'slop': 2
+                   }
                  }
                }
              ]


### PR DESCRIPTION
this is the API PR to change the query logic slightly to account for https://github.com/pelias/schema/pull/70

I also included an update which explicitly specifies the analyzer to use for ngrams queries (peliasOneEdgeGram) as autocomplete for single letter inputs is currently not working (it should be enabled for admin layers only)

note: the schema PR should be merged before this PR and after a staging build and review.

Closes https://github.com/pelias/schema/issues/66