### PR TITLE
Fix typo

### DIFF
--- a/sanitiser/_warn_quattroshapes.js
+++ b/sanitiser/_warn_quattroshapes.js
@@ -15,7 +15,7 @@ function sanitize( raw, clean, opts ) {
      'Quattroshapes will be disabled as a data source for Mapzen Search in the next several ' +
      'weeks, and is being replaced by Who\'s on First, an actively maintained data project ' +
      'based on Quattroshapes. Your existing queries WILL CONTINUE TO WORK for the foreseeable ' +
-     'future, but results will be coming from Who\'s on First and `source=quattroshapes` will ' +
+     'future, but results will be coming from Who\'s on First and `sources=quattroshapes` will ' +
      'be deprecated. If you have any questions, please email search@mapzen.com.');
   }
 

--- a/test/ciao/reverse/sources_layers_invalid_combo.coffee
+++ b/test/ciao/reverse/sources_layers_invalid_combo.coffee
@@ -27,7 +27,7 @@ should.exist json.geocoding.errors
 json.geocoding.errors.should.eql [ 'You have specified both the `sources` and `layers` parameters in a combination that will return no results.' ]
 
 #? expected warnings
-json.geocoding.warnings.should.eql [ 'You are using Quattroshapes as a data source in this query. Quattroshapes will be disabled as a data source for Mapzen Search in the next several weeks, and is being replaced by Who\'s on First, an actively maintained data project based on Quattroshapes. Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `source=quattroshapes` will be deprecated. If you have any questions, please email search@mapzen.com.' ]
+json.geocoding.warnings.should.eql [ 'You are using Quattroshapes as a data source in this query. Quattroshapes will be disabled as a data source for Mapzen Search in the next several weeks, and is being replaced by Who\'s on First, an actively maintained data project based on Quattroshapes. Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `sources=quattroshapes` will be deprecated. If you have any questions, please email search@mapzen.com.' ]
 
 #? inputs
 json.geocoding.query['size'].should.eql 10

--- a/test/ciao/search/sources_layers_invalid_combo.coffee
+++ b/test/ciao/search/sources_layers_invalid_combo.coffee
@@ -27,7 +27,7 @@ should.exist json.geocoding.errors
 json.geocoding.errors.should.eql [ 'You have specified both the `sources` and `layers` parameters in a combination that will return no results.' ]
 
 #? expected warnings
-json.geocoding.warnings.should.eql [ 'You are using Quattroshapes as a data source in this query. Quattroshapes will be disabled as a data source for Mapzen Search in the next several weeks, and is being replaced by Who\'s on First, an actively maintained data project based on Quattroshapes. Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `source=quattroshapes` will be deprecated. If you have any questions, please email search@mapzen.com.' ]
+json.geocoding.warnings.should.eql [ 'You are using Quattroshapes as a data source in this query. Quattroshapes will be disabled as a data source for Mapzen Search in the next several weeks, and is being replaced by Who\'s on First, an actively maintained data project based on Quattroshapes. Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `sources=quattroshapes` will be deprecated. If you have any questions, please email search@mapzen.com.' ]
 
 #? inputs
 json.geocoding.query['text'].should.eql 'a'


### PR DESCRIPTION
The parameter name is `sources`, not `source`. We changed this a while ago but I think we're still going to be making this typo for a long time