### PR TITLE
support node v4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "markdown": "0.5.0",
     "morgan": "1.5.2",
     "pelias-config": "^1.0.1",
-    "pelias-esclient": "0.0.25",
+    "pelias-esclient": "^1.0.0",
     "pelias-logger": "^0.0.8",
     "pelias-query": "2.0.0",
     "pelias-schema": "1.0.0",


### PR DESCRIPTION
[do not merge] on hold till after the dust settles from the imminent v1 release.

this PR allows all the code to run on the latest **stable** version of nodejs `4.0`