### PR TITLE
expose error messages in geojson

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -1,10 +1,18 @@
 var service = { mget: require('../service/mget') };
 
 function setup( backend ){
+
   // allow overriding of dependencies
   backend = backend || require('../src/backend');
 
   function controller( req, res, next ){
+
+    // do not run controller when a request
+    // validation error has occurred.
+    if( req.errors && req.errors.length ){
+      return next();
+    }
+
     var query = req.clean.ids.map( function(id) {
       return {
         _index: 'pelias',

--- a/controller/search.js
+++ b/controller/search.js
@@ -8,6 +8,12 @@ function setup( backend, query ){
 
   function controller( req, res, next ){
 
+    // do not run controller when a request
+    // validation error has occurred.
+    if( req.errors && req.errors.length ){
+      return next();
+    }
+
     // backend command
     var cmd = {
       index: 'pelias',

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -14,11 +14,6 @@ function setup(peliasConfig) {
 
 function convertToGeocodeJSON(peliasConfig, req, res, next) {
 
-  // do nothing if no result data set
-  if (!res || !res.data) {
-    return next();
-  }
-
   res.body = { geocoding: {} };
 
   // REQUIRED. A semver.org compliant version number. Describes the version of
@@ -38,8 +33,8 @@ function convertToGeocodeJSON(peliasConfig, req, res, next) {
   res.body.geocoding.query = req.clean;
 
   // OPTIONAL. Warnings and errors.
-  addMessages(res, 'warnings', res.body.geocoding);
-  addMessages(res, 'errors', res.body.geocoding);
+  addMessages(req, 'warnings', res.body.geocoding);
+  addMessages(req, 'errors', res.body.geocoding);
 
   // OPTIONAL
   // Freeform
@@ -49,15 +44,14 @@ function convertToGeocodeJSON(peliasConfig, req, res, next) {
   res.body.geocoding.timestamp = new Date().getTime();
 
   // convert docs to geojson and merge with geocoding block
-  extend(res.body, geojsonify(res.data));
+  extend(res.body, geojsonify(res.data || []));
 
   next();
 }
 
-function addMessages(results, msgType, geocoding) {
-  if (results.hasOwnProperty(msgType)) {
-    geocoding.messages = geocoding.messages || {};
-    geocoding.messages[msgType] = results[msgType];
+function addMessages(req, msgType, geocoding) {
+  if (req.hasOwnProperty(msgType) && req[msgType].length) {
+    geocoding[msgType] = req[msgType];
   }
 }
 

--- a/sanitiser/_geo_reverse.js
+++ b/sanitiser/_geo_reverse.js
@@ -14,6 +14,13 @@ module.exports = function sanitize( raw, clean ){
     geo_common.sanitize_coord( 'lat', clean, raw['point.lat'], LAT_LON_IS_REQUIRED );
     geo_common.sanitize_coord( 'lon', clean, raw['point.lon'], LAT_LON_IS_REQUIRED );
 
+    // remove both if only one is set
+    // @todo: clean this up!
+    if( !clean.hasOwnProperty('lat') || !clean.hasOwnProperty('lon') ){
+      delete clean.lat;
+      delete clean.lon;
+    }
+
     // boundary.circle.* is not mandatory, and only specifying radius is fine,
     // as point.lat/lon will be used to fill those values by default
     geo_common.sanitize_boundary_circle( clean, raw, CIRCLE_IS_REQUIRED, CIRCLE_MUST_BE_COMPLETE);

--- a/sanitiser/_id.js
+++ b/sanitiser/_id.js
@@ -18,8 +18,18 @@ function sanitize( raw, clean ){
   // error & warning messages
   var messages = { errors: [], warnings: [] };
 
-  // 'raw.id' can be an array!?
-  var rawIds = check.array( raw.id ) ? _.unique( raw.id ) : [ raw.id ];
+  // 'raw.id' can be an array
+  var rawIds = check.array( raw.id ) ? _.unique( raw.id ) : [];
+
+  // 'raw.id' can be a string
+  if( check.unemptyString( raw.id ) ){
+    rawIds.push( raw.id );
+  }
+
+  // no ids provided
+  if( !rawIds.length ){
+    messages.errors.push( errorMessage('id') );
+  }
 
   // ensure all elements are valid non-empty strings
   rawIds = rawIds.filter( function( uc ){
@@ -48,25 +58,27 @@ function sanitize( raw, clean ){
     }
 
     // id text
-    if( !check.unemptyString( id ) ){
+    else if( !check.unemptyString( id ) ){
       messages.errors.push( errorMessage( rawId ) );
     }
     // type text
-    if( !check.unemptyString( type ) ){
+    else if( !check.unemptyString( type ) ){
       messages.errors.push( errorMessage( rawId ) );
     }
     // type text must be one of the types
-    if( !_.contains( types, type ) ){
+    else if( !_.contains( types, type ) ){
       messages.errors.push(
         errorMessage('type', type + ' is invalid. It must be one of these values - [' + types.join(', ') + ']')
       );
     }
-
     // add valid id to 'clean.ids' array
-    clean.ids.push({
-      id: id,
-      type: type
-    });
+    else {
+      clean.ids.push({
+        id: id,
+        type: type
+      });
+    }
+
   });
 
   return messages;

--- a/sanitiser/place.js
+++ b/sanitiser/place.js
@@ -14,10 +14,6 @@ module.exports.sanitiser_list = sanitizers;
 // middleware
 module.exports.middleware = function( req, res, next ){
   sanitize( req, function( err, clean ){
-    if( err ){
-      res.status(400); // 400 Bad Request
-      return next(err);
-    }
     next();
   });
 };

--- a/sanitiser/reverse.js
+++ b/sanitiser/reverse.js
@@ -19,10 +19,6 @@ module.exports.sanitiser_list = sanitizers;
 // middleware
 module.exports.middleware = function( req, res, next ){
   sanitize( req, function( err, clean ){
-    if( err ){
-      res.status(400); // 400 Bad Request
-      return next(err);
-    }
     next();
   });
 };

--- a/sanitiser/sanitizeAll.js
+++ b/sanitiser/sanitizeAll.js
@@ -1,9 +1,15 @@
 
+var check = require('check-types');
+
 function sanitize( req, sanitizers, cb ){
 
   // init an object to store clean
   // (sanitized) input parameters
   req.clean = {};
+
+  // init erros and warnings arrays
+  req.errors = [];
+  req.warnings = [];
 
   // source of input parameters
   // (in this case from the GET querystring params)
@@ -12,14 +18,21 @@ function sanitize( req, sanitizers, cb ){
   for (var s in sanitizers) {
     var sanity = sanitizers[s]( params, req.clean );
 
-    // errors
+    // if errors occurred then set them
+    // on the req object.
     if( sanity.errors.length ){
-      return cb( sanity.errors[0] );
+      req.errors = req.errors.concat( sanity.errors );
+    }
+
+    // if warnings occurred then set them
+    // on the req object.
+    if( sanity.warnings.length ){
+      req.warnings = req.warnings.concat( sanity.warnings );
     }
   }
-  
-  return cb( undefined, req.clean );
 
+  // @todo remove these args, they do not need to be passed out
+  return cb( undefined, req.clean );
 }
 
 // export function

--- a/sanitiser/search.js
+++ b/sanitiser/search.js
@@ -20,10 +20,6 @@ module.exports.sanitiser_list = sanitizers;
 // middleware
 module.exports.middleware = function( req, res, next ){
   sanitize( req, function( err, clean ){
-    if( err ){
-      res.status(400); // 400 Bad Request
-      return next(err);
-    }
     next();
   });
 };


### PR DESCRIPTION
this PR refactors the handling of request `errors` and `warnings` so that:

- there are arrays `req.errors` and `req.warnings` which any middleware can push to
- sanitizers push messages to these arrays
- controllers do not execute when a request errors occur
- we no longer `next(err)` as we want to always reply with geoJSON
- the errors and warnings are exposed to the user in the geoJSON response

note: if `req.errors.length > 1` then controllers will not execute and the db will not be queried