### PR TITLE
Reenable address parsing for autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -1,7 +1,9 @@
 
 var peliasQuery = require('pelias-query'),
     defaults = require('./autocomplete_defaults'),
+    textParser = require('./text_parser'),
     check = require('check-types');
+
 
 //------------------------------
 // autocomplete query
@@ -10,6 +12,16 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
 query.score( peliasQuery.view.ngrams, 'must' );
+
+// admin components
+query.score( peliasQuery.view.admin('alpha3') );
+query.score( peliasQuery.view.admin('admin0') );
+query.score( peliasQuery.view.admin('admin1') );
+query.score( peliasQuery.view.admin('admin1_abbr') );
+query.score( peliasQuery.view.admin('admin2') );
+query.score( peliasQuery.view.admin('local_admin') );
+query.score( peliasQuery.view.admin('locality') );
+query.score( peliasQuery.view.admin('neighborhood') );
 
 // scoring boost
 query.score( peliasQuery.view.phrase );
@@ -37,6 +49,11 @@ function generateQuery( clean ){
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
     });
+  }
+
+  // run the address parser
+  if( clean.parsed_text ){
+    textParser( clean.parsed_text, vs );
   }
 
   return query.render( vs );


### PR DESCRIPTION
This is just the one commit to re-enable address parsing pulled out of #378 and #381 in case we want to merge it by itself. Scoring wise, here's the breakdown:

### master
Pass: 575 Fail: 128 Regressions: 1294 Test success rate 35%

### master when search endpoint is used instead of autocomplete
Pass: 897 Fail: 126 Regressions: 974 Test success rate 51%

### this branch
Pass: 828 Fail: 129 Regressions: 1040 Test success rate 48%

### #381 
Pass: 802 Fail: 142 Regressions: 1053 Test success rate 47%

## full results as HTML for inspection
[address_parser_results.zip](https://github.com/pelias/api/files/56173/address_parser_results.zip)

## Notes
We will probably never get /autocomplete to perform as well as /search against our acceptance tests since a lot of them are written with search in mind, and search has more options like boundary.country. But this change brings us very very close.