### PR TITLE
Fix low hanging fruit in ciao tests

### DIFF
--- a/test/ciao/autocomplete/focus_point_missing_lat.coffee
+++ b/test/ciao/autocomplete/focus_point_missing_lat.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing point param \'focus.point\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters focus.point.lat and focus.point.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/autocomplete/focus_point_missing_lon.coffee
+++ b/test/ciao/autocomplete/focus_point_missing_lon.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing point param \'focus.point\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters focus.point.lat and focus.point.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/point_missing_lat.coffee
+++ b/test/ciao/reverse/point_missing_lat.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing point param \'point\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters point.lat and point.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/point_missing_lon.coffee
+++ b/test/ciao/reverse/point_missing_lon.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing point param \'point\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters point.lat and point.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/sources_multiple.coffee
+++ b/test/ciao/reverse/sources_multiple.coffee
@@ -31,4 +31,4 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.types['from_sources'].should.eql ["osmaddress","osmnode","osmway","geoname"]
-json.geocoding.query['type'].should.eql ["osmaddress","osmnode","osmway","geoname"]
+json.geocoding.query['type'].should.eql ["geoname","osmnode","osmway","osmaddress"]

--- a/test/ciao/reverse/sources_single.coffee
+++ b/test/ciao/reverse/sources_single.coffee
@@ -31,4 +31,4 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.types['from_sources'].should.eql ["osmaddress","osmnode","osmway"]
-json.geocoding.query['type'].should.eql ["osmaddress","osmnode","osmway"]
+json.geocoding.query['type'].should.eql ["osmnode","osmway","osmaddress"]

--- a/test/ciao/search/boundary_circle_missing_lat.coffee
+++ b/test/ciao/search/boundary_circle_missing_lat.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing circle param \'boundary.circle\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters boundary.circle.lat and boundary.circle.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/boundary_circle_missing_lon.coffee
+++ b/test/ciao/search/boundary_circle_missing_lon.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing circle param \'boundary.circle\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters boundary.circle.lat and boundary.circle.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/boundary_rect_partially_specified.coffee
+++ b/test/ciao/search/boundary_rect_partially_specified.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing rect param \'boundary.rect\' requires all of: \'min_lat\',\'max_lat\',\'min_lon\',\'max_lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters boundary.rect.min_lat, boundary.rect.max_lat, boundary.rect.min_lon and boundary.rect.max_lon must all be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/focus_point_missing_lat.coffee
+++ b/test/ciao/search/focus_point_missing_lat.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing point param \'focus.point\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters focus.point.lat and focus.point.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/focus_point_missing_lon.coffee
+++ b/test/ciao/search/focus_point_missing_lon.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ 'missing point param \'focus.point\' requires all of: \'lat\',\'lon\' to be present' ]
+json.geocoding.errors.should.eql [ 'parameters focus.point.lat and focus.point.lon must both be specified' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/sources_multiple.coffee
+++ b/test/ciao/search/sources_multiple.coffee
@@ -32,4 +32,4 @@ should.not.exist json.geocoding.warnings
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.types['from_sources'].should.eql ["osmaddress","osmnode","osmway","geoname"]
-json.geocoding.query['type'].should.eql ["osmaddress","osmnode","osmway","geoname"]
+json.geocoding.query['type'].should.eql ["geoname","osmnode","osmway","osmaddress"]

--- a/test/ciao/search/sources_single.coffee
+++ b/test/ciao/search/sources_single.coffee
@@ -32,4 +32,4 @@ should.not.exist json.geocoding.warnings
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.types['from_sources'].should.eql ["osmaddress","osmnode","osmway"]
-json.geocoding.query['type'].should.eql ["osmaddress","osmnode","osmway"]
+json.geocoding.query['type'].should.eql ["osmnode","osmway","osmaddress"]


### PR DESCRIPTION
Quite a few of our tests simply had old error messages as expectations,
or expected output in an array that was correct but in the wrong order.
Those are all fixed.