### PR TITLE
[on hold] add locality to the list of types which are boosted

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -14,7 +14,7 @@ query.score( peliasQuery.view.ngrams, 'must' );
 // scoring boost
 query.score( peliasQuery.view.phrase );
 query.score( peliasQuery.view.focus( peliasQuery.view.ngrams ) );
-query.score( peliasQuery.view.popularity(['admin0','admin1','admin2']) );
+query.score( peliasQuery.view.popularity(['admin0','admin1','admin2','locality']) );
 
 // --------------------------------
 

--- a/query/search.js
+++ b/query/search.js
@@ -15,7 +15,7 @@ query.score( peliasQuery.view.ngrams, 'must' );
 // scoring boost
 query.score( peliasQuery.view.phrase );
 query.score( peliasQuery.view.focus( peliasQuery.view.phrase ) );
-query.score( peliasQuery.view.popularity(['admin0','admin1','admin2']) );
+query.score( peliasQuery.view.popularity(['admin0','admin1','admin2','locality']) );
 
 // address components
 query.score( peliasQuery.view.address('housenumber') );

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -81,6 +81,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -81,6 +81,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -54,6 +54,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -64,6 +64,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_full_address.js
+++ b/test/unit/fixture/search_full_address.js
@@ -57,6 +57,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -54,6 +54,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -83,6 +83,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -83,6 +83,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -83,6 +83,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -54,6 +54,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_partial_address.js
+++ b/test/unit/fixture/search_partial_address.js
@@ -57,6 +57,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },

--- a/test/unit/fixture/search_regions_address.js
+++ b/test/unit/fixture/search_regions_address.js
@@ -57,6 +57,11 @@ module.exports = {
                     'type': {
                       'value': 'admin2'
                     }
+                  },
+                  {
+                    'type': {
+                      'value': 'locality'
+                    }
                   }
                 ]
               },


### PR DESCRIPTION
**[on hold] until the release is out of the way**

add `locality` to the list of types which are boosted by the sqrt(popularity) view

this simple change would allow `locality` records to get the same `sqrt(popularity)` boost that we give to `admin0` `admin1` and `admin2`

the motivation for this was to try and get better discoverability for `san francisco` (the city in California, USA), which is actually quite hard to surface due to being composed of very common search tokens in Spanish speaking areas.

will need some testing before a release, I did a check against the live database and found only `8482` `locality` records with `popularity` greater than 0, so it shouldn't have much (if any) negative effect

[edit] see testing notes below

cc/ @riordan 