### PR TITLE
Hotfix: add geoname type to locality layer to fix SF and Brooklyn searches

### DIFF
--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -52,7 +52,7 @@ var LAYER_TO_TYPE = {
   'country': ['admin0'],
   'region': ['admin1'],
   'county': ['admin2'],
-  'locality': ['locality'],
+  'locality': ['locality', 'geoname'],
   'localadmin': ['local_admin'],
   'neighbourhood': ['neighborhood']
 };

--- a/test/unit/helper/type_mapping.js
+++ b/test/unit/helper/type_mapping.js
@@ -68,7 +68,7 @@ module.exports.tests.interfaces = function(test, common) {
     t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'country'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'region'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'county'), []);
-    t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'locality'), []);
+    t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'locality'), [ 'geoname' ]);
     t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'localadmin'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'neighbourhood'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('gn', 'coarse'), []);
@@ -77,7 +77,7 @@ module.exports.tests.interfaces = function(test, common) {
     t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'country'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'region'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'county'), []);
-    t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'locality'), []);
+    t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'locality'), [ 'geoname' ]);
     t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'localadmin'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'neighbourhood'), []);
     t.deepEquals(type_mapping.source_and_layer_to_type('geonames', 'coarse'), []);

--- a/test/unit/sanitiser/_layers.js
+++ b/test/unit/sanitiser/_layers.js
@@ -77,7 +77,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
   });
   test('address alias layer plus regular layers', function(t) {
     var address_layers = ['osmaddress','openaddresses'];
-    var reg_layers   = ['admin0', 'locality'];
+    var reg_layers   = ['admin0', 'locality', 'geoname'];
 
     var raw = { layers: 'address,country,locality' };
     var clean = {};


### PR DESCRIPTION
This small code change, combined with removing [two geonames records](http://pelias.github.io/compare/#/v1/place%3Fids=geonames:venue:6955114,geonames:venue:10630414) that are not localities, and are frankly, pretty weird, allows [this](https://github.com/pelias/acceptance-tests/pull/187) set of acceptance tests to pass.

Currently tested on my machine with all of QS and GN for USA imported.