### PR TITLE
Make street/number flipping configurable

### DIFF
--- a/middleware/localNamingConventions.js
+++ b/middleware/localNamingConventions.js
@@ -1,4 +1,5 @@
 var check = require('check-types');
+var _ = require('lodash');
 
 var flipNumberAndStreetCountries = ['DEU', 'FIN', 'SWE', 'NOR', 'DNK', 'ISL'];
 
@@ -7,12 +8,7 @@ function setup() {
   var settings = api.localization;
   if (settings && settings.flipNumberAndStreetCountries) {
     var countries = settings.flipNumberAndStreetCountries;
-    for (var i=0; i<countries.length; i++) {
-      var country = countries[i];
-      if ( flipNumberAndStreetCountries.indexOf(country===-1) ) {
-	flipNumberAndStreetCountries.push(country);
-      }
-    }
+    flipNumberAndStreetCountries = _.uniq(flipNumberAndStreetCountries.concat(countries));
   }
 
   return applyLocalNamingConventions;
@@ -28,17 +24,10 @@ function applyLocalNamingConventions(req, res, next) {
   // loop through data items and flip relevant number/street
   res.data.filter(function(place){
     // relevant for some countries
-    var flip = false;
-    for (var i=0; i<place.parent.country_a.length; i++) {
-      var country_a = place.parent.country_a[i];
-      if( flipNumberAndStreetCountries.indexOf(country_a) !== -1 ) {
-	flip = true;
-	break;
-      }
-    }
+    var flip = place.parent.country_a.some(function(country) {
+      return _.includes(flipNumberAndStreetCountries, country);
+    });
     if (!flip){ return false; }
-
-    if( place.parent.country_a.indexOf('DEU') === -1 ){ return false; }
     if( !place.hasOwnProperty('address_parts') ){ return false; }
     if( !place.address_parts.hasOwnProperty('number') ){ return false; }
     if( !place.address_parts.hasOwnProperty('street') ){ return false; }


### PR DESCRIPTION
The convention 'number after street name' is very common, and used widely in Europe (not only in Germany).  In this version, peliasConfig.api.localization.flipNumberAndStreetCountries can define an array of ISO 3166-1 alpha-3 country codes, for which the street number should come after street name.
