### PR TITLE
fix CORS support by enabling OPTIONS endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ if( peliasConfig.accessLog ){
 
 app.use( require('./middleware/headers') );
 app.use( require('./middleware/cors') );
+app.use( require('./middleware/options') );
 app.use( require('./middleware/jsonp') );
 
 /** ----------------------- routes ----------------------- **/

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -1,7 +1,7 @@
 
 function middleware(req, res, next){
   res.header('Access-Control-Allow-Origin', '*');
-  res.header('Access-Control-Allow-Methods', 'GET');
+  res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');
   res.header('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
   res.header('Access-Control-Allow-Credentials', true);
   next();

--- a/middleware/options.js
+++ b/middleware/options.js
@@ -1,0 +1,18 @@
+
+/**
+  this functionality is required by CORS as the browser will send an
+  HTTP OPTIONS request before performing the CORS request.
+
+  if the OPTIONS request returns a non-200 status code then the 
+  transaction will fail.
+**/
+
+function middleware(req, res, next){
+  if( req.method === 'OPTIONS' ){
+    res.send(200);
+  } else {
+    next();
+  }
+}
+
+module.exports = middleware;


### PR DESCRIPTION
when updating the [compare app](https://github.com/pelias/compare) today I needed to make these changes to enable [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) support.

@heffergm this CORS thing is a bit funny in that the client issues an http `OPTIONS` request before sending the actual request, presumably in order to sniff out [these headers](https://github.com/pelias/api/blob/master/middleware/cors.js)

this is a little problematic as the route which responds to the `OPTIONS` http verb requires an `api_key` to be set otherwise the load balancer returns `301`.

so in the mean time, so long as we set an api_key on every request then it works fine, otherwise it fails silently (in the browser).

how would you feel about disabling auth for all `OPTIONS` requests? cc/ @baldur @riordan @louh as this is ditto across the board for all our services which support CORS.