### PR TITLE
Use multi_match query for admin fields

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -3,6 +3,13 @@ var peliasQuery = require('pelias-query'),
     textParser = require('./text_parser'),
     check = require('check-types'),
     geolib = require('geolib');
+var placeTypes = require('../helper/placeTypes');
+
+// region_a is also an admin field. addressit tries to detect
+// region_a, in which case we use a match query specifically for it.
+// but address it doesn't know about all of them so it helps to search
+// against this with the other admin parts as a fallback
+var adminFields = placeTypes.concat(['region_a']);
 
 //------------------------------
 // general-purpose search query
@@ -25,15 +32,12 @@ query.score( peliasQuery.view.address('street') );
 query.score( peliasQuery.view.address('postcode') );
 
 // admin components
-query.score( peliasQuery.view.admin('country') );
+// country_a and region_a are left as matches here because the text-analyzer
+// can sometimes detect them, in which case a query more specific than a
+// multi_match is appropriate.
 query.score( peliasQuery.view.admin('country_a') );
-query.score( peliasQuery.view.admin('region') );
 query.score( peliasQuery.view.admin('region_a') );
-query.score( peliasQuery.view.admin('county') );
-query.score( peliasQuery.view.admin('borough') );
-query.score( peliasQuery.view.admin('localadmin') );
-query.score( peliasQuery.view.admin('locality') );
-query.score( peliasQuery.view.admin('neighbourhood') );
+query.score( peliasQuery.view.admin_multi_match(adminFields), 'peliasAdmin' );
 
 // non-scoring hard filters
 query.filter( peliasQuery.view.boundary_circle );

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -52,23 +52,23 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a',
-  'admin:country_a:boost': 5,
+  'admin:country_a:boost': 1,
 
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country',
-  'admin:country:boost': 4,
+  'admin:country:boost': 1,
 
   'admin:region:analyzer': 'peliasAdmin',
   'admin:region:field': 'parent.region',
-  'admin:region:boost': 3,
+  'admin:region:boost': 1,
 
   'admin:region_a:analyzer': 'peliasAdmin',
   'admin:region_a:field': 'parent.region_a',
-  'admin:region_a:boost': 3,
+  'admin:region_a:boost': 1,
 
   'admin:county:analyzer': 'peliasAdmin',
   'admin:county:field': 'parent.county',
-  'admin:county:boost': 2,
+  'admin:county:boost': 1,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin',

--- a/test/unit/fixture/search_full_address.js
+++ b/test/unit/fixture/search_full_address.js
@@ -118,14 +118,14 @@ module.exports = {
           }, {
             'multi_match': {
                 'fields': [
-                  'parent.country^4',
-                  'parent.region^3',
-                  'parent.county^2',
+                  'parent.country^1',
+                  'parent.region^1',
+                  'parent.county^1',
                   'parent.localadmin^1',
                   'parent.locality^1',
                   'parent.borough^1',
                   'parent.neighbourhood^1',
-                  'parent.region_a^3'
+                  'parent.region_a^1'
                 ],
                 'query': 'new york',
                 'analyzer': 'peliasAdmin'

--- a/test/unit/fixture/search_full_address.js
+++ b/test/unit/fixture/search_full_address.js
@@ -101,26 +101,10 @@ module.exports = {
             }
           }, {
             'match': {
-              'parent.country': {
-                'query': 'new york',
-                'boost': vs['admin:country:boost'],
-                'analyzer': vs['admin:country:analyzer']
-              }
-            }
-          }, {
-            'match': {
               'parent.country_a': {
                 'query': 'USA',
                 'boost': vs['admin:country_a:boost'],
                 'analyzer': vs['admin:country_a:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.region': {
-                'query': 'new york',
-                'boost': vs['admin:region:boost'],
-                'analyzer': vs['admin:region:analyzer']
               }
             }
           }, {
@@ -132,44 +116,19 @@ module.exports = {
               }
             }
           }, {
-            'match': {
-              'parent.county': {
+            'multi_match': {
+                'fields': [
+                  'parent.country^4',
+                  'parent.region^3',
+                  'parent.county^2',
+                  'parent.localadmin^1',
+                  'parent.locality^1',
+                  'parent.borough^1',
+                  'parent.neighbourhood^1',
+                  'parent.region_a^3'
+                ],
                 'query': 'new york',
-                'boost': vs['admin:county:boost'],
-                'analyzer': vs['admin:county:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.borough': {
-                'query': 'new york',
-                'boost': vs['admin:borough:boost'],
-                'analyzer': vs['admin:borough:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.localadmin': {
-                'query': 'new york',
-                'boost': vs['admin:localadmin:boost'],
-                'analyzer': vs['admin:localadmin:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.locality': {
-                'query': 'new york',
-                'boost': vs['admin:locality:boost'],
-                'analyzer': vs['admin:locality:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.neighbourhood': {
-                'query': 'new york',
-                'boost': vs['admin:neighbourhood:boost'],
-                'analyzer': vs['admin:neighbourhood:analyzer']
-              }
+                'analyzer': 'peliasAdmin'
             }
           }]
         }

--- a/test/unit/fixture/search_partial_address.js
+++ b/test/unit/fixture/search_partial_address.js
@@ -75,69 +75,28 @@ module.exports = {
                 'weight': 2
               }]
             }
-          },{
-            'match': {
-              'parent.country': {
-                'query': 'new york',
-                'boost': vs['admin:country:boost'],
-                'analyzer': vs['admin:country:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.region': {
-                'query': 'new york',
-                'boost': vs['admin:region:boost'],
-                'analyzer': vs['admin:region:analyzer']
-              }
-            }
           }, {
             'match': {
               'parent.region_a': {
-                'query': 'new york',
-                'boost': vs['admin:region_a:boost'],
-                'analyzer': vs['admin:region_a:analyzer']
+                'analyzer': 'peliasAdmin',
+                'boost': 3,
+                'query': 'new york'
               }
             }
           }, {
-            'match': {
-              'parent.county': {
+            'multi_match': {
+                'fields': [
+                  'parent.country^4',
+                  'parent.region^3',
+                  'parent.county^2',
+                  'parent.localadmin^1',
+                  'parent.locality^1',
+                  'parent.borough^1',
+                  'parent.neighbourhood^1',
+                  'parent.region_a^3'
+                ],
                 'query': 'new york',
-                'boost': vs['admin:county:boost'],
-                'analyzer': vs['admin:county:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.borough': {
-                'query': 'new york',
-                'boost': vs['admin:borough:boost'],
-                'analyzer': vs['admin:borough:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.localadmin': {
-                'query': 'new york',
-                'boost': vs['admin:localadmin:boost'],
-                'analyzer': vs['admin:localadmin:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.locality': {
-                'query': 'new york',
-                'boost': vs['admin:locality:boost'],
-                'analyzer': vs['admin:locality:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.neighbourhood': {
-                'query': 'new york',
-                'boost': vs['admin:neighbourhood:boost'],
-                'analyzer': vs['admin:neighbourhood:analyzer']
-              }
+                'analyzer': 'peliasAdmin'
             }
           }]
         }

--- a/test/unit/fixture/search_partial_address.js
+++ b/test/unit/fixture/search_partial_address.js
@@ -79,21 +79,21 @@ module.exports = {
             'match': {
               'parent.region_a': {
                 'analyzer': 'peliasAdmin',
-                'boost': 3,
+                'boost': 1,
                 'query': 'new york'
               }
             }
           }, {
             'multi_match': {
                 'fields': [
-                  'parent.country^4',
-                  'parent.region^3',
-                  'parent.county^2',
+                  'parent.country^1',
+                  'parent.region^1',
+                  'parent.county^1',
                   'parent.localadmin^1',
                   'parent.locality^1',
                   'parent.borough^1',
                   'parent.neighbourhood^1',
-                  'parent.region_a^3'
+                  'parent.region_a^1'
                 ],
                 'query': 'new york',
                 'analyzer': 'peliasAdmin'

--- a/test/unit/fixture/search_regions_address.js
+++ b/test/unit/fixture/search_regions_address.js
@@ -93,22 +93,6 @@ module.exports = {
             }
           }, {
             'match': {
-              'parent.country': {
-                'query': 'manhattan',
-                'boost': vs['admin:country:boost'],
-                'analyzer': vs['admin:country:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.region': {
-                'query': 'manhattan',
-                'boost': vs['admin:region:boost'],
-                'analyzer': vs['admin:region:analyzer']
-              }
-            }
-          }, {
-            'match': {
               'parent.region_a': {
                 'query': 'NY',
                 'boost': vs['admin:region_a:boost'],
@@ -116,44 +100,19 @@ module.exports = {
               }
             }
           }, {
-            'match': {
-              'parent.county': {
+            'multi_match': {
+                'fields': [
+                  'parent.country^4',
+                  'parent.region^3',
+                  'parent.county^2',
+                  'parent.localadmin^1',
+                  'parent.locality^1',
+                  'parent.borough^1',
+                  'parent.neighbourhood^1',
+                  'parent.region_a^3'
+                ],
                 'query': 'manhattan',
-                'boost': vs['admin:county:boost'],
-                'analyzer': vs['admin:county:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.borough': {
-                'query': 'manhattan',
-                'boost': vs['admin:borough:boost'],
-                'analyzer': vs['admin:borough:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.localadmin': {
-                'query': 'manhattan',
-                'boost': vs['admin:localadmin:boost'],
-                'analyzer': vs['admin:localadmin:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.locality': {
-                'query': 'manhattan',
-                'boost': vs['admin:locality:boost'],
-                'analyzer': vs['admin:locality:analyzer']
-              }
-            }
-          }, {
-            'match': {
-              'parent.neighbourhood': {
-                'query': 'manhattan',
-                'boost': vs['admin:neighbourhood:boost'],
-                'analyzer': vs['admin:neighbourhood:analyzer']
-              }
+                'analyzer': 'peliasAdmin'
             }
           }]
         }

--- a/test/unit/fixture/search_regions_address.js
+++ b/test/unit/fixture/search_regions_address.js
@@ -102,14 +102,14 @@ module.exports = {
           }, {
             'multi_match': {
                 'fields': [
-                  'parent.country^4',
-                  'parent.region^3',
-                  'parent.county^2',
+                  'parent.country^1',
+                  'parent.region^1',
+                  'parent.county^1',
                   'parent.localadmin^1',
                   'parent.locality^1',
                   'parent.borough^1',
                   'parent.neighbourhood^1',
-                  'parent.region_a^3'
+                  'parent.region_a^1'
                 ],
                 'query': 'manhattan',
                 'analyzer': 'peliasAdmin'


### PR DESCRIPTION
This PR uses the new multi_match view from pelias/model#14 to improve queries that look for POIs or addresses in a given admin area.

It fixes 4 of our acceptance test issues! :tada:

Two are related to pelias/pelias#294:
* Hillside, Santa Clara
* Northwest, Singapore

The other two are related to pelias/pelias#185
* Target, Eureka, CA
* Target, Eureka, California

It also scores exactly the same in all of our fuzzy-tests, which are mostly address related.

However, *please try to come up with queries that break this code*. The code that transforms output from the address parser into the query is actually quite basic. There are almost certainly cases where it doesn't work well. However, major refactorings will probably require improving the text-analyzer module to return a more clearly defined response.

There is also definitely more work to be done tweaking boosts. Currently the best results come from a boost of 1 across the board.

The relevant Elasticsearch docs are here, I'd definitely suggest giving them a a read:

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
https://www.elastic.co/guide/en/elasticsearch/guide/current/multi-match-query.html

Fixes pelias/pelias#294
Fixes pelias/pelias#185
Connected to pelias/model#14