### PR TITLE
Change properties.bounding_box to bbox at top level

### DIFF
--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -333,14 +333,9 @@ module.exports.tests.search = function(test, common) {
             'localadmin_id': '404521211',
             'locality': 'New York',
             'locality_id': '85977539',
-            'bounding_box': {
-              'min_lat': 40.6514712164,
-              'max_lat': 40.6737320588,
-              'min_lon': -73.8967895508,
-              'max_lon': -73.8665771484
-            },
             'label': 'East New York, Brooklyn, NY, USA'
           },
+          'bbox': [-73.8967895508,40.6514712164,-73.8665771484,40.6737320588],
           'geometry': {
             'type': 'Point',
             'coordinates': [


### PR DESCRIPTION
Feature bounding boxes were added under the properties object and had the format of `min_lon`, `min_lat`, `max_lon`, `max_lat`. However it didn't match the geojson specification which calls for the array format with the minimums of each axis first, and maximum last, as follows: [`min_lon`, `min_lat`, `max_lon`, `max_lat`]. According to the spec, this `bbox` property should also reside on the same level as the `type` and `geometry` objects.

Fixes #479