### PR TITLE
Debug log full queries and responses between Pelias and Elasticsearch

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -30,6 +30,8 @@ function setup( backend, query ){
       cmd.type = req.clean.type;
     }
 
+    logger.debug( '[ES req]', JSON.stringify(cmd) );
+
     // query backend
     service.search( backend, cmd, function( err, docs, meta ){
 
@@ -42,7 +44,7 @@ function setup( backend, query ){
         res.data = docs;
         res.meta = meta;
       }
-
+      logger.debug('[ES response]', JSON.stringify(docs));
       next();
     });
 


### PR DESCRIPTION
Ability to see full query/response content is very useful when debugging. Logging all queries in Elasticsearch seems to be difficult. 