### PR TITLE
Search query builder not checking all available admin values

### DIFF
--- a/helper/address_weights.js
+++ b/helper/address_weights.js
@@ -1,0 +1,13 @@
+/**
+ * These values specify how much a document that matches certain parts of an address
+ * should be boosted in elasticsearch results.
+ */
+
+module.exports = {
+  number: 1,
+  street: 3,
+  zip: 3,
+  admin2: 2,
+  admin1_abbr: 3,
+  alpha3: 5
+};

--- a/helper/adminFields.js
+++ b/helper/adminFields.js
@@ -1,0 +1,30 @@
+var schema = require('pelias-schema');
+var logger = require( 'pelias-logger' ).get( 'api' );
+
+var ADMIN_FIELDS = [
+  'admin0',
+  'admin1',
+  'admin1_abbr',
+  'admin2',
+  'local_admin',
+  'locality',
+  'neighborhood'
+];
+
+function getAvailableAdminFields() {
+  var actualFields = Object.keys(schema.mappings._default_.properties);
+
+  // check if expected fields are actually in current schema
+  var available = ADMIN_FIELDS.filter(function (field) {
+    return (actualFields.indexOf(field) !== -1);
+  });
+
+  if (available.length === 0) {
+    logger.error('helper/adminFields: no expected admin fields found in schema');
+  }
+
+  return available;
+}
+
+module.exports.availableFields = getAvailableAdminFields();
+module.exports.expectedFields = ADMIN_FIELDS;

--- a/helper/adminFields.js
+++ b/helper/adminFields.js
@@ -1,5 +1,5 @@
-var schema = require('pelias-schema');
-var logger = require( 'pelias-logger' ).get( 'api' );
+var peliasSchema = require('pelias-schema');
+var peliasLogger = require( 'pelias-logger' ).get( 'api' );
 
 var ADMIN_FIELDS = [
   'admin0',
@@ -11,11 +11,24 @@ var ADMIN_FIELDS = [
   'neighborhood'
 ];
 
-function getAvailableAdminFields() {
+/**
+ * Get all admin fields that were expected and also found in schema
+ *
+ * @param {Object} [schema] optional: for testing only
+ * @param {Array} [expectedFields] optional: for testing only
+ * @param {Object} [logger] optional: for testing only
+ * @returns {Array.<string>}
+ */
+function getAvailableAdminFields(schema, expectedFields, logger) {
+
+  schema = schema || peliasSchema;
+  expectedFields = expectedFields || ADMIN_FIELDS;
+  logger = logger || peliasLogger;
+
   var actualFields = Object.keys(schema.mappings._default_.properties);
 
   // check if expected fields are actually in current schema
-  var available = ADMIN_FIELDS.filter(function (field) {
+  var available = expectedFields.filter(function (field) {
     return (actualFields.indexOf(field) !== -1);
   });
 
@@ -26,5 +39,4 @@ function getAvailableAdminFields() {
   return available;
 }
 
-module.exports.availableFields = getAvailableAdminFields();
-module.exports.expectedFields = ADMIN_FIELDS;
+module.exports = getAvailableAdminFields;

--- a/helper/category_weights.js
+++ b/helper/category_weights.js
@@ -3,7 +3,14 @@
  * should be boosted in elasticsearch results.
  */
 
-module.exports = {
+module.exports.default = {
+  'transport:air': 2,
+  'transport:air:aerodrome': 2,
+  'transport:air:airport': 2,
+  'admin': 2
+};
+
+module.exports.address = {
   'transport:air': 2,
   'transport:air:aerodrome': 2,
   'transport:air:airport': 2

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
     "elasticsearch": ">=1.2.1"
   },
   "dependencies": {
+    "addressit": "1.3.0",
     "async": "^0.9.0",
     "cluster2": "git://github.com/missinglink/cluster2.git#node_zero_twelve",
     "express": "^4.8.8",
+    "extend": "2.0.1",
     "geojson": "^0.2.1",
     "geojson-extent": "^0.3.1",
     "geopipes-elasticsearch-backend": "^0.2.0",
@@ -44,10 +46,9 @@
     "microtime": "1.4.0",
     "morgan": "1.5.2",
     "pelias-config": "^0.1.4",
-    "extend": "2.0.1",
-    "addressit": "1.3.0",
     "pelias-esclient": "0.0.25",
     "pelias-logger": "^0.0.8",
+    "pelias-schema": "1.0.0",
     "pelias-suggester-pipeline": "2.0.2",
     "through2": "0.6.5"
   },

--- a/query/search.js
+++ b/query/search.js
@@ -30,14 +30,14 @@ function generate( params ){
   };
 
   if (params.parsed_input) {
-    addParsedMatch(query, input, params.parsed_input);
-
     // update input
     if (params.parsed_input.number && params.parsed_input.street) {
       input = params.parsed_input.number + ' ' + params.parsed_input.street;
     } else if (params.parsed_input.admin_parts) {
       input = params.parsed_input.name;
     }
+
+    addParsedMatch(query, input, params.parsed_input);
   }
 
   // add search condition to distance query
@@ -122,11 +122,13 @@ function addUnmatchedAdminFieldsToQuery(query, unmatchedAdminFields, parsedInput
     return;
   }
 
+  leftovers = leftovers.join(' ');
+
   // if there are additional regions/admin_parts found
   if (leftovers !== defaultInput) {
     unmatchedAdminFields.forEach(function (key) {
       // combine all the leftover parts into one string
-      addMatch(query, [], key, leftovers.join(' '));
+      addMatch(query, [], key, leftovers);
     });
   }
 }

--- a/query/sort.js
+++ b/query/sort.js
@@ -43,7 +43,7 @@ module.exports = function( params ){
     {
       '_script': {
         'params': {
-          'category_weights': category_weights
+          'category_weights': getCategoryWeights(params)
         },
         'file': category,
         'type': 'number',
@@ -64,3 +64,12 @@ module.exports = function( params ){
 
   return scriptsConfig;
 };
+
+function getCategoryWeights(params) {
+  if (params && params.hasOwnProperty('parsed_input') &&
+        (params.parsed_input.hasOwnProperty('number') ||
+         params.parsed_input.hasOwnProperty('street'))) {
+    return category_weights.address;
+  }
+  return category_weights.default;
+}

--- a/test/unit/helper/adminFields.js
+++ b/test/unit/helper/adminFields.js
@@ -1,0 +1,84 @@
+var proxyquire = require('proxyquire');
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('validate fields', function(t) {
+    var adminFields = require('../../../helper/adminFields').availableFields;
+    t.assert(adminFields instanceof Array, 'adminFields is an array');
+    t.assert(adminFields.length > 0, 'adminFields array is not empty');
+    t.end();
+  });
+  test('validate fields', function(t) {
+    var adminFields = require('../../../helper/adminFields').expectedFields;
+    t.assert(adminFields instanceof Array, 'adminFields is an array');
+    t.assert(adminFields.length > 0, 'adminFields array is not empty');
+    t.end();
+  });
+};
+
+module.exports.tests.lookupExistance = function(test, common) {
+  test('all expected fields in schema', function(t) {
+
+    var expectedFields = require('../../../helper/adminFields').expectedFields;
+    var schemaMock = { mappings: { _default_: { properties: {} } } };
+
+    // inject all expected fields into schema mock
+    expectedFields.forEach(function (field) {
+      schemaMock.mappings._default_.properties[field] = {};
+    });
+
+    var adminFields = proxyquire('../../../helper/adminFields', {'pelias-schema': schemaMock});
+
+    t.deepEquals(adminFields.availableFields, adminFields.expectedFields, 'all expected fields are returned');
+    t.end();
+  });
+
+  test('some expected fields in schema', function(t) {
+
+    var expectedFields = require('../../../helper/adminFields').expectedFields.slice(0, 3);
+    var schemaMock = { mappings: { _default_: { properties: {} } } };
+
+    // inject all expected fields into schema mock
+    expectedFields.forEach(function (field) {
+      schemaMock.mappings._default_.properties[field] = {};
+    });
+
+    var adminFields = proxyquire('../../../helper/adminFields', {'pelias-schema': schemaMock});
+
+    t.deepEquals(adminFields.availableFields, expectedFields, 'only matching expected fields are returned');
+    t.end();
+  });
+
+  test('no expected fields in schema', function(t) {
+
+    var schemaMock = { mappings: { _default_: { properties: { foo: {} } } } };
+
+    var loggerMock = { get: function (name) {
+      t.equal(name, 'api');
+      return {
+        error: function () {}
+      };
+    }};
+
+    var adminFields = proxyquire('../../../helper/adminFields',
+      {
+        'pelias-schema': schemaMock,
+        'pelias-logger': loggerMock
+      });
+
+    t.deepEquals([], adminFields.availableFields, 'no admin fields found');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('adminFields: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -53,7 +53,7 @@ var sort = [
   {
     '_script': {
       'params': {
-        'category_weights': category_weights
+        'category_weights': category_weights.default
       },
       'file': category,
       'type': 'number',

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -7,7 +7,9 @@ var category = 'category';
 var parser = require('../../../helper/query_parser');
 var category_weights = require('../../../helper/category_weights');
 var admin_weights = require('../../../helper/admin_weights');
+var address_weights = require('../../../helper/address_weights');
 var weights = require('pelias-suggester-pipeline').weights;
+
 
 module.exports.tests = {};
 
@@ -269,7 +271,7 @@ module.exports.tests.query = function(test, common) {
                  'match': {
                    'address.number': {
                      'query': 123,
-                     'boost': 1
+                     'boost': address_weights.number
                    }
                  }
                },
@@ -277,7 +279,7 @@ module.exports.tests.query = function(test, common) {
                  'match': {
                    'address.street': {
                      'query': 'main st',
-                     'boost': 3
+                     'boost': address_weights.street
                    }
                  }
                },
@@ -285,7 +287,7 @@ module.exports.tests.query = function(test, common) {
                  'match': {
                    'address.zip': {
                      'query': 10010,
-                     'boost': 3
+                     'boost': address_weights.zip
                    }
                  }
                },
@@ -293,7 +295,7 @@ module.exports.tests.query = function(test, common) {
                  'match': {
                    'admin1_abbr': {
                      'query': 'NY',
-                     'boost': 3
+                     'boost': address_weights.admin1_abbr
                    }
                  }
                },
@@ -301,7 +303,7 @@ module.exports.tests.query = function(test, common) {
                  'match': {
                    'alpha3': {
                      'query': 'USA',
-                     'boost': 5
+                     'boost': address_weights.alpha3
                    }
                  }
                },
@@ -623,7 +625,7 @@ module.exports.tests.query = function(test, common) {
                   match: {
                     'address.number': {
                       'query': 1,
-                      'boost': 1
+                      'boost': address_weights.number
                     }
                   }
                 },
@@ -631,7 +633,7 @@ module.exports.tests.query = function(test, common) {
                   match: {
                     'address.street': {
                       'query': 'water st',
-                      'boost': 3
+                      'boost': address_weights.street
                     }
                   }
                 },
@@ -639,7 +641,7 @@ module.exports.tests.query = function(test, common) {
                   'match': {
                     'admin1_abbr': {
                       'query': 'NY',
-                      'boost': 3
+                      'boost': address_weights.admin1_abbr
                     }
                   }
                 },

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -54,7 +54,7 @@ var sort = [
   {
     '_script': {
       'params': {
-        'category_weights': category_weights
+        'category_weights': category_weights.default
       },
       'file': category,
       'type': 'number',
@@ -267,27 +267,72 @@ module.exports.tests.query = function(test, common) {
              'should': [
                {
                  'match': {
-                   'address.number': 123
+                   'address.number': {
+                     'query': 123,
+                     'boost': 1
+                   }
                  }
                },
                {
                  'match': {
-                   'address.street': 'main st'
+                   'address.street': {
+                     'query': 'main st',
+                     'boost': 3
+                   }
                  }
                },
                {
                  'match': {
-                   'address.zip': 10010
+                   'address.zip': {
+                     'query': 10010,
+                     'boost': 3
+                   }
                  }
                },
                {
                  'match': {
-                   'admin1_abbr': 'NY'
+                   'admin1_abbr': {
+                     'query': 'NY',
+                     'boost': 3
+                   }
                  }
                },
                {
                  'match': {
-                   'alpha3': 'USA'
+                   'alpha3': {
+                     'query': 'USA',
+                     'boost': 5
+                   }
+                 }
+               },
+               {
+                 match: {
+                   admin0: 'new york'
+                 }
+               },
+               {
+                 match: {
+                   admin1: 'new york'
+                 }
+               },
+               {
+                 match: {
+                   admin2: 'new york'
+                 }
+               },
+               {
+                 match: {
+                   local_admin: 'new york'
+                 }
+               },
+               {
+                 match: {
+                   locality: 'new york'
+                 }
+               },
+               {
+                 match: {
+                   neighborhood: 'new york'
                  }
                },
                {
@@ -416,7 +461,7 @@ module.exports.tests.query = function(test, common) {
              'should': [
                {
                  'match': {
-                   'admin2': 'new york'
+                   'admin0': 'new york'
                  }
                },
                {
@@ -431,12 +476,22 @@ module.exports.tests.query = function(test, common) {
                },
                {
                  'match': {
-                   'admin0': 'new york'
+                   'admin2': 'new york'
                  }
                },
                {
                  'match': {
-                   'alpha3': 'new york'
+                   'local_admin': 'new york'
+                 }
+               },
+               {
+                 'match': {
+                   'locality': 'new york'
+                 }
+               },
+               {
+                 'match': {
+                   'neighborhood': 'new york'
                  }
                },
                {
@@ -501,7 +556,8 @@ module.exports.tests.query = function(test, common) {
              'category_weights': {
                'transport:air': 2,
                'transport:air:aerodrome': 2,
-               'transport:air:airport': 2
+               'transport:air:airport': 2,
+               'admin': 2
              }
            },
            'file': 'category',
@@ -534,10 +590,189 @@ module.exports.tests.query = function(test, common) {
      ],
      'track_scores': true
     };
-    
+
     t.deepEqual(query, expected, 'valid search query');
     t.end();
   });
+
+  test('valid query with regions in address', function(t) {
+    var partial_address = '1 water st manhattan ny';
+    var query = generate({ input: partial_address,
+      layers: [ 'geoname', 'osmnode', 'osmway', 'admin0', 'admin1', 'admin2', 'neighborhood',
+        'locality', 'local_admin', 'osmaddress', 'openaddresses' ],
+      size: 10,
+      details: true,
+      parsed_input: parser(partial_address),
+      default_layers_set: true
+    });
+
+    var expected = {
+      'query': {
+        'filtered': {
+          'query': {
+            'bool': {
+              'must': [
+                {
+                  'match': {
+                    'name.default': '1 water st'
+                  }
+                }
+              ],
+              'should': [
+                {
+                  match: {
+                    'address.number': {
+                      'query': 1,
+                      'boost': 1
+                    }
+                  }
+                },
+                {
+                  match: {
+                    'address.street': {
+                      'query': 'water st',
+                      'boost': 3
+                    }
+                  }
+                },
+                {
+                  'match': {
+                    'admin1_abbr': {
+                      'query': 'NY',
+                      'boost': 3
+                    }
+                  }
+                },
+                {
+                  'match': {
+                    'admin0': 'manhattan'
+                  }
+                },
+                {
+                  'match': {
+                    'admin1': 'manhattan'
+                  }
+                },
+                {
+                  'match': {
+                    'admin2': 'manhattan'
+                  }
+                },
+                {
+                  match: {
+                    local_admin: 'manhattan'
+                  }
+                },
+                {
+                  match: {
+                    locality: 'manhattan'
+                  }
+                },
+                {
+                  match: {
+                    neighborhood: 'manhattan'
+                  }
+                },
+                {
+                  'match': {
+                    'phrase.default': '1 water st'
+                  }
+                }
+              ]
+            }
+          },
+          'filter': {
+            'bool': {
+              'must': []
+            }
+          }
+        }
+      },
+      'size': 10,
+      'sort': [
+        '_score',
+        {
+          '_script': {
+            'file': 'admin_boost',
+            'type': 'number',
+            'order': 'desc'
+          }
+        },
+        {
+          '_script': {
+            'file': 'popularity',
+            'type': 'number',
+            'order': 'desc'
+          }
+        },
+        {
+          '_script': {
+            'file': 'population',
+            'type': 'number',
+            'order': 'desc'
+          }
+        },
+        {
+          '_script': {
+            'params': {
+              'weights': {
+                'admin0': 4,
+                'admin1': 3,
+                'admin2': 2,
+                'local_admin': 1,
+                'locality': 1,
+                'neighborhood': 1
+              }
+            },
+            'file': 'weights',
+            'type': 'number',
+            'order': 'desc'
+          }
+        },
+        {
+          '_script': {
+            'params': {
+              'category_weights': {
+                'transport:air': 2,
+                'transport:air:aerodrome': 2,
+                'transport:air:airport': 2
+              }
+            },
+            'file': 'category',
+            'type': 'number',
+            'order': 'desc'
+          }
+        },
+        {
+          '_script': {
+            'params': {
+              'weights': {
+                'geoname': 0,
+                'address': 4,
+                'osmnode': 6,
+                'osmway': 6,
+                'poi-address': 8,
+                'neighborhood': 10,
+                'local_admin': 12,
+                'locality': 12,
+                'admin2': 12,
+                'admin1': 14,
+                'admin0': 2
+              }
+            },
+            'file': 'weights',
+            'type': 'number',
+            'order': 'desc'
+          }
+        }
+      ],
+      'track_scores': true
+    };
+
+    t.deepEqual(query, expected, 'valid search query');
+    t.end();
+  });
+
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/query/sort.js
+++ b/test/unit/query/sort.js
@@ -53,7 +53,7 @@ var expected = [
   {
     '_script': {
       'params': {
-        'category_weights': category_weights
+        'category_weights': category_weights.default
       },
       'file': category,
       'type': 'number',

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -19,7 +19,8 @@ var tests = [
   require('./query/reverse'),
   require('./helper/query_parser'),
   require('./helper/geojsonify'),
-  require('./helper/outputSchema')
+  require('./helper/outputSchema'),
+  require('./helper/adminFields'),
 ];
 
 tests.map(function(t) {


### PR DESCRIPTION
Fixes #187 

* Not all admin fields were being used by the `query builder`. Refactored a bit and added `adminFields.js` where the fields are validated against the current schema.
* Added `admin` to category boosts to help `soho, new york` pass. This should be used in all cases, except when we know the query is an address.
* Added boosting for each address part we've parsed out with certainty. We can play around with the actual boost numbers separately.

