### PR TITLE
Add /status controller

### DIFF
--- a/controller/status.js
+++ b/controller/status.js
@@ -1,0 +1,3 @@
+module.exports = function controller( req, res, next) {
+  res.send('status: ok');
+};

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -19,7 +19,8 @@ var middleware = {
 var controllers     = {
   mdToHTML: require('../controller/markdownToHtml'),
   place: require('../controller/place'),
-  search: require('../controller/search')
+  search: require('../controller/search'),
+  status: require('../controller/status')
 };
 
 /** ----------------------- controllers ----------------------- **/
@@ -82,6 +83,9 @@ function addRoutes(app, peliasConfig) {
       postProc.renamePlacenames(),
       postProc.geocodeJSON(peliasConfig),
       postProc.sendJSON
+    ]),
+    status: createRouter([
+      controllers.status
     ])
   };
 
@@ -96,6 +100,8 @@ function addRoutes(app, peliasConfig) {
   app.get ( base + 'search',       routers.search );
   app.post( base + 'search',       routers.search );
   app.get ( base + 'reverse',      routers.reverse );
+
+  app.get (        '/status',      routers.status );
 }
 
 /**


### PR DESCRIPTION
It's at the root level, and simply returns 200 with 'status: ok' as the
body.

@heffergm, this is intended to fix #231. I'm not completely clear on how all the proxy logic between v1 and legacy work, but let me know if this works. I assume to an outside user of the pelias api, this endpoint ISN'T actually reachable, because any non /v1/ routes would get forwarded to the legacy server, which will not have this /status endpoint. However presumably that's ok.