### PR TITLE
Handle geonames gids

### DIFF
--- a/sanitiser/_ids.js
+++ b/sanitiser/_ids.js
@@ -45,7 +45,13 @@ function sanitizeId(rawId, messages) {
     return;
   }
 
-  var types = type_mapping.source_and_layer_to_type(source, layer);
+  //TODO: remove this once we have a better set of layers for Geonames
+  var types;
+  if (source === 'gn' || source === 'geonames') {
+    types = ['geoname'];
+  } else {
+    types = type_mapping.source_and_layer_to_type(source, layer);
+  }
 
   return {
     id: id,

--- a/test/unit/sanitiser/_ids.js
+++ b/test/unit/sanitiser/_ids.js
@@ -122,6 +122,34 @@ module.exports.tests.valid_ids = function(test, common) {
   });
 };
 
+module.exports.tests.geonames = function(test, common) {
+  test('geonames venue maps correctly as normal', function(t) {
+    var raw = { ids: 'geonames:venue:15' };
+    var clean = {};
+
+    var messages = sanitize( raw, clean);
+
+    var expected_clean = { ids: [ { id: '15', types: [ 'geoname' ] } ] };
+    t.deepEqual( messages.errors, [], 'no errors' );
+    t.deepEqual( messages.warnings, [], 'no warnings' );
+    t.deepEqual(clean, expected_clean, 'clean set correctly');
+    t.end();
+  });
+
+  test('arbitrary geonames layer maps to geoname type', function(t) {
+    var raw = { ids: 'geonames:address:16' }; // geonames technically has no address records!
+    var clean = {};
+
+    var messages = sanitize( raw, clean);
+
+    var expected_clean = { ids: [ { id: '16', types: [ 'geoname' ] } ] };
+    t.deepEqual( messages.errors, [], 'no errors' );
+    t.deepEqual( messages.warnings, [], 'no warnings' );
+    t.deepEqual(clean, expected_clean, 'clean set correctly');
+    t.end();
+  });
+};
+
 module.exports.tests.multiple_ids = function(test, common) {
   test('multiple ids', function(t) {
     var raw = { ids: 'geonames:venue:1,osm:venue:2' };

--- a/test/unit/sanitiser/_ids.js
+++ b/test/unit/sanitiser/_ids.js
@@ -2,10 +2,6 @@ var sanitize = require('../../../sanitiser/_ids');
 
 var delimiter = ':';
 var type_mapping = require('../../../helper/type_mapping');
-var inputs = {
-  valid: [ 'geoname:1', 'osmnode:2', 'admin0:53', 'osmway:44', 'geoname:5' ],
-  invalid: [ ':', '', '::', 'geoname:', ':234', 'gibberish:23' ]
-};
 
 var formatError = function(input) {
   return 'id `' + input + ' is invalid: must be of the format source:layer:id for ex: \'geonames:venue:4163334\'';


### PR DESCRIPTION
Instead of checking if the source/layer combination for geonames is
valid, always use the geoname type if the source is set to geonames,
regardless of which layer is in the gid.

This helps us better handle the case where people directly take gids
from our API responses.

Note: this functionality shouldn't be permanent and should be removed
once our new source/layer mapping system is in.

Fixes pelias/pelias#226
Fixes pelias/pelias#176

