### PR TITLE
remove ngram analysis from search endpoint

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -11,10 +11,9 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
 query.score( peliasQuery.view.boundary_country, 'must' );
-query.score( peliasQuery.view.ngrams, 'must' );
+query.score( peliasQuery.view.phrase, 'must' );
 
 // scoring boost
-query.score( peliasQuery.view.phrase );
 query.score( peliasQuery.view.focus( peliasQuery.view.phrase ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.phrase ) );
 query.score( peliasQuery.view.population( peliasQuery.view.phrase ) );

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -15,25 +15,17 @@ module.exports = {
             },
             {
               'match': {
-                'name.default': {
+                'phrase.default': {
                   'query': 'test',
+                  'analyzer': 'peliasPhrase',
+                  'type': 'phrase',
                   'boost': 1,
-                  'analyzer': 'peliasOneEdgeGram'
+                  'slop': 2
                 }
               }
             }
           ],
           'should': [{
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'boost': 1,
-                'slop': 2
-              }
-            }
-          },{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_full_address.js
+++ b/test/unit/fixture/search_full_address.js
@@ -9,15 +9,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': '123 main st',
-                'analyzer': 'peliasOneEdgeGram',
-                'boost': 1
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': '123 main st',
                 'analyzer': 'peliasPhrase',
@@ -26,8 +17,8 @@ module.exports = {
                 'boost': 1
               }
             }
-          },
-          {
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -6,15 +6,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': 'test',
-                'boost': 1,
-                'analyzer': 'peliasOneEdgeGram'
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
@@ -23,7 +14,8 @@ module.exports = {
                 'slop': 2
               }
             }
-          },{
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -6,15 +6,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': 'test',
-                'boost': 1,
-                'analyzer': 'peliasOneEdgeGram'
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
@@ -23,7 +14,8 @@ module.exports = {
                 'slop': 2
               }
             }
-          }, {
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -6,15 +6,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': 'test',
-                'boost': 1,
-                'analyzer': 'peliasOneEdgeGram'
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
@@ -23,7 +14,8 @@ module.exports = {
                 'slop': 2
               }
             }
-          }, {
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -6,15 +6,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': 'test',
-                'boost': 1,
-                'analyzer': 'peliasOneEdgeGram'
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
@@ -23,7 +14,8 @@ module.exports = {
                 'slop': 2
               }
             }
-          }, {
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -6,15 +6,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': 'test',
-                'boost': 1,
-                'analyzer': 'peliasOneEdgeGram'
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
@@ -23,7 +14,8 @@ module.exports = {
                 'slop': 2
               }
             }
-          },{
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_linguistic_viewport.js
+++ b/test/unit/fixture/search_linguistic_viewport.js
@@ -6,17 +6,6 @@ module.exports = {
           'must': [
             {
               'match': {
-                'name.default': {
-                  'analyzer': 'peliasOneEdgeGram',
-                  'boost': 1,
-                  'query': 'test'
-                }
-              }
-            }
-          ],
-          'should': [
-            {
-              'match': {
                 'phrase.default': {
                   'analyzer': 'peliasPhrase',
                   'type': 'phrase',
@@ -25,7 +14,9 @@ module.exports = {
                   'query': 'test'
                 }
               }
-            },
+            }
+          ],
+          'should': [
             {
               'function_score': {
                 'query': {

--- a/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
+++ b/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
@@ -6,17 +6,6 @@ module.exports = {
           'must': [
             {
               'match': {
-                'name.default': {
-                  'analyzer': 'peliasOneEdgeGram',
-                  'boost': 1,
-                  'query': 'test'
-                }
-              }
-            }
-          ],
-          'should': [
-            {
-              'match': {
                 'phrase.default': {
                   'analyzer': 'peliasPhrase',
                   'type': 'phrase',
@@ -25,7 +14,9 @@ module.exports = {
                   'query': 'test'
                 }
               }
-            },
+            }
+          ],
+          'should': [
             {
               'function_score': {
                 'query': {

--- a/test/unit/fixture/search_partial_address.js
+++ b/test/unit/fixture/search_partial_address.js
@@ -9,15 +9,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': 'soho grand',
-                'analyzer': 'peliasOneEdgeGram',
-                'boost': 1
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': 'soho grand',
                 'analyzer': 'peliasPhrase',
@@ -26,7 +17,8 @@ module.exports = {
                 'boost': 1
               }
             }
-          },{
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {

--- a/test/unit/fixture/search_regions_address.js
+++ b/test/unit/fixture/search_regions_address.js
@@ -9,15 +9,6 @@ module.exports = {
         'bool': {
           'must': [{
             'match': {
-              'name.default': {
-                'query': '1 water st',
-                'analyzer': 'peliasOneEdgeGram',
-                'boost': 1
-              }
-            }
-          }],
-          'should': [{
-            'match': {
               'phrase.default': {
                 'query': '1 water st',
                 'analyzer': 'peliasPhrase',
@@ -26,7 +17,8 @@ module.exports = {
                 'boost': 1
               }
             }
-          },{
+          }],
+          'should': [{
             'function_score': {
               'query': {
                 'match': {


### PR DESCRIPTION
DO NOT MERGE

remove ngram analysis from search endpoint
the start of good things to come ;)
requires dev testing

[EDIT] did a little testing and having second thoughts on this one, see:
- http://pelias.github.io/compare/#/v1/search%3Ftext=whole%20foods%20NY
- http://pelias.github.io/compare/#/v1/search%3Ftext=new%20zealand

it would probably be better to use a `shingles` analysis for the `must` condition rather than `phrase`