### PR TITLE
Remove the geoname _type from all layers except venue

### DIFF
--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -48,13 +48,13 @@ var SOURCE_TO_TYPE = {
  */
 var LAYER_TO_TYPE = {
   'venue': ['geoname','osmnode','osmway'],
-  'address': ['osmaddress','openaddresses', 'geoname'],
-  'country': ['admin0', 'geoname'],
-  'region': ['admin1', 'geoname'],
-  'county': ['admin2', 'geoname'],
-  'locality': ['locality', 'geoname'],
+  'address': ['osmaddress','openaddresses'],
+  'country': ['admin0'],
+  'region': ['admin1'],
+  'county': ['admin2'],
+  'locality': ['locality'],
   'localadmin': ['local_admin'],
-  'neighbourhood': ['neighborhood', 'geoname']
+  'neighbourhood': ['neighborhood']
 };
 
 var LAYER_ALIASES = {

--- a/test/ciao/reverse/layers_multiple.coffee
+++ b/test/ciao/reverse/layers_multiple.coffee
@@ -30,5 +30,5 @@ should.not.exist json.geocoding.warnings
 
 #? inputs
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["admin0","geoname","admin1"]
-json.geocoding.query['type'].should.eql ["admin0","geoname","admin1"]
+json.geocoding.query.types['from_layers'].should.eql ["admin0","admin1"]
+json.geocoding.query['type'].should.eql ["admin0","admin1"]

--- a/test/ciao/reverse/layers_single.coffee
+++ b/test/ciao/reverse/layers_single.coffee
@@ -30,5 +30,5 @@ should.not.exist json.geocoding.warnings
 
 #? inputs
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["admin0","geoname"]
-json.geocoding.query['type'].should.eql ["admin0","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["admin0"]
+json.geocoding.query['type'].should.eql ["admin0"]

--- a/test/ciao/reverse/sources_layers_invalid_combo.coffee
+++ b/test/ciao/reverse/sources_layers_invalid_combo.coffee
@@ -31,6 +31,6 @@ should.not.exist json.geocoding.warnings
 
 #? inputs
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses"]
 json.geocoding.query.types['from_sources'].should.eql ["admin0","admin1","admin2","neighborhood","locality","local_admin"]
 should.not.exist json.geocoding.query['type']

--- a/test/ciao/reverse/sources_layers_valid_combo.coffee
+++ b/test/ciao/reverse/sources_layers_valid_combo.coffee
@@ -30,5 +30,5 @@ should.not.exist json.geocoding.warnings
 
 #? inputs
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses"]
 json.geocoding.query['type'].should.eql ["openaddresses"]

--- a/test/ciao/search/layers_alias_address.coffee
+++ b/test/ciao/search/layers_alias_address.coffee
@@ -31,5 +31,5 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses","geoname"]
-json.geocoding.query['type'].should.eql ["osmaddress","openaddresses","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses"]
+json.geocoding.query['type'].should.eql ["osmaddress","openaddresses"]

--- a/test/ciao/search/layers_multiple.coffee
+++ b/test/ciao/search/layers_multiple.coffee
@@ -31,5 +31,5 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["admin0","geoname","admin1"]
-json.geocoding.query['type'].should.eql ["admin0","geoname","admin1"]
+json.geocoding.query.types['from_layers'].should.eql ["admin0","admin1"]
+json.geocoding.query['type'].should.eql ["admin0","admin1"]

--- a/test/ciao/search/layers_single.coffee
+++ b/test/ciao/search/layers_single.coffee
@@ -31,5 +31,5 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["admin0","geoname"]
-json.geocoding.query['type'].should.eql ["admin0","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["admin0"]
+json.geocoding.query['type'].should.eql ["admin0"]

--- a/test/ciao/search/sources_layers_invalid_combo.coffee
+++ b/test/ciao/search/sources_layers_invalid_combo.coffee
@@ -32,6 +32,6 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses"]
 json.geocoding.query.types['from_sources'].should.eql ["admin0","admin1","admin2","neighborhood","locality","local_admin"]
 should.not.exist json.geocoding.query['type']

--- a/test/ciao/search/sources_layers_valid_combo.coffee
+++ b/test/ciao/search/sources_layers_valid_combo.coffee
@@ -31,5 +31,5 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses","geoname"]
+json.geocoding.query.types['from_layers'].should.eql ["osmaddress","openaddresses"]
 json.geocoding.query['type'].should.eql ["openaddresses"]

--- a/test/unit/sanitiser/_layers.js
+++ b/test/unit/sanitiser/_layers.js
@@ -43,7 +43,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
     t.end();
   });
   test('address (alias) layer', function(t) {
-    var address_layers = ['osmaddress','openaddresses','geoname'];
+    var address_layers = ['osmaddress','openaddresses'];
     var raw = { layers: 'address' };
     var clean = {};
 
@@ -76,7 +76,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
     t.end();
   });
   test('address alias layer plus regular layers', function(t) {
-    var address_layers = ['osmaddress','openaddresses','geoname'];
+    var address_layers = ['osmaddress','openaddresses'];
     var reg_layers   = ['admin0', 'locality'];
 
     var raw = { layers: 'address,country,locality' };


### PR DESCRIPTION
We can't distinguish between geonames of different layers due to an
ambiguity in our Elasticsearch schema that we unfortunately won't be
able to fix for a few weeks.

So, while it's technically true that there are countries, cities, etc
contained in the geonames dataset, it's still better for now to remove
geonames from these layers. We have good coverage of most coarse layers
from quattroshapes alone, so the impact isn't too bad.

Fixes #315 