### PR TITLE
Remove expensive JSON.stringify from api debug logging calls

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -22,7 +22,7 @@ function setup( backend ){
       };
     });
 
-    logger.debug( '[ES req]', JSON.stringify(query) );
+    logger.debug( '[ES req]', query );
 
     service.mget( backend, query, function( err, docs ) {
       console.log('err:' + err);
@@ -35,7 +35,7 @@ function setup( backend ){
       else {
         res.data = docs;
       }
-      logger.debug('[ES response]', JSON.stringify(docs));
+      logger.debug('[ES response]', docs);
 
       next();
     });

--- a/controller/search.js
+++ b/controller/search.js
@@ -29,7 +29,7 @@ function setup( backend, query ){
       cmd.type = req.clean.layers;
     }
 
-    logger.debug( '[ES req]', JSON.stringify(cmd) );
+    logger.debug( '[ES req]', cmd );
 
     // query backend
     service.search( backend, cmd, function( err, docs, meta ){
@@ -43,7 +43,7 @@ function setup( backend, query ){
         res.data = docs;
         res.meta = meta;
       }
-      logger.debug('[ES response]', JSON.stringify(docs));
+      logger.debug('[ES response]', docs);
       next();
     });
 


### PR DESCRIPTION
Fixing my own mistake here. Logger does not currently print object parameters as json, but this should be addressed in logger side, not in the api code.