### PR TITLE
Redirect to /v1 if no legacy proxy specified

### DIFF
--- a/routes/legacy.js
+++ b/routes/legacy.js
@@ -4,8 +4,8 @@ function addRoutes(app, peliasConfig) {
   var sendToLegacy;
 
   if (!peliasConfig.hasOwnProperty('legacyUrl')) {
-    sendToLegacy = function doNothing(req, res, next) {
-      next(new Error('Invalid path, no legacy proxy specified'));
+    sendToLegacy = function redirectToV1(req, res, next) {
+      res.redirect(301, '/v1');
     };
   }
   else {


### PR DESCRIPTION
For when we have multiple active API versions, we have code to redirect
from one running API server to another. Right now, we've disabled the
beta/legacy API server and haven't released a V2 yet, so we currently
have no proxying configured.

Right now the default with no configuration is to simply return an
error. However that means that request to http://search.mapzen.com/
return that unfriendly error. We have a nice friendly /v1 page, so in
the case of no proxy being set up, it makes sense to redirect to that.

Fixes #511 