### PR TITLE
german street/number naming convention

### DIFF
--- a/middleware/localNamingConventions.js
+++ b/middleware/localNamingConventions.js
@@ -1,0 +1,39 @@
+
+function setup() {
+  return applyLocalNamingConventions;
+}
+
+function applyLocalNamingConventions(req, res, next) {
+
+  // do nothing if no result data set
+  if (!res || !res.data) {
+    return next();
+  }
+
+  // loop through data items and flip relevant number/street
+  res.data.filter(function(place){
+    // only relevant for German addresses
+    if( 'DEU' !== place.alpha3 ){ return false; }
+    if( !place.hasOwnProperty('address') ){ return false; }
+    if( !place.address.hasOwnProperty('number') ){ return false; }
+    if( !place.address.hasOwnProperty('street') ){ return false; }
+    return true;
+  })
+  .forEach( flipNumberAndStreet );
+
+  next();
+}
+
+// DE address should have the housenumber and street name flipped
+// eg. '101 Grolmanstraße' -> 'Grolmanstraße 101'
+function flipNumberAndStreet(place) {
+  var standard = ( place.address.number + ' ' + place.address.street ),
+      flipped  = ( place.address.street + ' ' + place.address.number );
+
+  // flip street name and housenumber
+  if( place.name.default === standard ){
+    place.name.default = flipped;
+  }
+}
+
+module.exports = setup;

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -30,6 +30,7 @@ var postProc = {
   distances: require('../middleware/distance'),
   confidenceScores: require('../middleware/confidenceScore'),
   confidenceScoresReverse: require('../middleware/confidenceScoreReverse'),
+  localNamingConventions: require('../middleware/localNamingConventions'),
   renamePlacenames: require('../middleware/renamePlacenames'),
   geocodeJSON: require('../middleware/geocodeJSON'),
   sendJSON: require('../middleware/sendJSON')
@@ -60,6 +61,7 @@ function addRoutes(app, peliasConfig) {
       controllers.search(),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig),
+      postProc.localNamingConventions(),
       postProc.renamePlacenames(),
       postProc.geocodeJSON(peliasConfig, base),
       postProc.sendJSON
@@ -70,6 +72,7 @@ function addRoutes(app, peliasConfig) {
       controllers.search(null, require('../query/autocomplete')),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig),
+      postProc.localNamingConventions(),
       postProc.renamePlacenames(),
       postProc.geocodeJSON(peliasConfig, base),
       postProc.sendJSON
@@ -82,6 +85,7 @@ function addRoutes(app, peliasConfig) {
       // reverse confidence scoring depends on distance from origin
       //  so it must be calculated first
       postProc.confidenceScoresReverse(),
+      postProc.localNamingConventions(),
       postProc.renamePlacenames(),
       postProc.geocodeJSON(peliasConfig, base),
       postProc.sendJSON
@@ -89,6 +93,7 @@ function addRoutes(app, peliasConfig) {
     place: createRouter([
       sanitisers.place.middleware,
       controllers.place(),
+      postProc.localNamingConventions(),
       postProc.renamePlacenames(),
       postProc.geocodeJSON(peliasConfig, base),
       postProc.sendJSON

--- a/test/unit/middleware/localNamingConventions.js
+++ b/test/unit/middleware/localNamingConventions.js
@@ -1,0 +1,71 @@
+var localNamingConventions = require('../../../middleware/localNamingConventions');
+
+module.exports.tests = {};
+
+// ref: https://github.com/pelias/pelias/issues/141
+module.exports.tests.flipNumberAndStreet = function(test, common) {
+
+  var ukAddress = {
+    '_id': 'test1',
+    '_type': 'test',
+    'name': { 'default': '1 Main St' },
+    'center_point': { 'lon': -7.131521, 'lat': 54.428866 },
+    'address': {
+       'zip': 'BT77 0BG',
+       'number': '1',
+       'street': 'Main St'
+    },
+    'admin1': 'Dungannon',
+    'alpha3': 'GBR',
+    'admin0': 'United Kingdom'
+  };
+
+  var deAddress = {
+    '_id': 'test2',
+    '_type': 'test',
+    'name': { 'default': '23 Grolmanstraße' },
+    'center_point': { 'lon': 13.321487, 'lat': 52.506781 },
+    'address': {
+       'zip': '10623',
+       'number': '23',
+       'street': 'Grolmanstraße'
+    },
+    'admin1': 'Berlin',
+    'locality': 'Berlin',
+    'alpha3': 'DEU',
+    'admin2': 'Berlin',
+    'admin0': 'Germany',
+    'neighborhood': 'Hansaviertel'
+  };
+
+  var req = {},
+      res = { data: [ ukAddress, deAddress ] },
+      middleware = localNamingConventions();
+
+  test('flipNumberAndStreet', function(t) {
+
+    middleware( req, res, function next(){
+
+      // GBR address should be a noop
+      t.equal( res.data[0].name.default, '1 Main St', 'standard name' );
+
+      // DEU address should have the housenumber and street name flipped
+      // eg. '101 Grolmanstraße' -> 'Grolmanstraße 101'
+      t.equal( res.data[1].name.default, 'Grolmanstraße 23', 'flipped name' );
+
+      t.end();
+    });
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('[middleware] localNamingConventions: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -15,6 +15,7 @@ var tests = [
   require('./middleware/confidenceScore'),
   require('./middleware/confidenceScoreReverse'),
   require('./middleware/distance'),
+  require('./middleware/localNamingConventions'),
   require('./query/autocomplete'),
   require('./query/defaults'),
   require('./query/reverse'),


### PR DESCRIPTION
resolves https://github.com/pelias/pelias/issues/141

this PR simply flips the housenumber and street name for german addresses.

eg. '101 Grolmanstraße' -> 'Grolmanstraße 101'