### PR TITLE
fix focus weighting

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -30,10 +30,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:slop': 2,
 
   'focus:function': 'linear',
-  'focus:offset': '10km',
+  'focus:offset': '0km',
   'focus:scale': '250km',
   'focus:decay': 0.5,
-  'focus:weight': 3,
+  'focus:weight': 10,
 
   'function_score:score_mode': 'avg',
   'function_score:boost_mode': 'multiply',
@@ -90,6 +90,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'population:field': 'population',
   'population:modifier': 'log1p',
   'population:max_boost': 20,
-  'population:weight': 2
+  'population:weight': 3
 
 });

--- a/query/view/focus_selected_layers.js
+++ b/query/view/focus_selected_layers.js
@@ -22,10 +22,8 @@ module.exports = function( subview ){
     if( view && view.hasOwnProperty('function_score') ){
       view.function_score.filter = {
         'or': [
-          { 'type': { 'value': 'osmnode' } },
-          { 'type': { 'value': 'osmway' } },
-          { 'type': { 'value': 'osmaddress' } },
-          { 'type': { 'value': 'openaddresses' } }
+          { 'term': { 'layer': 'venue' } },
+          { 'term': { 'layer': 'address' } }
         ]
       };
     }

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -70,7 +70,7 @@ module.exports = {
                   'modifier': 'log1p',
                   'field': 'population'
                 },
-                'weight': 2
+                'weight': 3
               }]
             }
           }]

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -35,35 +35,25 @@ module.exports = {
                       'lat': 29.49136,
                       'lon': -82.50622
                     },
-                    'offset': '10km',
+                    'offset': '0km',
                     'scale': '250km',
                     'decay': 0.5
                   }
                 },
-                'weight': 3
+                'weight': 10
               }],
               'score_mode': 'avg',
               'boost_mode': 'multiply',
               'filter': {
                 'or': [
                   {
-                    'type': {
-                      'value': 'osmnode'
+                    'term': {
+                      'layer': 'venue'
                     }
                   },
                   {
-                    'type': {
-                      'value': 'osmway'
-                    }
-                  },
-                  {
-                    'type': {
-                      'value': 'osmaddress'
-                    }
-                  },
-                  {
-                    'type': {
-                      'value': 'openaddresses'
+                    'term': {
+                      'layer': 'address'
                     }
                   }
                 ]
@@ -124,7 +114,7 @@ module.exports = {
                   'modifier': 'log1p',
                   'field': 'population'
                 },
-                'weight': 2
+                'weight': 3
               }]
             }
           }]

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -35,35 +35,25 @@ module.exports = {
                       'lat': 0,
                       'lon': 0
                     },
-                    'offset': '10km',
+                    'offset': '0km',
                     'scale': '250km',
                     'decay': 0.5
                   }
                 },
-                'weight': 3
+                'weight': 10
               }],
               'score_mode': 'avg',
               'boost_mode': 'multiply',
               'filter': {
                 'or': [
                   {
-                    'type': {
-                      'value': 'osmnode'
+                    'term': {
+                      'layer': 'venue'
                     }
                   },
                   {
-                    'type': {
-                      'value': 'osmway'
-                    }
-                  },
-                  {
-                    'type': {
-                      'value': 'osmaddress'
-                    }
-                  },
-                  {
-                    'type': {
-                      'value': 'openaddresses'
+                    'term': {
+                      'layer': 'address'
                     }
                   }
                 ]
@@ -124,7 +114,7 @@ module.exports = {
                   'modifier': 'log1p',
                   'field': 'population'
                 },
-                'weight': 2
+                'weight': 3
               }]
             }
           }]

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -81,7 +81,7 @@ module.exports = {
                   'modifier': 'log1p',
                   'field': 'population'
                 },
-                'weight': 2
+                'weight': 3
               }]
             }
           }]

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -70,7 +70,7 @@ module.exports = {
                   'modifier': 'log1p',
                   'field': 'population'
                 },
-                'weight': 2
+                'weight': 3
               }]
             }
           }]

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -133,7 +133,7 @@ module.exports = {
                       'modifier': 'log1p',
                       'field': 'population'
                     },
-                    'weight': 2
+                    'weight': 3
                   }
                 ],
                 'score_mode': 'first',


### PR DESCRIPTION
**note:** for all the screenshots in the PR you'll find the current **production server on the left**, the current **dev build in the centre** and **my local machine on the right**.

**note:** the `focus.point` for all the screenshots is a point in Manhattan, NYC.

#### issue

This PR fixes a regression in the 'focus bias' applied to autocomplete queries, you can see what I mean in the screenshot below:

![mcdonalds](http://missinglink.embed.s3.amazonaws.com/api418/mcdonalds.png)

In the above screenshot, when you compare the left and the centre maps you'll see a big difference, on the live server you can see results clustering towards the `focus.point` whereas on the dev server they don't.

#### query changes

The fix for that was pretty simple:

```diff
query/view/focus_selected_layers.js
 @@ -22,10 +22,8 @@ module.exports = function( subview ){
      if( view && view.hasOwnProperty('function_score') ){
        view.function_score.filter = {
          'or': [
 -          { 'type': { 'value': 'osmnode' } },
 -          { 'type': { 'value': 'osmway' } },
 -          { 'type': { 'value': 'osmaddress' } },
 -          { 'type': { 'value': 'openaddresses' } }
 +          { 'term': { 'layer': 'venue' } },
 +          { 'term': { 'layer': 'address' } }
          ]
        };
      }
```

... in the past we were using the '_type' to pick which documents got a focus boost, now we are using the 'layer' value, so big win there, we don't have to maintain a list of magic variables in our code and it will 'just work' with new datasets.

Changing the above 'mostly' fixed the issue but the weightings seem to no longer be strong enough to ensure the delicate local-over-regional balance we had before, eg:

![balance](http://missinglink.embed.s3.amazonaws.com/api418/balance.png)

the focus is too strong in this case as we would like 'London, UK' in the mix.

#### weighting changes

So I've changed some of the default values, I upped the `focus.weight` from 3 to 10 and then I had to also up the `population.weight` from 2 to 3 in order to get a similar 'feeling' balance to what we had before.

![london](http://missinglink.embed.s3.amazonaws.com/api418/london.png)

you can see in the image above (map on the right) that *most* of the results are now around the focus point *but* we also find the UK city; winning.

#### tighter clustering

I also changed `focus:offset` from `10km` to `0km`, I'm not sure why we had it like this in the first place, likely a mistake. What this was doing is saying "everything within 10km of the focus point get's the same boost", which resulted in Brooklyn venues getting returned when there was a closer match in Manhattan.

This should actually improve local searches significantly.

@riordan let's have a chat about this, it could end up making it hard for long-distance drivers to find their destination although it shouldn't have too much effect as I didn't touch `focus.scale`? I'm sure it would make taxi drivers happier.

![donut](http://missinglink.embed.s3.amazonaws.com/api418/donut.png)

![26_street](http://missinglink.embed.s3.amazonaws.com/api418/26street.png)

you can see that the grouping is now 'tighter' around the focus point:

![grouping1](http://missinglink.embed.s3.amazonaws.com/api418/grouping1.png)

![grouping2](http://missinglink.embed.s3.amazonaws.com/api418/grouping2.png)

This will have to go up on to the dev server as we're never really sure about the side effects of changing the weights until we've run the full regression test suite against it.