### PR TITLE
Add link to GitHub documentation on /v1/ "landing page"

### DIFF
--- a/public/apiDoc.md
+++ b/public/apiDoc.md
@@ -1,1 +1,1 @@
-## DETAILED DOCUMENTATION COMING SOON!
+## [View our documentation on GitHub](https://github.com/pelias/pelias-doc/blob/master/index.md)


### PR DESCRIPTION
Fixes #234 