### PR TITLE
Use new express sendStatus method

### DIFF
--- a/middleware/options.js
+++ b/middleware/options.js
@@ -9,7 +9,7 @@
 
 function middleware(req, res, next){
   if( req.method === 'OPTIONS' ){
-    res.send(200);
+    res.sendStatus(200);
   } else {
     next();
   }


### PR DESCRIPTION
According to a message on the console:

```
express deprecated res.send(status): Use res.sendStatus(status) instead
middleware/options.js:12:9
```