### PR TITLE
remove microtime module

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "iso3166-1": "^0.2.3",
     "lodash": "^3.10.1",
     "markdown": "0.5.0",
-    "microtime": "1.4.0",
     "morgan": "1.5.2",
     "pelias-config": "^1.0.1",
     "pelias-esclient": "0.0.25",

--- a/service/mget.js
+++ b/service/mget.js
@@ -12,7 +12,6 @@
 **/
 
 var peliasLogger = require( 'pelias-logger' ).get( 'service/mget' );
-var microtime = require( 'microtime' );
 
 function service( backend, query, cb ){
 
@@ -22,11 +21,9 @@ function service( backend, query, cb ){
       docs: query
     }
   };
-  
-  var startTime = microtime.nowDouble();
+
   // query new backend
   backend().client.mget( cmd, function( err, data ){
-    peliasLogger.verbose( 'time elasticsearch query took:', microtime.nowDouble() - startTime );
 
     // handle backend errors
     if( err ){ return cb( err ); }
@@ -39,7 +36,7 @@ function service( backend, query, cb ){
 
         // remove docs not actually found
         return doc.found;
-      
+
       }).map( function( doc ){
 
         // map metadata in to _source so we

--- a/service/search.js
+++ b/service/search.js
@@ -6,14 +6,11 @@
 **/
 
 var peliasLogger = require( 'pelias-logger' ).get( 'service/search' );
-var microtime = require( 'microtime' );
 
 function service( backend, cmd, cb ){
-  
-  var startTime = microtime.nowDouble();
+
   // query new backend
   backend().client.search( cmd, function( err, data ){
-    peliasLogger.verbose( 'time elasticsearch query took:', microtime.nowDouble() - startTime );
 
     // handle backend errors
     if( err ){ return cb( err ); }


### PR DESCRIPTION
remove `microtime` module:

- frequently fails to compile with message `Error: Module did not self-register.` reported by @heffergm 
- only emits output to stdout
- adds latency to the request
- this sort of microbenchmarking is not particularly useful
- we still report this: https://github.com/pelias/api/blob/remove_microtime/service/search.js#L18-L19