### PR TITLE
Make doc generation a bit easier

### DIFF
--- a/bin/generate-docs
+++ b/bin/generate-docs
@@ -2,5 +2,8 @@
 
 rm -r docs || true
 
+curl -s http://localhost:3100/v1 > /dev/null || die "Pelias server does not appear to be running \
+on http://localhost:3100, run npm start in another window before generating docs."
+
 cd test/ciao
 node ../../node_modules/ciao/bin/ciao -c ../ciao.json . -d ../../docs

--- a/bin/generate-docs
+++ b/bin/generate-docs
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+rm -r docs || true
+
+cd test/ciao
+node ../../node_modules/ciao/bin/ciao -c ../ciao.json . -d ../../docs

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",
-    "docs": "rm -r docs; cd test/ciao; node ../../node_modules/ciao/bin/ciao -c ../ciao.json . -d ../../docs"
+    "docs": "rm -r docs || true; cd test/ciao; node ../../node_modules/ciao/bin/ciao -c ../ciao.json . -d ../../docs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",
-    "docs": "rm -r docs || true; cd test/ciao; node ../../node_modules/ciao/bin/ciao -c ../ciao.json . -d ../../docs"
+    "docs": "./bin/generate-docs"
   },
   "repository": {
     "type": "git",

--- a/test/ciao/search/layers_invalid.coffee
+++ b/test/ciao/search/layers_invalid.coffee
@@ -32,5 +32,3 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-should.not.exist json.geocoding.query['types']
-should.not.exist json.geocoding.query['type']

--- a/test/ciao/search/layers_mix_invalid_valid.coffee
+++ b/test/ciao/search/layers_mix_invalid_valid.coffee
@@ -32,5 +32,3 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-should.not.exist json.geocoding.query['types']
-should.not.exist json.geocoding.query['type']

--- a/test/ciao/search/sources_invalid.coffee
+++ b/test/ciao/search/sources_invalid.coffee
@@ -32,5 +32,3 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
-should.not.exist json.geocoding.query['types']
-should.not.exist json.geocoding.query['type']


### PR DESCRIPTION
While looking into #395, I discovered it's a bit hard to generate the pelias docs. This PR...

* Fixes some Ciao tests that were failing because of overspecified expectations
* Moves the commands to generate docs into its own file since it was already quite long
* Fixes a case where trying to generate the docs will fail if the docs aren't already there (oh the irony)
* Checks if Pelias is running before starting doc generation, and reminds you to start it if not 