### PR TITLE
Autocomplete config tweaks separated

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -100,7 +100,8 @@ function checkForDealBreakers(req, hit) {
     return true;
   }
 
-  if (check.assigned(req.clean.parsed_text.postalcode) && req.clean.parsed_text.postalcode !== hit.address.zip) {
+  if (check.assigned(req.clean.parsed_text.postalcode) && check.assigned(hit.address) &&
+      req.clean.parsed_text.postalcode !== hit.address.zip) {
     logger.debug('[confidence][deal-breaker]: postalcode !== zip (' + req.clean.parsed_text.postalcode + ' !== ' + hit.address.zip + ')');
     return true;
   }

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -1,7 +1,9 @@
 
 var peliasQuery = require('pelias-query'),
     defaults = require('./autocomplete_defaults'),
+    textParser = require('./text_parser'),
     check = require('check-types');
+
 
 //------------------------------
 // autocomplete query
@@ -10,6 +12,16 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
 query.score( peliasQuery.view.ngrams, 'must' );
+
+// admin components
+query.score( peliasQuery.view.admin('alpha3') );
+query.score( peliasQuery.view.admin('admin0') );
+query.score( peliasQuery.view.admin('admin1') );
+query.score( peliasQuery.view.admin('admin1_abbr') );
+query.score( peliasQuery.view.admin('admin2') );
+query.score( peliasQuery.view.admin('local_admin') );
+query.score( peliasQuery.view.admin('locality') );
+query.score( peliasQuery.view.admin('neighborhood') );
 
 // scoring boost
 query.score( peliasQuery.view.phrase );
@@ -62,6 +74,11 @@ function generateQuery( clean ){
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
     });
+  }
+
+  // run the address parser
+  if( clean.parsed_text ){
+    textParser( clean.parsed_text, vs );
   }
 
   var q = query.render( vs );

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -39,7 +39,11 @@ function generateQuery( clean ){
     });
   }
 
-  return query.render( vs );
+  var q = query.render( vs );
+
+  console.log( JSON.stringify( q, null, 2 ) );
+
+  return q;
 }
 
 module.exports = generateQuery;

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -13,7 +13,32 @@ query.score( peliasQuery.view.ngrams, 'must' );
 
 // scoring boost
 query.score( peliasQuery.view.phrase );
-query.score( peliasQuery.view.focus( peliasQuery.view.ngrams ) );
+
+var focus = peliasQuery.view.focus( peliasQuery.view.phrase );
+
+var _tmpview = function( vs ){
+
+  var view = focus( vs );
+
+  if( view && view.hasOwnProperty('function_score') ){
+    view.function_score.filter = {
+      'or': [
+        { 'type': { 'value': 'osmnode' } },
+        { 'type': { 'value': 'osmway' } },
+        { 'type': { 'value': 'osmaddress' } },
+        { 'type': { 'value': 'openaddresses' } },
+        { 'type': { 'value': 'geoname' } },
+      ]
+    };
+  }
+
+  // console.log( JSON.stringify( view, null, 2 ) );
+  return view;
+};
+
+// console.log( focus );
+
+query.score( _tmpview );
 query.score( peliasQuery.view.popularity( peliasQuery.view.phrase ) );
 query.score( peliasQuery.view.population( peliasQuery.view.phrase ) );
 

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -30,8 +30,8 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:slop': 2,
 
   'focus:function': 'linear',
-  'focus:offset': '1km',
-  'focus:scale': '50km',
+  'focus:offset': '100km',
+  'focus:scale': '250km',
   'focus:decay': 0.5,
   'focus:weight': 2,
 

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -36,7 +36,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'focus:weight': 10,
 
   'function_score:score_mode': 'avg',
-  'function_score:boost_mode': 'replace',
+  'function_score:boost_mode': 'multiply',
 
   'address:housenumber:analyzer': 'peliasHousenumber',
   'address:housenumber:field': 'address.number',

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -33,7 +33,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'focus:offset': '100km',
   'focus:scale': '250km',
   'focus:decay': 0.5,
-  'focus:weight': 2,
+  'focus:weight': 10,
 
   'function_score:score_mode': 'avg',
   'function_score:boost_mode': 'replace',


### PR DESCRIPTION
I took @missinglink's commits from #378, separated out each logical change (as I understood them, let me know if I got this wrong), and ran the autocomplete acceptance tests against each individual commit, to gauge how each one affects our scoring. Note that as you go down the list of results, all the previous commits have been applied, so the scores represent the cumulative effect.

All these tests were run against dev today, 12/8, using a local API instance pointed at the dev Elasticsearch cluster

## baseline

[8ded573 - Console.log query](https://github.com/pelias/api/commit/8ded573cb4c7555e28a74990eaa13d72200baee4) (this and the previous commit simply fix a minor bug and add some debugging, and otherwise are the same as master)
Pass: 575 Fail: 128 Regressions: 1294 Test success rate 35%


## from this branch

[de26564 - Apply function_score to only some types](https://github.com/pelias/api/commit/de2656424e13cd257e3dcdb9f92ee3ea5c2f6dbc)
Pass: 549 Fail: 141 Regressions: 1307 Test success rate 35%


[4f1087b - Increase focus offset and scale to 100 and 250km](https://github.com/pelias/api/commit/4f1087b11cf7ce6f8f4ef37438ce65c99ff90b43)
Pass: 549 Fail: 141 Regressions: 1307 Test success rate 35%

[1a252e1 - Increase weight of autocomplete focus to 10 from 2](https://github.com/pelias/api/commit/1a252e15dbacf994f6a23ee7ae983a359b7d9383)
Pass: 547 Fail: 141 Regressions: 1309 Test success rate 34%

[e027816 - Use multiply mode for autocomplete focus boosting](https://github.com/pelias/api/commit/e027816296fcb29c3e560ec606b5c65e9c444a14)
Pass: 547 Fail: 141 Regressions: 1309 Test success rate 34%


[a231b86 - enable text parsing](https://github.com/pelias/api/commit/a231b86adf5de250b5df4cb98a91a8b3377ee092)
Pass: 802 Fail: 142 Regressions: 1053 Test success rate 47%

## Takeaways

I don't think just the acceptance tests cover enough situations to be a 100% foolproof scoring metric. As we gather more interesting test cases in the near future I think we will be able to do that, but at the moment small changes in simply the number of pass/fail doesn't seem meaningful. To that end, here are the full results in HTML format so we can look at minor differences:
[autocomplete-results.zip](https://github.com/pelias/api/files/56129/autocomplete-results.zip)

In particular, I don't think the drop from 575 pass as a baseline to ~549 for the first couple commits means we don't want to merge those. It's worth investigating more, because these separate commits were in fact intended to all work together, so merging just some of them might not make sense.

But, most importantly: we _do_ want to merge at least the final commit, a231b86, to enable text parsing (aka address parsing) right away. It's huge and basically makes autocomplete perform on par with search. It should at the very least go out with the next build, or perhaps we even deploy during this week. But it's clearly really big.