### PR TITLE
Fix dedupe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN npm install && \
   npm test && \
   chmod -R a+rwX .
 
+ADD pelias.json.docker pelias.json
+
 # Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
 # This also reveals permission problems on local Docker.
 RUN chown -R 9999:9999 ${WORK}

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -42,6 +42,9 @@ function isDifferent(item1, item2) {
     propMatch(item1, item2, 'admin1_abbr');
     propMatch(item1, item2, 'alpha3');
 
+    propMatch(item1, item2, 'locality');
+    propMatch(item1, item2, 'neighborhood');
+
     if (item1.hasOwnProperty('name') && item2.hasOwnProperty('name')) {
       propMatch(item1.name, item2.name, 'default');
     }

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -80,6 +80,9 @@ function isDifferent(item1, item2) {
  * @throws {Error}
  */
 function propMatch(item1, item2, prop) {
+  if (!item1[prop] || !item2[prop]) {
+    return; // absence of information does not make an item different
+  }
   if (normalizeString(item1[prop]) !== normalizeString(item2[prop])) {
     throw new Error('different');
   }

--- a/pelias.json.docker
+++ b/pelias.json.docker
@@ -1,0 +1,18 @@
+{
+  "esclient": {
+    "hosts": [
+      {
+        "env": "production",
+        "protocol": "http",
+        "host": "pelias-data-container",
+        "port": 9200
+      },
+      {
+        "env": "production",
+        "protocol": "http",
+        "host": "pelias-data-container",
+        "port": 9300
+      }
+    ]
+  }
+}

--- a/test/unit/fixture/dedupe_elasticsearch_results.js
+++ b/test/unit/fixture/dedupe_elasticsearch_results.js
@@ -33,6 +33,30 @@ module.exports = [
     'local_admin': 'East Lampeter',
     'admin1_abbr': 'PA',
     'name': {
+      'default': 'East Lampeter High School'
+    },
+    'admin1': 'Pennsylvania',
+    'alpha3': 'USA',
+    'admin2': 'Lancaster County',
+    'admin0': 'United States',
+    'neighborhood': 'Greenland',
+    'category': [
+      'education'
+    ],
+    '_id': '357321757',
+    '_type': 'osmnode',
+    '_score': 1.2367082,
+    'confidence': 0.879
+  },
+  {
+    'center_point': {
+      'lon': -76.207456,
+      'lat': 40.039265
+    },
+    'address': {},
+    'local_admin': 'East Lampeter',
+    'admin1_abbr': 'PA',
+    'name': {
       'default': 'East Lampeter, High-School'
     },
     'admin1': 'Pennsylvania',


### PR DESCRIPTION
Deduper should really consider locality and neighborhood, too. Especially with POI data, which is not necessarily bound to street addresses, current deduping works really badly.
 
It also seems that a missing field should not make an item different if it is otherwise identical with another item.  A more complete item gets higher scores, so it is safe to drop the document which just duplicates some fields.

Further thoughts: maybe the distance should be considered, too. This is not a  straightforward thing, because distance between street addresses should match well (say, with a 500 m limit), whereas location of a city can vary several kilometers.
