### PR TITLE
Do not consider absence of an additional name as a difference

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -51,10 +51,10 @@ function isDifferent(item1, item2) {
 
     if (item1.hasOwnProperty('name') && item2.hasOwnProperty('name')) {
       for (var lang in item1.name) {
-	if(item2.name[lang] || lang === 'default') {
-	  // do not consider absence of an additional name as a difference
-	  propMatch(item1.name, item2.name, lang);
-	}
+        if(item2.name[lang] || lang === 'default') {
+          // do not consider absence of an additional name as a difference
+          propMatch(item1.name, item2.name, lang);
+        }
       }
     }
     else {

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -51,7 +51,10 @@ function isDifferent(item1, item2) {
 
     if (item1.hasOwnProperty('name') && item2.hasOwnProperty('name')) {
       for (var lang in item1.name) {
-	propMatch(item1.name, item2.name, lang);
+	if(item2.name[lang] || lang === 'default') {
+	  // do not consider absence of an additional name as a difference
+	  propMatch(item1.name, item2.name, lang);
+	}
       }
     }
     else {

--- a/test/unit/fixture/dedupe_elasticsearch_results.js
+++ b/test/unit/fixture/dedupe_elasticsearch_results.js
@@ -80,6 +80,34 @@ module.exports = [
     '_score': 1.2367082,
     'confidence': 0.879
   },
+  { // same as #1, but with an additional name
+    'center_point': {
+      'lon': -76.207456,
+      'lat': 40.039265
+    },
+    'address_parts': {},
+    'parent': {
+      'localadmin': ['East Lampeter'],
+      'region_a': ['PA'],
+      'region': ['Pennsylvania'],
+      'locality': ['Smoketown'],
+      'country_a': ['USA'],
+      'county': ['Lancaster County'],
+      'country': ['United States'],
+      'neighbourhood': ['Greenland']
+    },
+    'name': {
+      'default': 'East Lampeter High School',
+      'alt': 'High School of East Lampeter',
+    },
+    'category': [
+      'education'
+    ],
+    '_id': '357321757',
+    '_type': 'venue',
+    '_score': 1.2367082,
+    'confidence': 0.879
+  },
   {
     'center_point': {
       'lon': -76.207456,


### PR DESCRIPTION
OSM data includes two almost identical 'Keskustori, Tampere' entries.
The second one does not have additional 'name.ru' property. This is
no longer considered as a difference in deduping.