### PR TITLE
Fix timeout error handling

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 var service = { search: require('../service/search') };
 var logger = require('pelias-logger').get('api:controller:search');
 
@@ -36,7 +38,11 @@ function setup( backend, query ){
 
       // error handler
       if( err ){
-        req.errors.push( err );
+        if (_.isObject(err) && err.message) {
+          req.errors.push( err.message );
+        } else {
+          req.errors.push( err );
+        }
       }
       // set response data
       else {

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -123,6 +123,21 @@ module.exports.tests.functional_failure = function(test, common) {
   });
 };
 
+module.exports.tests.timeout = function(test, common) {
+  test('timeout', function(t) {
+    var backend = mockBackend( 'client/search/timeout/1', function( cmd ){
+      t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias', searchType: 'dfs_query_then_fetch' }, 'correct backend command');
+    });
+    var controller = setup( backend, mockQuery() );
+    var req = { clean: { a: 'b' }, errors: [], warnings: [] };
+    var next = function(){
+      t.equal(req.errors[0],'Request Timeout after 5000ms');
+      t.end();
+    };
+    controller(req, undefined, next );
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/unit/mock/backend.js
+++ b/test/unit/mock/backend.js
@@ -33,6 +33,14 @@ responses['client/search/fail/1'] = function( cmd, cb ){
   return cb( 'a backend error occurred' );
 };
 
+responses['client/search/timeout/1'] = function( cmd, cb) {
+  // timeout errors are objects
+  return cb({
+    status: 408,
+    message: 'Request Timeout after 5000ms'
+  });
+};
+
 responses['client/mget/ok/1'] = function( cmd, cb ){
   return cb( undefined, mgetEnvelope([{
     _id: 'myid1',


### PR DESCRIPTION
Timeout errors come back from the Elasticsearch module as Error objects,
so instead of pushing the entire object onto the errors array, we should
just push the message.

I'm not sure if there are other cases where errors are just strings,
errors that aren't objects with a message property are handled as
before.