### PR TITLE
Sort by confidence score

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -39,6 +39,8 @@ function computeScores(req, res, next) {
   // loop through data items and determine confidence scores
   res.data = res.data.map(computeConfidenceScore.bind(null, req, mean, stdev));
 
+  res.data.sort(function(a, b) { return(b.confidence - a.confidence); });
+
   next();
 }
 

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -76,7 +76,7 @@ module.exports.tests.confidenceScore = function(test, common) {
           county: ['city1']
         }
       }, {
-        _score: 20,
+        _score: 5,
         value: 2,
         center_point: { lat: 100.2, lon: -51.5 },
         name: { default: 'test name2' },
@@ -94,6 +94,29 @@ module.exports.tests.confidenceScore = function(test, common) {
     t.end();
   });
 
+  test('sort results by confidence score', function(t) {
+    var req = {
+      clean: { text: 'rank me first' }
+    };
+    var res = {
+      data: [{
+	_score: 10,
+	value: 1,
+	center_point: { lat: 100.1, lon: -50.5 },
+	name: { default: 'rank me second' },
+      }, {
+	_score: 10, // force equal score before conf.scoring
+	value: 2,
+	center_point: { lat: 100.2, lon: -51.5 },
+	name: { default: 'rank me first' }, // better match here
+      }],
+      meta: {scores: [10]}
+    };
+
+    confidenceScore(req, res, function() {});
+    t.equal(res.data[0].name.default, 'rank me first', 'results are sorted by confidence score');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Geocoding result array is now sorted by confidence score. A unit test included, plus a fix to another unit test, where wrong order was assumed.