### PR TITLE
Remove warning when no size param specified

### DIFF
--- a/sanitiser/_size.js
+++ b/sanitiser/_size.js
@@ -1,3 +1,4 @@
+var check = require('check-types');
 
 var MIN_SIZE = 1,
     MAX_SIZE = 40,
@@ -10,35 +11,22 @@ function sanitize( raw, clean ){
   var messages = { errors: [], warnings: [] };
 
   // coercions
-  var _size = parseInt( raw.size, 10 );
+  clean.size = parseInt( raw.size, 10 );
 
   // invalid numeric input
-  // @todo: this can be removed now as queries have default sizes?
-  if( isNaN( _size ) ){
-
-    // set the default size
-    messages.warnings.push('invalid integer \'size\', using DEFAULT_SIZE');
+  if( isNaN( clean.size ) ){
     clean.size = DEFAULT_SIZE;
   }
-  // valid numeric input
-  else {
-
-    // ensure size falls within defined range
-    if( _size > MAX_SIZE ){
-      // set the max size
-      messages.warnings.push('out-of-range integer \'size\', using MAX_SIZE');
-      clean.size = MAX_SIZE;
-    }
-    else if( _size < MIN_SIZE ){
-      // set the min size
-      messages.warnings.push('out-of-range integer \'size\', using MIN_SIZE');
-      clean.size = MIN_SIZE;
-    }
-    else {
-      // set the input size
-      clean.size = _size;
-    }
-
+  // ensure size falls within defined range
+  else if( clean.size > MAX_SIZE ){
+    // set the max size
+    messages.warnings.push('out-of-range integer \'size\', using MAX_SIZE');
+    clean.size = MAX_SIZE;
+  }
+  else if( clean.size < MIN_SIZE ){
+    // set the min size
+    messages.warnings.push('out-of-range integer \'size\', using MIN_SIZE');
+    clean.size = MIN_SIZE;
   }
 
   return messages;

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -27,6 +27,7 @@ var tests = [
   require('./helper/types'),
   require('./sanitiser/_geo_common'),
   require('./middleware/distance'),
+  require('./sanitiser/_size'),
 ];
 
 tests.map(function(t) {

--- a/test/unit/sanitiser/_size.js
+++ b/test/unit/sanitiser/_size.js
@@ -1,0 +1,61 @@
+var sanitize = require('../../../sanitiser/_size');
+
+module.exports.tests = {};
+
+module.exports.tests.sanitize_size = function(test, common) {
+  test('size=0', function(t) {
+    var raw = { size: 0 };
+    var clean = {};
+    var res = sanitize(raw, clean);
+    t.equal(res.errors.length, 0, 'should return no errors');
+    t.equal(res.warnings.length, 1, 'should return warning');
+    t.equal(res.warnings[0], 'out-of-range integer \'size\', using MIN_SIZE', 'check warning text');
+    t.equal(clean.size, 1, 'default to 1');
+    t.end();
+  });
+
+  test('size=10000', function(t) {
+    var raw = { size: 10000 };
+    var clean = {};
+    var res = sanitize(raw, clean);
+    t.equal(res.errors.length, 0, 'should return no errors');
+    t.equal(res.warnings.length, 1, 'should return warning');
+    t.equal(res.warnings[0], 'out-of-range integer \'size\', using MAX_SIZE', 'check warning text');
+    t.equal(clean.size, 40, 'default to 40');
+    t.end();
+  });
+
+  test('size not set', function(t) {
+    var raw = {};
+    var clean = {};
+    var res = sanitize(raw, clean);
+    t.equal(res.errors.length, 0, 'should return no errors');
+    t.equal(res.warnings.length, 0, 'should return no warning');
+    t.equal(clean.size, 10, 'default to 10');
+    t.end();
+  });
+
+
+  var valid_sizes = [5, '5', 5.5, '5.5'];
+  valid_sizes.forEach(function (size) {
+    test('size=' + size, function (t) {
+      var raw = {size: size};
+      var clean = {};
+      var res = sanitize(raw, clean);
+      t.equal(res.errors.length, 0, 'should return no errors');
+      t.equal(res.warnings.length, 0, 'should return warning');
+      t.equal(clean.size, 5, 'set to correct integer');
+      t.end();
+    });
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('SANTIZE _size ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};


### PR DESCRIPTION
Originally intended to remove an unwanted warning when size param was not being specified in the query. Ended up adding tests for _size sanitizer while in there. Also looks like the warning about size being out of range were already in place.

Fixes #236 