### PR TITLE
fixed extraneous comma labels for results with only a `name`

### DIFF
--- a/helper/labelGenerator.js
+++ b/helper/labelGenerator.js
@@ -16,18 +16,27 @@ module.exports = function( record ){
   // retain only things that are truthy
   labelParts = _.compact(labelParts);
 
-  // first, dedupe the name and 1st label array elements
-  //  this is used to ensure that the `name` and first admin hierarchy elements aren't repeated
-  //  eg - `["Lancaster", "Lancaster", "PA", "United States"]` -> `["Lancaster", "PA", "United States"]`
-  var dedupedNameAndFirstLabelElement = _.uniq([labelParts.shift(), labelParts.shift()]);
-
-  // second, unshift the deduped parts back onto the labelParts
-  labelParts.unshift.apply(labelParts, dedupedNameAndFirstLabelElement);
-
-  // third, join with a comma and return
-  return labelParts.join(', ');
+  // third, dedupe and join with a comma and return
+  return dedupeNameAndFirstLabelElement(labelParts).join(', ');
 
 };
+
+function dedupeNameAndFirstLabelElement(labelParts) {
+  // only dedupe if a result has more than a name (the first label part)
+  if (labelParts.length > 1) {
+    // first, dedupe the name and 1st label array elements
+    //  this is used to ensure that the `name` and first admin hierarchy elements aren't repeated
+    //  eg - `["Lancaster", "Lancaster", "PA", "United States"]` -> `["Lancaster", "PA", "United States"]`
+    var deduped = _.uniq([labelParts.shift(), labelParts.shift()]);
+
+    // second, unshift the deduped parts back onto the labelParts
+    labelParts.unshift.apply(labelParts, deduped);
+
+  }
+
+  return labelParts;
+
+}
 
 function getSchema(country_a) {
   if (country_a && country_a.length && schemas[country_a]) {

--- a/test/unit/helper/labelGenerator_examples.js
+++ b/test/unit/helper/labelGenerator_examples.js
@@ -104,6 +104,17 @@ module.exports.tests.france = function(test, common) {
 
 };
 
+module.exports.tests.name_only = function(test, common) {
+  test('name-only results (no admin fields) should not include extraneous comma', function(t) {
+    var doc = {
+      'name': 'Result name',
+    };
+    t.equal(generator(doc),'Result name');
+    t.end();
+  });
+
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {


### PR DESCRIPTION
Fixed #516 

This fixes geonames records like "Northern Europe" where there are no admin fields, just a name.  The old code was introducing a null due to how parts of the label were deduped.