### PR TITLE
Focus offset minimum

### DIFF
--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -31,7 +31,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:slop': 2,
 
   'focus:function': 'linear',
-  'focus:offset': '1km',
+  'focus:offset': '0km',
   'focus:scale': '50km',
   'focus:decay': 0.5,
   'focus:weight': 2,

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -30,7 +30,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:slop': 2,
 
   'focus:function': 'linear',
-  'focus:offset': '1km',
+  'focus:offset': '0km',
   'focus:scale': '50km',
   'focus:decay': 0.5,
   'focus:weight': 2,

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -43,7 +43,7 @@ module.exports = {
                       'lat': 29.49136,
                       'lon': -82.50622
                     },
-                    'offset': '1km',
+                    'offset': '0km',
                     'scale': '50km',
                     'decay': 0.5
                   }

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -43,7 +43,7 @@ module.exports = {
                       'lat': 29.49136,
                       'lon': -82.50622
                     },
-                    'offset': '1km',
+                    'offset': '0km',
                     'scale': '50km',
                     'decay': 0.5
                   }

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -43,7 +43,7 @@ module.exports = {
                       'lat': 0,
                       'lon': 0
                     },
-                    'offset': '1km',
+                    'offset': '0km',
                     'scale': '50km',
                     'decay': 0.5
                   }

--- a/test/unit/fixture/search_linguistic_viewport.js
+++ b/test/unit/fixture/search_linguistic_viewport.js
@@ -48,7 +48,7 @@ module.exports = {
                           'lat': 29.49136,
                           'lon': -82.50622
                         },
-                        'offset': '1km',
+                        'offset': '0km',
                         'scale': '50km',
                         'decay': 0.5
                       }

--- a/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
+++ b/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
@@ -48,7 +48,7 @@ module.exports = {
                           'lat': 28.49136,
                           'lon': -87.50623
                         },
-                        'offset': '1km',
+                        'offset': '0km',
                         'scale': '1km',
                         'decay': 0.5
                       }


### PR DESCRIPTION
Set all `focus.offset` values to a minimum of `0km` instead of `1km`.

This was a bug and an oversight, the `/autocomplete` behavior was set to `0km` but wasn't changed for `/search` or `/reverse`.

The effect of this was scoring all matching documents within 1km of the `focus.point` with the same score!

This should make some of the intermittent test failures settle down a bit and will give much better scoring for results within 1km of the target.