### PR TITLE
bugfix: enable support for ?sources= filtering on /reverse

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -28,6 +28,9 @@ function generateQuery( clean ){
     vs.var( 'size', clean.querySize);
   }
 
+  // sources
+  vs.var( 'sources', clean.sources);
+
   // focus point to score by distance
   if( check.number(clean['point.lat']) &&
       check.number(clean['point.lon']) ){

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -15,6 +15,7 @@ query.sort( peliasQuery.view.sort_distance );
 
 // non-scoring hard filters
 query.filter( peliasQuery.view.boundary_circle );
+query.filter( peliasQuery.view.sources );
 
 // --------------------------------
 

--- a/query/search.js
+++ b/query/search.js
@@ -51,6 +51,7 @@ function generateQuery( clean ){
   // input text
   vs.var( 'input:name', clean.text );
 
+  // sources
   vs.var( 'sources', clean.sources);
 
   // size

--- a/test/ciao/reverse/layers_alias_address.coffee
+++ b/test/ciao/reverse/layers_alias_address.coffee
@@ -1,0 +1,33 @@
+
+#> layer alias
+path: '/v1/reverse?point.lat=1&point.lon=2&layers=address'
+
+#? 200 ok
+response.statusCode.should.be.equal 200
+response.should.have.header 'charset', 'utf8'
+response.should.have.header 'content-type', 'application/json; charset=utf-8'
+
+#? valid geocoding block
+should.exist json.geocoding
+should.exist json.geocoding.version
+should.exist json.geocoding.attribution
+should.exist json.geocoding.query
+should.exist json.geocoding.engine
+should.exist json.geocoding.engine.name
+should.exist json.geocoding.engine.author
+should.exist json.geocoding.engine.version
+should.exist json.geocoding.timestamp
+
+#? valid geojson
+json.type.should.be.equal 'FeatureCollection'
+json.features.should.be.instanceof Array
+
+#? expected errors
+should.not.exist json.geocoding.errors
+
+#? expected warnings
+should.not.exist json.geocoding.warnings
+
+#? inputs
+json.geocoding.query['size'].should.eql 10
+json.geocoding.query.layers.should.eql ["address"]

--- a/test/unit/fixture/reverse_with_source_filtering.js
+++ b/test/unit/fixture/reverse_with_source_filtering.js
@@ -1,0 +1,51 @@
+var vs = require('../../../query/reverse_defaults');
+
+module.exports = {
+  'query': {
+    'filtered': {
+      'query': {
+        'bool': {
+          'must': []
+        }
+      },
+      'filter': {
+        'bool': {
+          'must': [
+            {
+              'geo_distance': {
+                'distance': '500km',
+                'distance_type': 'plane',
+                'optimize_bbox': 'indexed',
+                '_cache': true,
+                'center_point': {
+                  'lat': 29.49136,
+                  'lon': -82.50622
+                }
+              }
+            },
+            {
+              'terms': {
+                'source': ['test']
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  'sort': [
+    '_score',
+    {
+      '_geo_distance': {
+        'center_point': {
+          'lat': 29.49136,
+          'lon': -82.50622
+        },
+        'order': 'asc',
+        'distance_type': 'plane'
+      }
+    }
+  ],
+  'size': vs.size,
+  'track_scores': true
+};

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -108,6 +108,23 @@ module.exports.tests.query = function(test, common) {
     t.deepEqual(compiled, expected, 'valid reverse query with boundary.country');
     t.end();
   });
+
+  test('valid sources filter', function(t) {
+    var query = generate({
+      'point.lat': 29.49136,
+      'point.lon': -82.50622,
+      'boundary.circle.lat': 29.49136,
+      'boundary.circle.lon': -82.50622,
+      'boundary.circle.radius': 500,
+      'sources': ['test']
+    });
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/reverse_with_source_filtering');
+
+    t.deepEqual(compiled, expected, 'valid reverse query with source filtering');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This PR re-enables `?sources=` filtering for the `/v1/reverse` endpoint.

resolves https://github.com/pelias/api/issues/440