### PR TITLE
Construct gids for reponses and remove id

### DIFF
--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -179,13 +179,13 @@ function copyProperties( source, props, dst ) {
 }
 
 /**
- * Determine and set place id, type, and source
+ * Determine and set place gid, type, and source
  *
  * @param {object} src
  * @param {object} dst
  */
 function addMetaData(src, dst) {
-  dst.id = src._id;
+  dst.gid = src._type + ':' + src._id;
   dst.layer = lookupLayer(src);
   dst.source = lookupSource(src);
 }

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -140,7 +140,7 @@ module.exports.tests.search = function(test, common) {
           ]
         },
         'properties': {
-          'id': 'id1',
+          'gid': 'type1:id1',
           'layer': 'type1',
           'source': 'type1',
           'label': '\'Round Midnight Jazz and Blues Bar, test3, Angel',
@@ -169,7 +169,7 @@ module.exports.tests.search = function(test, common) {
           ]
         },
         'properties': {
-          'id': 'id2',
+          'gid': 'type2:id2',
           'layer': 'type2',
           'source': 'type2',
           'label': 'Blues Cafe, test3, Smithfield',
@@ -194,7 +194,7 @@ module.exports.tests.search = function(test, common) {
           ]
         },
         'properties': {
-          'id': '34633854',
+          'gid': 'osmway:34633854',
           'layer': 'venue',
           'source': 'osm',
           'label': 'Empire State Building, Manhattan, NY',


### PR DESCRIPTION
This is a simple change to fix #238

Mostly it creates gids as one might expect, for example with osm they
look like

    osmway:23458099
    osmnode:21269005

Or for openaddresses

    openaddresses:3028382
    openaddresses:3028381

Similarly geonames

    geoname:4930956

Quattroshapes though, is a little weird, but these gids do all work, you
can plug them into /place?ids= just fine

    locality:7693:locality:us:usa:boston