### PR TITLE
Pass esclient config to elasticsearch module

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -1,6 +1,6 @@
-
+var config = require( 'pelias-config' ).generate().esclient;
 var Backend = require('geopipes-elasticsearch-backend'),
-    client = require('elasticsearch').Client(),
+    client = require('elasticsearch').Client(config),
     backends = {};
 
 function getBackend( index, type ){

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -45,6 +45,7 @@ var tests = [
   require('./sanitiser/_sources'),
   require('./sanitiser/_sources_and_layers'),
   require('./sanitiser/_text'),
+  require('./src/backend'),
   require('./sanitiser/autocomplete'),
   require('./sanitiser/place'),
   require('./sanitiser/reverse'),

--- a/test/unit/src/backend.js
+++ b/test/unit/src/backend.js
@@ -1,0 +1,40 @@
+var proxyquire = require('proxyquire');
+
+var stubConfig = {
+  generate: function generate() {
+    return {
+      esclient: {
+        hosts: [
+          'http://notLocalhost:9200',
+          'http://anotherHost:9200'
+        ]
+      }
+    };
+  }
+};
+
+
+module.exports.tests = {};
+
+module.exports.tests.config_properly_passed = function(test, common) {
+  test('Elasticsearch config is properly passed to elasticsearch module', function(t) {
+    var stubElasticsearchClient = {
+      Client: function(config) {
+        t.deepEquals(config.hosts, [ 'http://notLocalhost:9200', 'http://anotherHost:9200' ], 'hosts set correctly' );
+        t.end();
+      }
+    };
+
+    proxyquire('../../../src/backend', { 'pelias-config': stubConfig, 'elasticsearch': stubElasticsearchClient } );
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('SANTIZE src/backend ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};


### PR DESCRIPTION
This fixes a regression in #423 that breaks our configuration in dev and
production.