### PR TITLE
Handle fatal errors in unit tests

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+node test/unit/run.js | ./node_modules/.bin/tap-dot

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "npm run unit",
-    "unit": "node test/unit/run.js | tap-dot",
+    "unit": "./bin/units",
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nspCLI.js audit-shrinkwrap; rm npm-shrinkwrap.json;",


### PR DESCRIPTION
Due to the way our unit tests are run, a fatal error in the API code
that causes the node process to quit with an error will not be picked up
by `tap-dot`, and the unit tests will still return a passing status
code. This is due to the way status codes from pipes are handled by
default.

Fortunately, there is an ["unofficial bash strict mode"](http://redsymbol.net/articles/unofficial-bash-strict-mode/)
that helps fix this sort of thing, and by running our unit tests with a
few tweaks we can ensure that any failure in the unit tests is captured.