### PR TITLE
Lower default reverse search radius, add a bigger radius for coarse reverse

### DIFF
--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -12,7 +12,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'sort:distance:order': 'asc',
   'sort:distance:distance_type': 'plane',
 
-  'boundary:circle:radius': '500km',
+  'boundary:circle:radius': '1km',
   'boundary:circle:distance_type': 'plane',
   'boundary:circle:optimize_bbox': 'indexed',
   'boundary:circle:_cache': true,

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -13,6 +13,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'sort:distance:distance_type': 'plane',
 
   'boundary:circle:radius': '1km',
+  'boundary:circle:radius:coarse': '500km',
   'boundary:circle:distance_type': 'plane',
   'boundary:circle:optimize_bbox': 'indexed',
   'boundary:circle:_cache': true,

--- a/sanitiser/_geo_reverse.js
+++ b/sanitiser/_geo_reverse.js
@@ -29,7 +29,12 @@ module.exports = function sanitize( raw, clean ){
 
     // if no radius was passed, set the default
     if ( _.isUndefined( raw['boundary.circle.radius'] ) ) {
-      raw['boundary.circle.radius'] = defaults['boundary:circle:radius'];
+      // the default is small unless layers other than venue or address were explicitly specified
+      if (clean.layers && clean.layers.length > 0 && !_.includes(clean.layers, 'venue') && !_.includes(clean.layers, 'address')) {
+        raw['boundary.circle.radius'] = defaults['boundary:circle:radius:coarse'];
+      } else {
+        raw['boundary.circle.radius'] = defaults['boundary:circle:radius'];
+      }
     }
 
     // santize the boundary.circle

--- a/sanitiser/_geo_reverse.js
+++ b/sanitiser/_geo_reverse.js
@@ -1,4 +1,3 @@
-
 var geo_common = require ('./_geo_common');
 var _ = require('lodash');
 var defaults = require('../query/reverse_defaults');

--- a/test/unit/sanitiser/_geo_reverse.js
+++ b/test/unit/sanitiser/_geo_reverse.js
@@ -72,7 +72,7 @@ module.exports.tests.sanitize_boundary_country = function(test, common) {
     t.end();
   });
 
-  test('no boundary.circle.radius supplied should be set to default', function(t) {
+  test('no boundary.circle.radius and no layers supplied should be set to default', function(t) {
     var raw = {
       'point.lat': '12.121212',
       'point.lon': '21.212121'

--- a/test/unit/sanitiser/_geo_reverse.js
+++ b/test/unit/sanitiser/_geo_reverse.js
@@ -85,6 +85,32 @@ module.exports.tests.sanitize_boundary_country = function(test, common) {
     t.end();
   });
 
+  test('no boundary.circle.radius and coarse layers supplied should be set to coarse default', function(t) {
+    var raw = {
+      'point.lat': '12.121212',
+      'point.lon': '21.212121'
+    };
+    var clean = { layers: 'coarse' };
+    var errorsAndWarnings = sanitize(raw, clean);
+
+    t.equals(raw['boundary.circle.radius'], defaults['boundary:circle:radius:coarse'], 'should be from defaults');
+    t.equals(clean['boundary.circle.radius'], parseFloat(defaults['boundary:circle:radius:coarse']), 'should be same as raw');
+    t.end();
+  });
+
+  test('no boundary.circle.radius and coarse layer supplied should be set to coarse default', function(t) {
+    var raw = {
+      'point.lat': '12.121212',
+      'point.lon': '21.212121'
+    };
+    var clean = { layers: 'locality' };
+    var errorsAndWarnings = sanitize(raw, clean);
+
+    t.equals(raw['boundary.circle.radius'], defaults['boundary:circle:radius:coarse'], 'should be from defaults');
+    t.equals(clean['boundary.circle.radius'], parseFloat(defaults['boundary:circle:radius:coarse']), 'should be same as raw');
+    t.end();
+  });
+
   test('explicit boundary.circle.radius should be used instead of default', function(t) {
     var raw = {
       'point.lat': '12.121212',

--- a/test/unit/sanitiser/_geo_reverse.js
+++ b/test/unit/sanitiser/_geo_reverse.js
@@ -83,7 +83,6 @@ module.exports.tests.sanitize_boundary_country = function(test, common) {
     t.equals(raw['boundary.circle.radius'], defaults['boundary:circle:radius'], 'should be from defaults');
     t.equals(clean['boundary.circle.radius'], parseFloat(defaults['boundary:circle:radius']), 'should be same as raw');
     t.end();
-
   });
 
   test('explicit boundary.circle.radius should be used instead of default', function(t) {
@@ -98,9 +97,7 @@ module.exports.tests.sanitize_boundary_country = function(test, common) {
     t.equals(raw['boundary.circle.radius'], '3248732857km', 'should be parsed float');
     t.equals(clean['boundary.circle.radius'], 3248732857.0, 'should be copied from raw');
     t.end();
-
   });
-
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Defaulting to 500km for the reverse search radius means lots of records will often be searched, when we only care about the nearest ones. This PR reduces that radius to 1km (it's a bit more difficult to specify different units in the two defaults, but 1km is still quite performant).

It also adds a second default, for when any coarse layer was manually specified. This remains at 500km.

Fixes pelias/pelias#340

