### PR TITLE
removed redundant is-ids-an-array check 

### DIFF
--- a/sanitiser/_ids.js
+++ b/sanitiser/_ids.js
@@ -57,13 +57,6 @@ function sanitize( raw, clean ){
   // error & warning messages
   var messages = { errors: [], warnings: [] };
 
-  // 'raw.ids' can be an array if ids is specified multiple times
-  // see https://github.com/pelias/api/issues/272
-  if (check.array( raw.ids )) {
-    messages.errors.push( '`ids` parameter specified multiple times.' );
-    return messages;
-  }
-
   if (!check.unemptyString( raw.ids )) {
     messages.errors.push( lengthError);
     return messages;

--- a/test/unit/sanitiser/_ids.js
+++ b/test/unit/sanitiser/_ids.js
@@ -126,20 +126,6 @@ module.exports.tests.valid_ids = function(test, common) {
   });
 };
 
-module.exports.tests.array_of_ids = function(test, common) {
-  // see https://github.com/pelias/api/issues/272
-  test('array of ids sent by queryparser', function(t) {
-    var raw = { ids: ['geoname:2', 'oswmay:4'] };
-    var clean = {};
-
-    var messages = sanitize( raw, clean);
-
-    t.deepEqual( messages.errors, ['`ids` parameter specified multiple times.'], 'error sent' );
-    t.deepEqual( clean.ids, undefined, 'response is empty due to error' );
-    t.end();
-  });
-};
-
 module.exports.tests.multiple_ids = function(test, common) {
   test('multiple ids', function(t) {
     var raw = { ids: 'geonames:venue:1,osm:venue:2' };


### PR DESCRIPTION
it's already covered by _single_scalar_parameter sanitizer