### PR TITLE
Configurable label schemas

### DIFF
--- a/helper/labelSchema.js
+++ b/helper/labelSchema.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
+var api = require('pelias-config').generate().api;
 
-module.exports = {
+var schemas = {
   'default': {
     'local': getFirstProperty(['locality', 'localadmin']),
     'country': getFirstProperty(['country'])
@@ -22,6 +23,20 @@ module.exports = {
     'country': getFirstProperty(['country'])
   }
 };
+
+if (api && api.localization && api.localization.labelSchemas) {
+  var imported = api.localization.labelSchemas;
+
+  for (var country in imported) {
+    var schema = imported[country];
+    for (var key in schema) { // convert to the convention above
+      schema[key] = getFirstProperty(schema[key]); // param array to func
+    }
+    schemas[country] = schema;
+  }
+}
+
+module.exports = schemas;
 
 // find the first field of record that has a non-empty value that's not already in labelParts
 function getFirstProperty(fields) {

--- a/test/unit/helper/labelSchema.js
+++ b/test/unit/helper/labelSchema.js
@@ -19,7 +19,6 @@ module.exports.tests.supported_countries = function(test, common) {
     t.notEquals(supported_countries.indexOf('CAN'), -1);
     t.notEquals(supported_countries.indexOf('GBR'), -1);
     t.notEquals(supported_countries.indexOf('default'), -1);
-    t.equals(supported_countries.length, 4);
 
     t.equals(Object.keys(schemas.USA).length, 4);
     t.equals(Object.keys(schemas.CAN).length, 3);


### PR DESCRIPTION
Additional label schemas can now be defined in pelias config.  For example:
```
{
  "api" : {
    "localization" : {
      "labelSchemas": {
        "FIN": {
          "local": ["locality", "region"],
          "country": ["country"]
        }
      }
    }
  }
}
```