### PR TITLE
Use postcode filter instead of should match

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -22,7 +22,6 @@ query.score( peliasQuery.view.population( peliasQuery.view.phrase ) );
 // address components
 query.score( peliasQuery.view.address('housenumber') );
 query.score( peliasQuery.view.address('street') );
-query.score( peliasQuery.view.address('postcode') );
 
 // admin components
 query.score( peliasQuery.view.admin('country') );
@@ -38,6 +37,7 @@ query.score( peliasQuery.view.admin('neighbourhood') );
 query.filter( peliasQuery.view.boundary_circle );
 query.filter( peliasQuery.view.boundary_rect );
 query.filter( peliasQuery.view.sources );
+query.filter( peliasQuery.view.postcode );
 // --------------------------------
 
 /**

--- a/test/unit/fixture/search_full_address.js
+++ b/test/unit/fixture/search_full_address.js
@@ -93,14 +93,6 @@ module.exports = {
             }
           }, {
             'match': {
-              'address_parts.zip': {
-                'query': '10010',
-                'boost': vs['address:postcode:boost'],
-                'analyzer': vs['address:postcode:analyzer']
-              }
-            }
-          }, {
-            'match': {
               'parent.country': {
                 'query': 'new york',
                 'boost': vs['admin:country:boost'],
@@ -164,6 +156,31 @@ module.exports = {
               }
             }
           }]
+        }
+      },
+      'filter': {
+        'bool': {
+          'must': [
+            {
+              'or': [
+                {
+                  'query': {
+                    'match': {
+                      'address_parts.zip': {
+                        'analyzer': 'peliasZip',
+                        'query': '10010'
+                      }
+                    }
+                  }
+                },
+                {
+                  'missing': {
+                    'field': 'address_parts.zip'
+                  }
+                }
+              ]
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
This filter removes all document that have a mismatching postcode, but
not those that don't have a postcode at all. This fixes queries like
those mentioned in pelias/pelias#286, where a zipcode is given in the
query, but the correct document has no zipcode. The example query from
that issue to try is [440 S Combee Rd, Lakeland, FL 33801](http://pelias.github.io/compare/#/v1/search%3Ftext=440%20S%20Combee%20Rd,%20Lakeland,%20FL%2033801).

There's probably some work still to be done here, as I think a bunch of our other boosts are dependent on the ability to boost postcodes. However, if we apply any boosts to postcodes we are inviting incorrect records to rank higher, simply by virtue of having a postcode. Even leaving the old match query in with this filter would still break things.

In particular, confidence scores should probably be updated so that missing zipcodes don't count against the confidence score (or at least don't count against it as much)