### PR TITLE
Make the structure of the query configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",
     "docs": "./bin/generate-docs",
-    "lint": "jshint .",
-    "validate": "npm ls"
+    "lint": "jshint ."
   },
   "repository": {
     "type": "git",

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -2,44 +2,46 @@
 var peliasQuery = require('pelias-query'),
     defaults = require('./autocomplete_defaults'),
     textParser = require('./text_parser'),
-    check = require('check-types');
+    check = require('check-types'),
+    viewsToQuery = require('./views_to_query'),
+    _ = require('lodash');
 
 // additional views (these may be merged in to pelias/query at a later date)
-var views = {
+var viewLib = {
   ngrams_strict:              require('./view/ngrams_strict'),
   focus_selected_layers:      require('./view/focus_selected_layers'),
   ngrams_last_token_only:     require('./view/ngrams_last_token_only'),
   phrase_first_tokens_only:   require('./view/phrase_first_tokens_only')
 };
 
+// merge available views into a single library
+for (var name in peliasQuery.view) {
+  viewLib[name] = peliasQuery.view[name];
+}
+
 //------------------------------
 // autocomplete query
 //------------------------------
 var query = new peliasQuery.layout.FilteredBooleanQuery();
 
-// mandatory matches
-query.score( views.phrase_first_tokens_only, 'must' );
-query.score( views.ngrams_last_token_only, 'must' );
+var views;
+var api = require('pelias-config').generate().api;
+if (api && api.query && api.query.autocomplete) {
+  // external config
+  views = api.query.autocomplete.views;
 
-// address components
-query.score( peliasQuery.view.address('housenumber') );
-query.score( peliasQuery.view.address('street') );
-query.score( peliasQuery.view.address('postcode') );
+  if(api.query.autocomplete.defaults) {
+    defaults = _.merge({}, defaults, api.query.autocomplete.defaults);
+  }
+}
 
-// admin components
-query.score( peliasQuery.view.admin('country') );
-query.score( peliasQuery.view.admin('country_a') );
-query.score( peliasQuery.view.admin('region') );
-query.score( peliasQuery.view.admin('region_a') );
-query.score( peliasQuery.view.admin('county') );
-query.score( peliasQuery.view.admin('localadmin') );
-query.score( peliasQuery.view.admin('locality') );
-query.score( peliasQuery.view.admin('neighbourhood') );
+if (!views) {
+  // Get default view configuration
+  views = require( './autocomplete_views.json' );
+}
 
-// scoring boost
-query.score( views.focus_selected_layers( views.ngrams_strict ) );
-query.score( peliasQuery.view.popularity( views.ngrams_strict ) );
-query.score( peliasQuery.view.population( views.ngrams_strict ) );
+// add defined views to the query
+viewsToQuery(views, query, viewLib);
 
 // --------------------------------
 

--- a/query/autocomplete_views.json
+++ b/query/autocomplete_views.json
@@ -1,0 +1,23 @@
+{
+  "score": [
+    [ "phrase_first_tokens_only", null, false, "must"],
+    [ "ngrams_last_token_only", null, false, "must"],
+
+    [ "address", "housenumber" ],
+    [ "address", "street" ],
+    [ "address", "postcode" ],
+
+    ["admin", "country"],
+    ["admin", "country_a"],
+    ["admin", "region"],
+    ["admin", "region_a"],
+    ["admin", "county"],
+    ["admin", "localadmin"],
+    ["admin", "locality"],
+    ["admin", "neighbourhood"],
+
+    ["focus_selected_layers", "ngrams_strict", true],
+    ["popularity", "ngrams_strict", true],
+    ["population", "ngrams_strict", true]
+  ]
+}

--- a/query/reverse_views.json
+++ b/query/reverse_views.json
@@ -1,0 +1,5 @@
+{
+  "score":  [ ["boundary_country", null, false, "must"] ],
+  "sort":   [ ["sort_distance"] ],
+  "filter": [ ["boundary_circle"] ]
+}

--- a/query/search_views.json
+++ b/query/search_views.json
@@ -1,0 +1,29 @@
+{
+  "score": [
+    [ "boundary_country", null, false, "must"],
+    [ "ngrams", null, false, "must"],
+
+    ["phrase", null, false, "should"],
+    ["focus", "phrase", true],
+    ["popularity", "phrase", true],
+    ["population", "phrase", true],
+
+    ["address", "housenumber"],
+    ["address", "street"],
+    ["address", "postcode"],
+
+    ["admin", "country"],
+    ["admin", "country_a"],
+    ["admin", "region"],
+    ["admin", "region_a"],
+    ["admin", "county"],
+    ["admin", "localadmin"],
+    ["admin", "locality"],
+    ["admin", "neighbourhood"]
+  ],
+  "filter": [
+    ["boundary_circle"],
+    ["boundary_rect"],
+    ["sources"]
+  ]
+}

--- a/query/views_to_query.js
+++ b/query/views_to_query.js
@@ -1,0 +1,34 @@
+function addViewsToQuery(views, query, viewLib) {
+
+  // Note: 'views' config values below are not sanitized. Api should stop if conf is bad.
+  for(var type in views) { // type = score | filter
+    var viewSet = views[type];
+    for(var i=0; i<viewSet.length; i++) {
+      var params = viewSet[i];
+
+      // parse parameters from an array with the following format:
+      //   [0]=view name, [1]=view's parameter type (string or func)
+      //   [2]=bool to select func in [1], [3]=optional scoring type
+      var viewName = params[0];
+      var param = null, option=null;
+      if(params.length >= 2) {
+	param = params[1];
+      }
+      if(params.length >= 3) {
+        if (param && params[2]) {  // param is name of a function parameter
+          param =  viewLib[param]; // name to function
+	}
+      }
+      if(params.length >= 4) {
+	option = params[3]; // must | should ...
+      }
+      if(param) {
+	query[type]( viewLib[viewName](param), option );
+      } else {
+	query[type]( viewLib[viewName], option );
+      }
+    }
+  }
+}
+
+module.exports = addViewsToQuery;

--- a/query/views_to_query.js
+++ b/query/views_to_query.js
@@ -7,7 +7,7 @@ function addViewsToQuery(views, query, viewLib) {
       var params = viewSet[i];
 
       // parse parameters from an array with the following format:
-      //   [0]=view name, [1]=view's parameter type (string or func)
+      //   [0]=view name, [1]=view's parameter (string or func)
       //   [2]=bool to select func in [1], [3]=optional scoring type
       var viewName = params[0];
       var param = null, option=null;

--- a/test/unit/fixture/search_custom_query.js
+++ b/test/unit/fixture/search_custom_query.js
@@ -1,0 +1,173 @@
+var vs = require('../../../query/search_defaults');
+
+module.exports = {
+  'query': {
+    'filtered': {
+      'query': {
+        'bool': {
+          'must': [{
+            'multi_match': {
+              'query': '123 main st',
+              'analyzer': 'peliasOneEdgeGram',
+              'boost': 1,
+	      'fields': ['name.*']
+            }
+          }],
+          'should': [{
+            'match': {
+              'phrase.default': {
+                'query': '123 main st',
+                'analyzer': 'peliasPhrase',
+                'type': 'phrase',
+                'slop': 2,
+                'boost': 1
+              }
+            }
+          },
+          {
+            'function_score': {
+              'query': {
+                'match': {
+                  'phrase.default': {
+                    'query': '123 main st',
+                    'analyzer': 'peliasPhrase',
+                    'type': 'phrase',
+                    'slop': 2,
+                    'boost': 1
+                  }
+                }
+              },
+              'max_boost': 20,
+              'score_mode': 'first',
+              'boost_mode': 'replace',
+              'functions': [{
+                'field_value_factor': {
+                  'modifier': 'log1p',
+                  'field': 'popularity',
+                  'missing': 1
+                },
+                'weight': 1
+              }]
+            }
+          },{
+            'function_score': {
+              'query': {
+                'match': {
+                  'phrase.default': {
+                    'query': '123 main st',
+                    'analyzer': 'peliasPhrase',
+                    'type': 'phrase',
+                    'slop': 2,
+                    'boost': 1
+                  }
+                }
+              },
+              'max_boost': 20,
+              'score_mode': 'first',
+              'boost_mode': 'replace',
+              'functions': [{
+                'field_value_factor': {
+                  'modifier': 'log1p',
+                  'field': 'population',
+                  'missing': 1
+                },
+                'weight': 2
+              }]
+            }
+          },{
+            'match': {
+              'address_parts.number': {
+                'query': '123',
+                'boost': vs['address:housenumber:boost'],
+                'analyzer': vs['address:housenumber:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'address_parts.street': {
+                'query': 'main st',
+                'boost': vs['address:street:boost'],
+                'analyzer': vs['address:street:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'address_parts.zip': {
+                'query': '10010',
+                'boost': vs['address:postcode:boost'],
+                'analyzer': vs['address:postcode:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.country': {
+                'query': 'new york',
+                'boost': vs['admin:country:boost'],
+                'analyzer': vs['admin:country:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.country_a': {
+                'query': 'USA',
+                'boost': vs['admin:country_a:boost'],
+                'analyzer': vs['admin:country_a:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.region': {
+                'query': 'new york',
+                'boost': vs['admin:region:boost'],
+                'analyzer': vs['admin:region:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.region_a': {
+                'query': 'NY',
+                'boost': vs['admin:region_a:boost'],
+                'analyzer': vs['admin:region_a:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.county': {
+                'query': 'new york',
+                'boost': vs['admin:county:boost'],
+                'analyzer': vs['admin:county:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.localadmin': {
+                'query': 'new york',
+                'boost': vs['admin:localadmin:boost'],
+                'analyzer': vs['admin:localadmin:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.locality': {
+                'query': 'new york',
+                'boost': vs['admin:locality:boost'],
+                'analyzer': vs['admin:locality:analyzer']
+              }
+            }
+          }, {
+            'match': {
+              'parent.neighbourhood': {
+                'query': 'new york',
+                'boost': vs['admin:neighbourhood:boost'],
+                'analyzer': vs['admin:neighbourhood:analyzer']
+              }
+            }
+          }]
+        }
+      }
+    }
+  },
+  'size': 10,
+  'sort': [ '_score' ],
+  'track_scores': true
+};

--- a/test/unit/query/custom_search.js
+++ b/test/unit/query/custom_search.js
@@ -1,0 +1,86 @@
+// test creating a custom query using pelias config file
+var parser = require('../../../helper/text_parser');
+var proxyquire = require('proxyquire');
+
+var customConfig = {
+  generate: function generate() {
+    return {
+      api : {
+	query: {
+	  search: {
+	    defaults: {
+	      'multingram:fields': ['name.*']
+	    },
+	    views: {
+	      score: [
+		['boundary_country', null, false, 'must'],
+		['multingrams', null, false, 'must'], // non-standard part
+
+		['phrase', null, false, 'should'],
+		['focus', 'phrase', true],
+		['popularity', 'phrase', true],
+		['population', 'phrase', true],
+
+		['address', 'housenumber'],
+		['address', 'street'],
+		['address', 'postcode'],
+
+		['admin', 'country'],
+		['admin', 'country_a'],
+		['admin', 'region'],
+		['admin', 'region_a'],
+		['admin', 'county'],
+		['admin', 'localadmin'],
+		['admin', 'locality'],
+		['admin', 'neighbourhood']
+	      ],
+	      filter: [
+		['boundary_circle'],
+		['boundary_rect'],
+		['sources']
+	      ]
+	    }
+	  }
+	}
+      }
+    };
+  }
+};
+
+var generate = proxyquire('../../../query/search',  { 'pelias-config': customConfig });
+
+module.exports.tests = {};
+
+module.exports.tests.interface = function(test, common) {
+  test('valid interface', function(t) {
+    t.equal(typeof generate, 'function', 'valid function');
+    t.end();
+  });
+};
+
+module.exports.tests.query = function(test, common) {
+  test('valid multiphrase query with a full valid address', function(t) {
+    var address = '123 main st new york ny 10010 US';
+    var query = generate({ text: address,
+      layers: [ 'address', 'venue', 'country', 'region', 'county', 'neighbourhood', 'locality', 'localadmin' ],
+      querySize: 10,
+      parsed_text: parser.get_parsed_address(address),
+    });
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/search_custom_query');
+
+    t.deepEqual(compiled, expected, 'valid multiphrase search query');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('custom search query ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -34,6 +34,7 @@ var tests = [
   require('./query/reverse_defaults'),
   require('./query/reverse'),
   require('./query/search'),
+  require('./query/custom_search'),
   require('./sanitiser/_boundary_country'),
   require('./sanitiser/_flag_bool'),
   require('./sanitiser/_geo_common'),


### PR DESCRIPTION
Query is constructed using a simple json format instead of hard coding
the elements across source files. Thanks to this, pelias api instances
can define custom queries defined in the pelias config file.

Current search endpoint is defined below. For the sake of clarity, array items have the following purpose:

 [0]=view name
 [1]=view's parameter (string or func)
 [2]=boolean `true` to select func in [1]
 [3]=optional scoring type

```
{
  "score": [
    [ "phrase_first_tokens_only", null, false, "must"],
    [ "ngrams_last_token_only", null, false, "must"],

    [ "address", "housenumber" ],
    [ "address", "street" ],
    [ "address", "postcode" ],

    ["admin", "country"],
    ["admin", "country_a"],
    ["admin", "region"],
    ["admin", "region_a"],
    ["admin", "county"],
    ["admin", "localadmin"],
    ["admin", "locality"],
    ["admin", "neighbourhood"],

    ["focus_selected_layers", "ngrams_strict", true],
    ["popularity", "ngrams_strict", true],
    ["population", "ngrams_strict", true]
  ]
}
```