### PR TITLE
Use tap-dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "npm run unit",
-    "unit": "node test/unit/run.js | tap-spec",
+    "unit": "node test/unit/run.js | tap-dot",
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "nsp": "^0.3.0",
     "precommit-hook": "^1.0.7",
     "proxyquire": "^1.4.0",
-    "tap-spec": "^0.2.0",
+    "tap-dot": "^1.0.0",
     "tape": "^2.13.4"
   }
 }


### PR DESCRIPTION
[tap-dot](https://www.npmjs.com/package/tap-dot) is a TAP(test anything protocol) formatter. It's quite a bit less verbose than what we're using now, [tap-spec](https://github.com/scottcorgan/tap-spec). It only includes dots for test output, with the exception of failures, where it shows at least as good of a diff of what was seen vs expected as tap-spec.

Please try out this branch, run the tests, and make a few fail, to see how it feels. One thing I noticed is we may want to turn off logging output when running tests. Does anyone know how to do that?

This means we don't have to scroll up endlessly or comment out tests to see just failures, and closes #343 