### PR TITLE
Remove unused engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "engines": {
     "node": ">=0.10.26",
-    "npm": ">=1.4.3",
-    "elasticsearch": ">=1.2.1"
+    "npm": ">=1.4.3"
   },
   "dependencies": {
     "async": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "url": "https://github.com/pelias/api/issues"
   },
   "engines": {
-    "node": ">=0.10.26",
-    "npm": ">=1.4.3"
+    "node": ">=0.10.26"
   },
   "dependencies": {
     "async": "^1.5.2",


### PR DESCRIPTION
According to the NPM docs on [engine](https://docs.npmjs.com/files/package.json#engines),
putting NPM versions in engines was only ever advisory, and is now deprecated. It
seems to cause NPM to pull in a very old version of NPM, which causes
warnings when installing dependencies.

Putting an Elasticsearch version in engines never did anything to enforce an Elasticsearch version at all. We do that with pelias-config and the apiVersion setting.