### PR TITLE
Use throws and doesNotThrow from Tape

### DIFF
--- a/test/unit/helper/types.js
+++ b/test/unit/helper/types.js
@@ -4,16 +4,13 @@ module.exports.tests = {};
 
 module.exports.tests.no_cleaned_types = function(test, common) {
   test('no cleaned types', function(t) {
-    try {
+    function testIt() {
       types({});
-      t.fail('exception should be thrown');
     }
-    catch (err) {
-      t.equal(err.message, 'clean_types should not be null or undefined', 'no input should result in exception');
-    }
-    finally {
-      t.end();
-    }
+
+    t.throws(testIt, /clean_types should not be null or undefined/, 'no input should result in exception');
+
+    t.end();
   });
 };
 

--- a/test/unit/helper/types.js
+++ b/test/unit/helper/types.js
@@ -5,19 +5,6 @@ module.exports.tests = {};
 module.exports.tests.no_cleaned_types = function(test, common) {
   test('no cleaned types', function(t) {
     try {
-      types();
-      t.fail('exception should be thrown');
-    }
-    catch (err) {
-      t.equal(err.message, 'clean_types should not be null or undefined', 'no input should result in exception');
-    }
-    finally {
-      t.end();
-    }
-  });
-
-  test('no cleaned types', function(t) {
-    try {
       types({});
       t.fail('exception should be thrown');
     }

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -5,17 +5,12 @@ module.exports.tests = {};
 module.exports.tests.confidenceScore = function(test, common) {
 
   test('empty res and req should not throw exception', function(t) {
-    try {
+    function testIt() {
       confidenceScore({}, {}, function() {});
-      t.pass('no exception');
-    }
-    catch (e) {
-      t.fail('an exception should not have been thrown');
-    }
-    finally {
-      t.end();
     }
 
+    t.doesNotThrow(testIt, 'an exception should not have been thrown');
+    t.end();
   });
 
   test('res.results without parsed_text should not throw exception', function(t) {
@@ -27,18 +22,12 @@ module.exports.tests.confidenceScore = function(test, common) {
       meta: [10]
     };
 
-    try {
+    function testIt() {
       confidenceScore(req, res, function() {});
-      t.pass('no exception');
-    }
-    catch (e) {
-      t.fail('an exception should not have been thrown');
-      console.log(e.stack);
-    }
-    finally {
-      t.end();
     }
 
+    t.doesNotThrow(testIt, 'an exception should not have been thrown');
+    t.end();
   });
 
   test('hit without address should not error', function(t) {
@@ -61,17 +50,12 @@ module.exports.tests.confidenceScore = function(test, common) {
       }
     };
 
-    try {
+    function testIt() {
       confidenceScore(req, res, function() {});
-      t.pass('no exception');
     }
-    catch (e) {
-      t.fail('an exception should not have been thrown with no address');
-      console.log(e.stack);
-    }
-    finally {
-      t.end();
-    }
+
+    t.doesNotThrow(testIt, 'an exception should not have been thrown with no address');
+    t.end();
   });
 
 

--- a/test/unit/middleware/confidenceScoreReverse.js
+++ b/test/unit/middleware/confidenceScoreReverse.js
@@ -6,16 +6,12 @@ module.exports.tests.confidenceScoreReverse = function(test, common) {
   test('res without results should not throw exception', function(t) {
     var res = {};
 
-    try {
+    function testIt() {
       confidenceScoreReverse(null, res, function() {});
     }
-    catch (e) {
-      t.fail('an exception should not have been thrown');
-    }
-    finally {
-      t.end();
-    }
 
+    t.doesNotThrow(testIt, 'an exception should not have been thrown');
+    t.end();
   });
 
   test('res.results without data should not throw exception', function(t) {
@@ -23,16 +19,12 @@ module.exports.tests.confidenceScoreReverse = function(test, common) {
       results: {}
     };
 
-    try {
+    function testIt() {
       confidenceScoreReverse(null, res, function() {});
     }
-    catch (e) {
-      t.fail('an exception should not have been thrown');
-    }
-    finally {
-      t.end();
-    }
 
+    t.doesNotThrow(testIt, 'an exception should not have been thrown');
+    t.end();
   });
 
   test('0m <= distance < 1m should be given score 1.0', function(t) {


### PR DESCRIPTION
inspired by @missinglink's comment from #380, this updates all our tests to use Tape's exception testing, rather than some homegrown stuff.

It shouldn't affect the behavior of the API, or the tests, in any way, but it does make things a bit cleaner to read and, hopefully, less error prone.