### PR TITLE
Lock down the pelias-query version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pelias-config": "^1.0.1",
     "pelias-esclient": "0.0.25",
     "pelias-logger": "^0.0.8",
-    "pelias-query": "^1.5.0",
+    "pelias-query": "1.5.0",
     "pelias-schema": "1.0.0",
     "pelias-suggester-pipeline": "2.0.2",
     "stats-lite": "^1.0.3",


### PR DESCRIPTION
Allowing for even the smallest changes to pelias-query is problematic.