### PR TITLE
Upgrade to precommit-hook 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",
-    "docs": "./bin/generate-docs"
+    "docs": "./bin/generate-docs",
+    "lint": "jshint .",
+    "validate": "npm ls"
   },
   "repository": {
     "type": "git",
@@ -66,5 +68,10 @@
     "proxyquire": "^1.4.0",
     "tap-dot": "1.0.4",
     "tape": "^2.13.4"
-  }
+  },
+  "pre-commit": [
+    "lint",
+    "validate",
+    "test"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "istanbul": "^0.3.13",
     "jshint": "^2.5.6",
     "nsp": "^0.3.0",
-    "precommit-hook": "^1.0.7",
+    "precommit-hook": "3.0.0",
     "proxyquire": "^1.4.0",
     "tap-dot": "1.0.4",
     "tape": "^2.13.4"


### PR DESCRIPTION
It handles keeping track of the tasks better (you can't do `npm run lint` with precommit-hook 1.x