### PR TITLE
Use patched branch of tap-dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "nsp": "^0.3.0",
     "precommit-hook": "^1.0.7",
     "proxyquire": "^1.4.0",
-    "tap-dot": "^1.0.0",
+    "tap-dot": "git://github.com/orangejulius/tap-dot#error-on-zero-tests",
     "tape": "^2.13.4"
   }
 }


### PR DESCRIPTION
Our test printer has a bug where a zero-test suite will pass. Usually,
and definitely for this repo, the only way a test suite will not have
any tests is if there was an error in the test program before it even
ran any tests ([example](https://travis-ci.org/pelias/api/jobs/110970031)).

Until [my PR](https://github.com/scottcorgan/tap-dot/pull/10) or something similar is merged into tap-dot, we should use
this branch.