### PR TITLE
set response data/meta/body on $res instead of $req

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -17,9 +17,8 @@ function setup( backend ){
       // error handler
       if( err ){ return next( err ); }
 
-      req.results = {
-        data: docs
-      };
+      // set response data
+      res.data = docs;
 
       next();
     });

--- a/controller/search.js
+++ b/controller/search.js
@@ -26,10 +26,9 @@ function setup( backend, query ){
       // error handler
       if( err ){ return next( err ); }
 
-      req.results = {
-        data: docs,
-        meta: meta
-      };
+      // set response data
+      res.data = docs;
+      res.meta = meta;
 
       next();
     });

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -23,17 +23,17 @@ function setup(peliasConfig) {
 
 function computeScores(req, res, next) {
   // do nothing if no result data set
-  if (!req.results || !req.results.data || !req.results.meta) {
+  if (!res || !res.data || !res.meta) {
     return next();
   }
 
   // compute standard deviation and mean from all scores
-  var scores = req.results.meta.scores;
+  var scores = res.meta.scores;
   var stdev = computeStandardDeviation(scores);
   var mean = stats.mean(scores);
 
   // loop through data items and determine confidence scores
-  req.results.data = req.results.data.map(computeConfidenceScore.bind(null, req, mean, stdev));
+  res.data = res.data.map(computeConfidenceScore.bind(null, req, mean, stdev));
 
   next();
 }

--- a/middleware/distance.js
+++ b/middleware/distance.js
@@ -9,7 +9,7 @@ function setup() {
 function computeDistances(req, res, next) {
 
   // do nothing if no result data set
-  if (!req.results || !req.results.data) {
+  if (!res || !res.data) {
     return next();
   }
 
@@ -17,7 +17,7 @@ function computeDistances(req, res, next) {
     return next();
   }
 
-  req.results.data.forEach(function (place) {
+  res.data.forEach(function (place) {
     // the result of getDistance is in meters, so convert to kilometers
     place.distance = geolib.getDistance(
       { latitude: req.clean.lat, longitude: req.clean.lon },

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -6,50 +6,50 @@ function setup(peliasConfig) {
   peliasConfig = peliasConfig || require( 'pelias-config' ).generate().api;
   
   function middleware(req, res, next) {
-    return convertToGeocodeJSON(peliasConfig, req, next);
+    return convertToGeocodeJSON(peliasConfig, req, res, next);
   }
 
   return middleware;
 }
 
-function convertToGeocodeJSON(peliasConfig, req, next) {
+function convertToGeocodeJSON(peliasConfig, req, res, next) {
 
   // do nothing if no result data set
-  if (!req.results || !req.results.data) {
+  if (!res || !res.data) {
     return next();
   }
 
-  req.results.geojson = { geocoding: {} };
+  res.body = { geocoding: {} };
 
   // REQUIRED. A semver.org compliant version number. Describes the version of
   // the GeocodeJSON spec that is implemented by this instance.
-  req.results.geojson.geocoding.version = '0.1';
+  res.body.geocoding.version = '0.1';
 
   // OPTIONAL. Default: null. The attribution of the data. In case of multiple sources,
   // and then multiple attributions, can be an object with one key by source.
   // Can be a URI on the server, which outlines attribution details.
-  req.results.geojson.geocoding.attribution = peliasConfig.host + 'attribution';
+  res.body.geocoding.attribution = peliasConfig.host + 'attribution';
 
   // OPTIONAL. Default: null. The query that has been issued to trigger the
   // search.
   // Freeform object.
   // This is the equivalent of how the engine interpreted the incoming request.
   // Helpful for debugging and understanding how the input impacts results.
-  req.results.geojson.geocoding.query = req.clean;
+  res.body.geocoding.query = req.clean;
 
   // OPTIONAL. Warnings and errors.
-  addMessages(req.results, 'warnings', req.results.geojson.geocoding);
-  addMessages(req.results, 'errors', req.results.geojson.geocoding);
+  addMessages(res, 'warnings', res.body.geocoding);
+  addMessages(res, 'errors', res.body.geocoding);
 
   // OPTIONAL
   // Freeform
-  addEngine(peliasConfig, req.results.geojson.geocoding);
+  addEngine(peliasConfig, res.body.geocoding);
 
   // response envelope
-  req.results.geojson.geocoding.timestamp = new Date().getTime();
+  res.body.geocoding.timestamp = new Date().getTime();
 
   // convert docs to geojson and merge with geocoding block
-  extend(req.results.geojson, geojsonify(req.results.data));
+  extend(res.body, geojsonify(res.data));
 
   next();
 }

--- a/middleware/renamePlacenames.js
+++ b/middleware/renamePlacenames.js
@@ -32,12 +32,12 @@ function setup() {
 function renamePlacenames(req, res, next) {
 
   // do nothing if no result data set
-  if (!req.results || !req.results.data) {
+  if (!res || !res.data) {
     return next();
   }
 
   // loop through data items and remap placenames
-  req.results.data = req.results.data.map(renameProperties);
+  res.data = res.data.map(renameProperties);
 
   next();
 }

--- a/middleware/sendJSON.js
+++ b/middleware/sendJSON.js
@@ -1,12 +1,12 @@
 function sendJSONResponse(req, res, next) {
 
   // do nothing if no result data set
-  if (!req.results || !req.results.geojson) {
+  if (!res || !res.body) {
     return next();
   }
 
   // respond
-  return res.status(200).json(req.results.geojson);
+  return res.status(200).json(res.body);
 }
 
 module.exports = sendJSONResponse;

--- a/test/unit/middleware/distance.js
+++ b/test/unit/middleware/distance.js
@@ -8,22 +8,22 @@ module.exports.tests.computeDistance = function(test, common) {
       clean: {
         lat: 45,
         lon: -77
-      },
-      results: {
-        data: [
-          {
-            center_point: {
-              lat: 40,
-              lon: -71
-            }
-          }
-        ]
       }
+    };
+    var res = {
+      data: [
+        {
+          center_point: {
+            lat: 40,
+            lon: -71
+          }
+        }
+      ]
     };
 
     var expected = 742.348;
-    distance(req, null, function () {
-      t.equal(req.results.data[0].distance, expected, 'correct distance computed');
+    distance(req, res, function () {
+      t.equal(res.data[0].distance, expected, 'correct distance computed');
       t.end();
     });
   });


### PR DESCRIPTION
this PR just renames/rescopes a few variables for clarity:

- `req.results.*` are now set directly on the response object `res`
 - `req.results.data` -> `res.data`
 - `req.results.meta` -> `res.meta`
 - `req.results.geojson` -> `res.body`