### PR TITLE
increase autocomplete 'phrase:slop' setting from 2->3

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -27,7 +27,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:analyzer': 'peliasPhrase',
   'phrase:field': 'phrase.default',
   'phrase:boost': 1,
-  'phrase:slop': 2,
+  'phrase:slop': 3,
 
   'focus:function': 'linear',
   'focus:offset': '0km',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -10,7 +10,7 @@ module.exports = {
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'boost': 1,
-                'slop': 2,
+                'slop': 3,
                 'query': 'one two'
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -11,7 +11,7 @@ module.exports = {
                   'analyzer': 'peliasPhrase',
                   'type': 'phrase',
                   'boost': 1,
-                  'slop': 2,
+                  'slop': 3,
                   'query': 'one two'
                 }
               }


### PR DESCRIPTION
this PR resolves https://github.com/pelias/pelias/issues/307

by increasing the phrase slop from 2->3 we are able to successfully match "52 Görlitzer Straße" with "Görlitzer Straße 52".

I will add integration tests in another PR against schema, the value of 3 was confirmed with the following test case (2 fails but 3 passes):

```javascript
// test the minimum amount of slop required to retrieve documents
module.exports.tests.slop = function(test, common){
  test( 'slop', function(t){

    var suite = new elastictest.Suite( null, { schema: schema } );
    suite.action( function( done ){ setTimeout( done, 500 ); }); // wait for es to bring some shards up

    // index a document
    suite.action( function( done ){
      suite.client.index({
        index: suite.props.index,
        type: 'test',
        id: '1',
        body: { name: { default: '52 Görlitzer Straße' } }
      }, done);
    });

    // search using 'peliasQueryFullToken'
    // in this case we require a slop of 3 to return the same
    // record with the street number and street name reversed.
    // (as is common in European countries, such as Germany).
    suite.assert( function( done ){
      suite.client.search({
        index: suite.props.index,
        type: 'test',
        body: { query: { match: {
          'name.default': {
            'analyzer': 'peliasQueryFullToken',
            'query': 'Görlitzer Straße 52',
            'type': 'phrase',
            'slop': 3,
          }
        }}}
      }, function( err, res ){
        t.equal( err, undefined );
        t.equal( res.hits.total, 1, 'document found' );
        done();
      });
    });

    suite.run( t.end );
  });
};
```

closes https://github.com/pelias/pelias/issues/307