### PR TITLE
Change macrocountry to macrocounty, add macroregion

### DIFF
--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -48,7 +48,7 @@ var LAYERS_BY_SOURCE = {
  openstreetmap: [ 'address', 'venue' ],
  openaddresses: [ 'address' ],
  geonames: [ 'country', 'region', 'county', 'locality', 'venue' ],
- whosonfirst: [ 'continent', 'country', 'dependency', 'region',
+ whosonfirst: [ 'continent', 'country', 'dependency', 'macroregion', 'region',
    'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood', 'microhood', 'disputed']
 };
 

--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -48,8 +48,8 @@ var LAYERS_BY_SOURCE = {
  openstreetmap: [ 'address', 'venue' ],
  openaddresses: [ 'address' ],
  geonames: [ 'country', 'region', 'county', 'locality', 'venue' ],
- whosonfirst: [ 'continent', 'macrocountry', 'country', 'dependency', 'region',
-   'locality', 'localadmin', 'county', 'macrohood', 'neighbourhood', 'microhood', 'disputed']
+ whosonfirst: [ 'continent', 'country', 'dependency', 'region',
+   'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood', 'microhood', 'disputed']
 };
 
 /*

--- a/test/ciao/autocomplete/layers_alias_coarse.coffee
+++ b/test/ciao/autocomplete/layers_alias_coarse.coffee
@@ -34,6 +34,7 @@ json.geocoding.query['size'].should.eql 10
 json.geocoding.query.layers.should.eql [ "continent",
   "country",
   "dependency",
+  "macroregion",
   "region",
   "locality",
   "localadmin",

--- a/test/ciao/autocomplete/layers_alias_coarse.coffee
+++ b/test/ciao/autocomplete/layers_alias_coarse.coffee
@@ -32,12 +32,12 @@ should.not.exist json.geocoding.warnings
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.layers.should.eql [ "continent",
-  "macrocountry",
   "country",
   "dependency",
   "region",
   "locality",
   "localadmin",
+  "macrocounty",
   "county",
   "macrohood",
   "neighbourhood",

--- a/test/ciao/autocomplete/layers_invalid.coffee
+++ b/test/ciao/autocomplete/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,macroregion,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/autocomplete/layers_invalid.coffee
+++ b/test/ciao/autocomplete/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocountry,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/autocomplete/layers_mix_invalid_valid.coffee
+++ b/test/ciao/autocomplete/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,macroregion,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/autocomplete/layers_mix_invalid_valid.coffee
+++ b/test/ciao/autocomplete/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocountry,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/layers_alias_coarse.coffee
+++ b/test/ciao/reverse/layers_alias_coarse.coffee
@@ -31,7 +31,7 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.layers.should.eql [ "continent",
-  "macrocountry",
+  "macrocounty",
   "country",
   "dependency",
   "region",

--- a/test/ciao/reverse/layers_alias_coarse.coffee
+++ b/test/ciao/reverse/layers_alias_coarse.coffee
@@ -31,12 +31,13 @@ should.not.exist json.geocoding.warnings
 #? inputs
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.layers.should.eql [ "continent",
-  "macrocounty",
   "country",
   "dependency",
+  "macroregion",
   "region",
   "locality",
   "localadmin",
+  "macrocounty",
   "county",
   "macrohood",
   "neighbourhood",

--- a/test/ciao/reverse/layers_invalid.coffee
+++ b/test/ciao/reverse/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,macroregion,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/layers_invalid.coffee
+++ b/test/ciao/reverse/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocountry,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/layers_mix_invalid_valid.coffee
+++ b/test/ciao/reverse/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,macroregion,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/layers_mix_invalid_valid.coffee
+++ b/test/ciao/reverse/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocountry,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/layers_alias_coarse.coffee
+++ b/test/ciao/search/layers_alias_coarse.coffee
@@ -34,6 +34,7 @@ json.geocoding.query['size'].should.eql 10
 json.geocoding.query.layers.should.eql [ "continent",
   "country",
   "dependency",
+  "macroregion",
   "region",
   "locality",
   "localadmin",

--- a/test/ciao/search/layers_alias_coarse.coffee
+++ b/test/ciao/search/layers_alias_coarse.coffee
@@ -32,12 +32,12 @@ should.not.exist json.geocoding.warnings
 json.geocoding.query['text'].should.eql 'a'
 json.geocoding.query['size'].should.eql 10
 json.geocoding.query.layers.should.eql [ "continent",
-  "macrocountry",
   "country",
   "dependency",
   "region",
   "locality",
   "localadmin",
+  "macrocounty",
   "county",
   "macrohood",
   "neighbourhood",

--- a/test/ciao/search/layers_invalid.coffee
+++ b/test/ciao/search/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,macroregion,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/layers_invalid.coffee
+++ b/test/ciao/search/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocountry,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/layers_mix_invalid_valid.coffee
+++ b/test/ciao/search/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,macroregion,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/layers_mix_invalid_valid.coffee
+++ b/test/ciao/search/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocountry,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,country,region,county,locality,continent,macrocounty,dependency,localadmin,macrohood,neighbourhood,microhood,disputed' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/unit/helper/type_mapping.js
+++ b/test/unit/helper/type_mapping.js
@@ -12,7 +12,7 @@ module.exports.tests.interfaces = function(test, common) {
 
   test('alias layer mapping', function(t) {
     t.deepEquals(type_mapping.layer_mapping.coarse,
-                 [ 'continent', 'country', 'dependency',
+                 [ 'continent', 'country', 'dependency', 'macroregion',
                    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood',
                    'neighbourhood', 'microhood', 'disputed' ]);
     t.end();

--- a/test/unit/helper/type_mapping.js
+++ b/test/unit/helper/type_mapping.js
@@ -12,8 +12,8 @@ module.exports.tests.interfaces = function(test, common) {
 
   test('alias layer mapping', function(t) {
     t.deepEquals(type_mapping.layer_mapping.coarse,
-                 [ 'continent', 'macrocountry', 'country', 'dependency',
-                   'region', 'locality', 'localadmin', 'county', 'macrohood',
+                 [ 'continent', 'country', 'dependency',
+                   'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood',
                    'neighbourhood', 'microhood', 'disputed' ]);
     t.end();
   });

--- a/test/unit/sanitiser/_layers.js
+++ b/test/unit/sanitiser/_layers.js
@@ -41,8 +41,8 @@ module.exports.tests.sanitize_layers = function(test, common) {
 
     sanitize(raw, clean);
 
-    var admin_layers = [ 'continent', 'macrocountry', 'country', 'dependency',
-    'region', 'locality', 'localadmin', 'county', 'macrohood', 'neighbourhood',
+    var admin_layers = [ 'continent', 'country', 'dependency',
+    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood',
     'microhood', 'disputed' ];
 
     t.deepEqual(clean.layers, admin_layers, 'coarse layers set');
@@ -76,8 +76,8 @@ module.exports.tests.sanitize_layers = function(test, common) {
 
     sanitize(raw, clean);
 
-    var expected_layers = [ 'continent', 'macrocountry', 'country', 'dependency',
-    'region', 'locality', 'localadmin', 'county', 'macrohood', 'neighbourhood',
+    var expected_layers = [ 'continent', 'country', 'dependency',
+    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood',
     'microhood', 'disputed' ];
 
     t.deepEqual(clean.layers, expected_layers, 'coarse + regular layers set');
@@ -112,9 +112,9 @@ module.exports.tests.sanitize_layers = function(test, common) {
 
     sanitize(raw, clean);
 
-    var coarse_layers = [ 'continent', 'macrocountry',
+    var coarse_layers = [ 'continent',
       'country', 'dependency', 'region', 'locality', 'localadmin',
-      'county', 'macrohood', 'neighbourhood', 'microhood',
+      'macrocounty', 'county', 'macrohood', 'neighbourhood', 'microhood',
       'disputed' ];
 
     var venue_layers = [ 'venue' ];

--- a/test/unit/sanitiser/_layers.js
+++ b/test/unit/sanitiser/_layers.js
@@ -42,7 +42,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
     sanitize(raw, clean);
 
     var admin_layers = [ 'continent', 'country', 'dependency',
-    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood',
+    'macroregion', 'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood',
     'microhood', 'disputed' ];
 
     t.deepEqual(clean.layers, admin_layers, 'coarse layers set');
@@ -77,7 +77,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
     sanitize(raw, clean);
 
     var expected_layers = [ 'continent', 'country', 'dependency',
-    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood',
+    'macroregion', 'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'neighbourhood',
     'microhood', 'disputed' ];
 
     t.deepEqual(clean.layers, expected_layers, 'coarse + regular layers set');
@@ -113,7 +113,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
     sanitize(raw, clean);
 
     var coarse_layers = [ 'continent',
-      'country', 'dependency', 'region', 'locality', 'localadmin',
+      'country', 'dependency', 'macroregion', 'region', 'locality', 'localadmin',
       'macrocounty', 'county', 'macrohood', 'neighbourhood', 'microhood',
       'disputed' ];
 


### PR DESCRIPTION
Fixed #495 

`macrocounty` was misspelled as `macrocountry` so it was impossible specify `layers=macrocounty`.  `macroregion` was missing, so this PR adds it.