### PR TITLE
fix: Explicitly depend on packages' optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,10 @@
     "nsp": "^2.2.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^1.7.7",
+    "source-map": "^0.5.6",
     "tap-dot": "1.0.5",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "uglify-js": "^2.6.2"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
[istanbul](https://www.npmjs.com/package/istanbul) and
[escodegen](https://www.npmjs.com/package/escodegen) have optional
dependencies, which for some reason `npm ls` in npm version 3 fails to
handle properly. We don't need these packages, but installing them does
little harm so it seems to be the best way to make our precommit-hook
scripts pass for all users.