### PR TITLE
Remove bounds checks for latitude and longitude

### DIFF
--- a/sanitiser/_geo.js
+++ b/sanitiser/_geo.js
@@ -81,7 +81,7 @@ function sanitize_bbox( clean, param ) {
  * @param {bool} latlon_is_required
  */
 function sanitize_coord( coord, clean, param, latlon_is_required ) {
-  var value = parseFloat( param, 10 );
+  var value = parseFloat( param );
   if ( !isNaN( value ) ) {
     if( coord === 'lat' && check_lat.is_invalid( value ) ){
       throw new Error( 'invalid ' + check_lat.error_msg );

--- a/sanitiser/_geo.js
+++ b/sanitiser/_geo.js
@@ -51,14 +51,17 @@ function sanitize_bbox( clean, param ) {
 
   if( Array.isArray( bboxArr ) && bboxArr.length === 4 ) {
 
-    var bbox = bboxArr.map( function ( latlon ){
-      return parseFloat( latlon, 10 );
-    });
-    bboxArr.forEach( function( latlon, index ) {
-      if( index % 2 === 1 && check_lat.is_invalid( latlon ) ){
-        throw new Error( 'Invalid lat: ' + latlon );
+    var bbox = [];
+    for( var ind = 0; ind < bboxArr.length; ind++ ){
+      var num = parseFloat( bboxArr[ ind ] );
+      if( isNaN( num ) ){
+        return;
       }
-    });
+      if( ind % 2 === 1 && check_lat.is_invalid( num ) ){
+        throw new Error( 'Invalid lat: ' + num );
+      }
+      bbox.push( num );
+    }
 
     clean.bbox = {
       right: Math.max( bbox[0], bbox[2] ),

--- a/sanitiser/_geo.js
+++ b/sanitiser/_geo.js
@@ -50,14 +50,10 @@ function sanitize_bbox( clean, param ) {
   var bboxArr = param.split( ',' );
 
   if( Array.isArray( bboxArr ) && bboxArr.length === 4 ) {
+    var bbox = bboxArr.map(parseFloat);
 
-    var bbox = [];
-    for( var ind = 0; ind < bboxArr.length; ind++ ){
-      var num = parseFloat( bboxArr[ ind ] );
-      if( isNaN( num ) ){
-        return;
-      }
-      bbox.push( num );
+    if (bbox.some(isNaN)) {
+      return;
     }
 
     clean.bbox = {

--- a/sanitiser/_geo.js
+++ b/sanitiser/_geo.js
@@ -1,3 +1,4 @@
+var util = require( 'util' );
 var isObject = require('is-object');
 
 
@@ -46,26 +47,25 @@ function sanitize_bbox( clean, param ) {
     return;
   }
 
-  var bbox = [];
   var bboxArr = param.split( ',' );
 
   if( Array.isArray( bboxArr ) && bboxArr.length === 4 ) {
 
-    bbox = bboxArr.filter( function( latlon, index ) {
-      latlon = parseFloat( latlon, 10 );
-      return !(lat_lon_checks[(index % 2 === 0 ? 'lon' : 'lat')].is_invalid( latlon ));
+    var bbox = bboxArr.map( function ( latlon ){
+      return parseFloat( latlon, 10 );
+    });
+    bboxArr.forEach( function( latlon, index ) {
+      if( index % 2 === 1 && check_lat.is_invalid( latlon ) ){
+        throw new Error( 'Invalid lat: ' + latlon );
+      }
     });
 
-    if( bbox.length === 4 ) {
-      clean.bbox = {
-        right: Math.max( bbox[0], bbox[2] ),
-        top: Math.max( bbox[1], bbox[3] ),
-        left: Math.min( bbox[0], bbox[2] ),
-        bottom: Math.min( bbox[1], bbox[3] )
-      };
-    } else {
-      throw new Error('invalid bbox');
-    }
+    clean.bbox = {
+      right: Math.max( bbox[0], bbox[2] ),
+      top: Math.max( bbox[1], bbox[3] ),
+      left: Math.min( bbox[0], bbox[2] ),
+      bottom: Math.min( bbox[1], bbox[3] )
+    };
   }
 }
 
@@ -80,13 +80,13 @@ function sanitize_bbox( clean, param ) {
 function sanitize_coord( coord, clean, param, latlon_is_required ) {
   var value = parseFloat( param, 10 );
   if ( !isNaN( value ) ) {
-    if( lat_lon_checks[coord].is_invalid( value ) ){
-      throw new Error( 'invalid ' + lat_lon_checks[coord].error_msg );
+    if( coord === 'lat' && check_lat.is_invalid( value ) ){
+      throw new Error( 'invalid ' + check_lat.error_msg );
     }
     clean[coord] = value;
   }
   else if (latlon_is_required) {
-    throw new Error('missing ' + lat_lon_checks[coord].error_msg);
+    throw new Error( util.format( 'missing param \'%s\'', coord ) );
   }
 }
 
@@ -97,18 +97,9 @@ function sanitize_zoom_level( clean, param ) {
   }
 }
 
-var lat_lon_checks = {
-  lat: {
-    is_invalid: function is_invalid_lat(lat) {
-      return isNaN( lat ) || lat < -90 || lat > 90;
-    },
-    error_msg: 'param \'lat\': must be >-90 and <90'
+var check_lat = {
+  is_invalid: function is_invalid_lat( lat ){
+    return isNaN( lat ) || lat < -90 || lat > 90;
   },
-  lon: {
-    is_invalid: function is_invalid_lon(lon) {
-      return isNaN(lon) || lon < -180 || lon > 180;
-    },
-    error_msg: 'param \'lon\': must be >-180 and <180'
-  }
+  error_msg: 'param \'lat\': must be >-90 and <90'
 };
-

--- a/sanitiser/_geo.js
+++ b/sanitiser/_geo.js
@@ -57,9 +57,6 @@ function sanitize_bbox( clean, param ) {
       if( isNaN( num ) ){
         return;
       }
-      if( ind % 2 === 1 && check_lat.is_invalid( num ) ){
-        throw new Error( 'Invalid lat: ' + num );
-      }
       bbox.push( num );
     }
 

--- a/sanitiser/_geo.js
+++ b/sanitiser/_geo.js
@@ -76,9 +76,6 @@ function sanitize_bbox( clean, param ) {
 function sanitize_coord( coord, clean, param, latlon_is_required ) {
   var value = parseFloat( param );
   if ( !isNaN( value ) ) {
-    if( coord === 'lat' && check_lat.is_invalid( value ) ){
-      throw new Error( 'invalid ' + check_lat.error_msg );
-    }
     clean[coord] = value;
   }
   else if (latlon_is_required) {
@@ -92,10 +89,3 @@ function sanitize_zoom_level( clean, param ) {
     clean.zoom = Math.min( Math.max( zoom, 1 ), 18 ); // max
   }
 }
-
-var check_lat = {
-  is_invalid: function is_invalid_lat( lat ){
-    return isNaN( lat ) || lat < -90 || lat > 90;
-  },
-  error_msg: 'param \'lat\': must be >-90 and <90'
-};

--- a/test/unit/sanitiser/reverse.js
+++ b/test/unit/sanitiser/reverse.js
@@ -3,7 +3,7 @@ var suggest  = require('../../../sanitiser/reverse'),
     _sanitize = suggest.sanitize,
     middleware = suggest.middleware,
     delim = ',',
-    defaultError = 'missing param \'lat\': must be >-90 and <90',
+    defaultError = 'missing param \'lat\'',
     defaultClean =  { lat:0,
                       layers: [ 'geoname', 'osmnode', 'osmway', 'admin0', 'admin1', 'admin2', 'neighborhood', 
                                 'locality', 'local_admin', 'osmaddress', 'openaddresses' ], 
@@ -59,7 +59,7 @@ module.exports.tests.sanitize_lat = function(test, common) {
   test('missing lat', function(t) {  
     lats.missing.forEach( function( lat ){
       sanitize({ lat: lat, lon: 0 }, function( err, clean ){
-        t.equal(err, 'missing param \'lat\': must be >-90 and <90', 'latitude is a required field');
+        t.equal(err, 'missing param \'lat\'', 'latitude is a required field');
         t.equal(clean, undefined, 'clean not set');
       });
     });
@@ -69,20 +69,9 @@ module.exports.tests.sanitize_lat = function(test, common) {
 
 module.exports.tests.sanitize_lon = function(test, common) {
   var lons = {
-    invalid: [ -360, -181, 181, 360 ],
-    valid: [ -180, -1, -0, 0, 45, 90, '-180', '0', '180' ],
+    valid: [ -360, -181, 181, -180, -1, -0, 0, 45, 90, '-180', '0', '180' ],
     missing: ['', undefined, null]
   };
-  test('invalid lon', function(t) {  
-    lons.invalid.forEach( function( lon ){
-      sanitize({ input: 'test', lat: 0, lon: lon }, function( err, clean ){
-        t.equal(err, 'invalid param \'lon\': must be >-180 and <180', lon + ' is an invalid longitude');
-        t.equal(clean, undefined, 'clean not set');
-        
-      });
-    });
-    t.end();
-  });
   test('valid lon', function(t) {  
     lons.valid.forEach( function( lon ){
       sanitize({ input: 'test', lat: 0, lon: lon }, function( err, clean ){
@@ -97,7 +86,7 @@ module.exports.tests.sanitize_lon = function(test, common) {
   test('missing lon', function(t) {  
     lons.missing.forEach( function( lon ){
       sanitize({ lat: 0, lon: lon }, function( err, clean ){
-        t.equal(err, 'missing param \'lon\': must be >-180 and <180', 'longitude is a required field');
+        t.equal(err, 'missing param \'lon\'', 'longitude is a required field');
         t.equal(clean, undefined, 'clean not set');
       });
     });
@@ -287,7 +276,7 @@ module.exports.tests.middleware_failure = function(test, common) {
       t.equal(code, 400, 'status set');
     }};
     var next = function( message ){
-      t.equal(message, defaultError);
+      t.equals(message, defaultError);
       t.end();
     };
     middleware( {}, res, next );

--- a/test/unit/sanitiser/reverse.js
+++ b/test/unit/sanitiser/reverse.js
@@ -32,8 +32,8 @@ module.exports.tests.interface = function(test, common) {
 
 module.exports.tests.sanitize_lat = function(test, common) {
   var lats = {
-    invalid: [ -181, -120, -91, 91, 120, 181 ],
-    valid: [ 0, 45, 90, -0, '0', '45', '90' ],
+    invalid: [],
+    valid: [ 0, 45, 90, -0, '0', '45', '90', -181, -120, -91, 91, 120, 181 ],
     missing: ['', undefined, null]
   };
   test('invalid lat', function(t) {  

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -84,8 +84,8 @@ module.exports.tests.sanitize_input_with_delim = function(test, common) {
 
 module.exports.tests.sanitize_lat = function(test, common) {
   var lats = {
-    invalid: [ -181, -120, -91, 91, 120, 181 ],
-    valid: [ 0, 45, 90, -0, '0', '45', '90' ]
+    invalid: [],
+    valid: [ 0, 45, 90, -0, '0', '45', '90', -181, -120, -91, 91, 120, 181  ]
   };
   test('invalid lat', function(t) {  
     lats.invalid.forEach( function( lat ){

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -113,19 +113,8 @@ module.exports.tests.sanitize_lat = function(test, common) {
 
 module.exports.tests.sanitize_lon = function(test, common) {
   var lons = {
-    invalid: [ -360, -181, 181, 360 ],
-    valid: [ -180, -1, -0, 0, 45, 90, '-180', '0', '180' ]
+    valid: [ -381, -181, -180, -1, -0, 0, 45, 90, '-180', '0', '180', 181 ]
   };
-  test('invalid lon', function(t) {  
-    lons.invalid.forEach( function( lon ){
-      sanitize({ input: 'test', lat: 0, lon: lon }, function( err, clean ){
-        t.equal(err, 'invalid param \'lon\': must be >-180 and <180', lon + ' is an invalid longitude');
-        t.equal(clean, undefined, 'clean not set');
-        
-      });
-    });
-    t.end();
-  });
   test('valid lon', function(t) {  
     lons.valid.forEach( function( lon ){
       sanitize({ input: 'test', lat: 0, lon: lon }, function( err, clean ){
@@ -198,7 +187,7 @@ module.exports.tests.sanitize_bbox = function(test, common) {
   test('invalid bbox coordinates', function(t) {  
     bboxes.invalid_coordinates.forEach( function( bbox ){
       sanitize({ input: 'test', bbox: bbox }, function( err, clean ){
-        t.equal(err, 'invalid bbox', bbox + ' is invalid');
+        t.ok(err.match(/Invalid (lat|lon)/), bbox + ' is invalid');
         t.equal(clean, undefined, 'clean not set');
       });
     });

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -167,12 +167,6 @@ module.exports.tests.sanitize_optional_geo = function(test, common) {
 module.exports.tests.sanitize_bbox = function(test, common) {
   var bboxes = {
     invalid_coordinates: [
-      // invalid latitude coordinates
-      '-181,90,34,-180',
-      '-170,91,-181,45',
-      '-181,91,181,-91',
-      '91, -181,-91,11',
-      '91, -11,-91,181'
     ],
     invalid: [
       '91;-181,-91,181', // invalid - semicolon between coordinates
@@ -190,7 +184,13 @@ module.exports.tests.sanitize_bbox = function(test, common) {
       '-40,-20,10,30',
       '-40,-20,10,30',
       '-1200,20,1000,20',
-      '-1400,90,1400,-90'
+      '-1400,90,1400,-90',
+      // wrapped latitude coordinates
+      '-181,90,34,-180',
+      '-170,91,-181,45',
+      '-181,91,181,-91',
+      '91, -181,-91,11',
+      '91, -11,-91,181'
     ]
     
   };

--- a/test/unit/sanitiser/search.js
+++ b/test/unit/sanitiser/search.js
@@ -167,20 +167,30 @@ module.exports.tests.sanitize_optional_geo = function(test, common) {
 module.exports.tests.sanitize_bbox = function(test, common) {
   var bboxes = {
     invalid_coordinates: [
-      '-181,90,34,-180', // invalid top_right lon, bottom_left lat
-      '-170,91,-181,45', // invalid top_right lat, bottom_left lon
-      '-181,91,181,-91', // invalid top_right lon/lat, bottom_left lon/lat
-      '91, -181,-91,181',// invalid - spaces between coordinates
+      // invalid latitude coordinates
+      '-181,90,34,-180',
+      '-170,91,-181,45',
+      '-181,91,181,-91',
+      '91, -181,-91,11',
+      '91, -11,-91,181'
     ],
     invalid: [
       '91;-181,-91,181', // invalid - semicolon between coordinates
+      'these,are,not,numbers',
+      '0,0,0,notANumber',
+      ',,,',
       '91, -181, -91',   // invalid - missing a coordinate
       '123,12',          // invalid - missing coordinates
       ''                 // invalid - empty param
     ],
     valid: [
       '-179,90,34,-80', // valid top_right lon/lat, bottom_left lon/lat
-      '0,0,0,0' // valid top_right lat/lon, bottom_left lat/lon
+      '0,0,0,0',
+      '10,20,30,40',
+      '-40,-20,10,30',
+      '-40,-20,10,30',
+      '-1200,20,1000,20',
+      '-1400,90,1400,-90'
     ]
     
   };

--- a/test/unit/sanitiser/suggest.js
+++ b/test/unit/sanitiser/suggest.js
@@ -82,8 +82,8 @@ module.exports.tests.sanitize_input_with_delim = function(test, common) {
 
 module.exports.tests.sanitize_lat = function(test, common) {
   var lats = {
-    invalid: [ -181, -120, -91, 91, 120, 181 ],
-    valid: [ 0, 45, 90, -0, '0', '45', '90' ]
+    invalid: [],
+    valid: [ 0, 45, 90, -0, '0', '45', '90', -181, -120, -91, 91, 120, 181 ]
   };
   test('invalid lat', function(t) {  
     lats.invalid.forEach( function( lat ){

--- a/test/unit/sanitiser/suggest.js
+++ b/test/unit/sanitiser/suggest.js
@@ -110,19 +110,8 @@ module.exports.tests.sanitize_lat = function(test, common) {
 
 module.exports.tests.sanitize_lon = function(test, common) {
   var lons = {
-    invalid: [ -360, -181, 181, 360 ],
-    valid: [ -180, -1, -0, 0, 45, 90, '-180', '0', '180' ]
+    valid: [ -381, -181, -180, -1, -0, 0, 45, 90, '-180', '0', '180', 181 ]
   };
-  test('invalid lon', function(t) {  
-    lons.invalid.forEach( function( lon ){
-      sanitize({ input: 'test', lat: 0, lon: lon }, function( err, clean ){
-        t.equal(err, 'invalid param \'lon\': must be >-180 and <180', lon + ' is an invalid longitude');
-        t.equal(clean, undefined, 'clean not set');
-        
-      });
-    });
-    t.end();
-  });
   test('valid lon', function(t) {  
     lons.valid.forEach( function( lon ){
       sanitize({ input: 'test', lat: 0, lon: lon }, function( err, clean ){
@@ -160,7 +149,7 @@ module.exports.tests.sanitize_bbox = function(test, common) {
   test('invalid bbox coordinates', function(t) {  
     bboxes.invalid_coordinates.forEach( function( bbox ){
       sanitize({ input: 'test', lat: 0, lon: 0, bbox: bbox }, function( err, clean ){
-        t.equal(err, 'invalid bbox', bbox + ' is invalid');
+        t.ok(err.match(/Invalid (lat|lon)/), bbox + ' is invalid');
         t.equal(clean, undefined, 'clean not set');
       });
     });

--- a/test/unit/sanitiser/suggest.js
+++ b/test/unit/sanitiser/suggest.js
@@ -129,10 +129,6 @@ module.exports.tests.sanitize_lon = function(test, common) {
 module.exports.tests.sanitize_bbox = function(test, common) {
   var bboxes = {
     invalid_coordinates: [
-      '-181,90,34,-180', // invalid top_right lon, bottom_left lat
-      '-170,91,-181,45', // invalid top_right lat, bottom_left lon
-      '-181,91,181,-91', // invalid top_right lon/lat, bottom_left lon/lat
-      '91, -181,-91,181',// invalid - spaces between coordinates
     ],
     invalid: [
       '91;-181,-91,181', // invalid - semicolon between coordinates
@@ -142,7 +138,11 @@ module.exports.tests.sanitize_bbox = function(test, common) {
     ],
     valid: [
       '-179,90,34,-80', // valid top_right lon/lat, bottom_left lon/lat
-      '0,0,0,0' // valid top_right lat/lon, bottom_left lat/lon
+      '0,0,0,0', // valid top_right lat/lon, bottom_left lat/lon
+      '-181,90,34,-180', // wrapped top_right lon, bottom_left lat
+      '-170,91,-181,45', // wrapped top_right lat, bottom_left lon
+      '-181,91,181,-91', // wrapped top_right lon/lat, bottom_left lon/lat
+      '91, -181,-91,181',// valid - spaces between coordinates
     ]
     
   };


### PR DESCRIPTION
Elasticsearch is able to properly handle latitudes outside [-90, 90] and longitudes outside [-180, 180]. The API currently checks for latitude and longitude bounds, but by removing those checks we can rely on Elasticsearch to interpret the latitudes and longitudes correctly. Here's an example set of requests:

**"Normal" reverse geocode for the NYC office**
http://localhost:3100/reverse?lat=40.744131&lon=-73.990425

**Reverse geocode for the same location, but with a latitude > 90 degrees**
http://localhost:3100/reverse?lat=139.255869&lon=106.009575

**Same location, longitude shifted west by 360 degrees**
http://localhost:3100/reverse?lat=40.744131&lon=-433.990425

**Same location, longitude shifted east by 360 degrees**
http://localhost:3100/reverse?lat=40.744131&lon=286.009575

These all return the same results!

Closes #121 
Closes #56 