### PR TITLE
Fix postalcode confidence score

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -100,7 +100,7 @@ function checkForDealBreakers(req, hit) {
     return true;
   }
 
-  if (check.assigned(req.clean.parsed_text.postalcode) && req.clean.parsed_text.postalcode !== hit.zip) {
+  if (check.assigned(req.clean.parsed_text.postalcode) && req.clean.parsed_text.postalcode !== hit.address.zip) {
     logger.debug('[confidence][deal-breaker]: postalcode !== zip');
     return true;
   }
@@ -208,7 +208,7 @@ function propMatch(textProp, hitProp, expectEnriched) {
  * @param {object} [hit.address]
  * @param {string|number} [hit.address.number]
  * @param {string} [hit.address.street]
- * @param {string|number} [hit.zip]
+ * @param {string|number} [hit.address.zip]
  * @param {string} [hit.admin1_abbr]
  * @param {string} [hit.alpha3]
  * @returns {number}

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -101,7 +101,7 @@ function checkForDealBreakers(req, hit) {
   }
 
   if (check.assigned(req.clean.parsed_text.postalcode) && req.clean.parsed_text.postalcode !== hit.address.zip) {
-    logger.debug('[confidence][deal-breaker]: postalcode !== zip');
+    logger.debug('[confidence][deal-breaker]: postalcode !== zip (' + req.clean.parsed_text.postalcode + ' !== ' + hit.address.zip + ')');
     return true;
   }
 }


### PR DESCRIPTION
I noticed when testing #368 that confidence scores were being capped at 0.5, and not matching on zipcode. Looks like we changed the mapping at some point but forgot to update this.

Note: I couldn't find any documents that didn't at least have the address property defined as an empty object, even with an Elasticsearch query like the one below, so I didn't add an explicit check that address is set.

```
GET /pelias/_search
{
  "query": {
    "filtered": {
      "filter": {
        "bool": {
          "must_not": [
            { 
              "exists": {
                "field": "address"
              }
            }
          ]
        }
      }
    }
  }
}
```