### PR TITLE
Short sources gid

### DIFF
--- a/sanitiser/_ids.js
+++ b/sanitiser/_ids.js
@@ -44,13 +44,9 @@ function sanitizeId(rawId, messages) {
     messages.errors.push( targetError(layer, type_mapping.layers) );
     return;
   }
-  //converts the shortened source names to the full name
-  if(source !== type_mapping.source_mapping[source]){
-    source = type_mapping.source_mapping[source][0];
-  }
 
   return {
-    source: source,
+    source: type_mapping.source_mapping[source][0],
     layer: layer,
     id: id,
   };

--- a/sanitiser/_ids.js
+++ b/sanitiser/_ids.js
@@ -34,15 +34,19 @@ function sanitizeId(rawId, messages) {
     messages.errors.push( formatError(rawId) );
     return;
   }
-
-  if (!_.includes(type_mapping.sources, source)) {
-    messages.errors.push( targetError(source, type_mapping.sources) );
+  var valid_values = Object.keys(type_mapping.source_mapping);
+  if (!_.includes(valid_values, source)) {
+    messages.errors.push( targetError(source, valid_values) );
     return;
   }
 
   if (!_.includes(type_mapping.layers, layer)) {
     messages.errors.push( targetError(layer, type_mapping.layers) );
     return;
+  }
+  //converts the shortened source names to the full name
+  if(source !== type_mapping.source_mapping[source]){
+    source = type_mapping.source_mapping[source][0];
   }
 
   return {

--- a/test/unit/sanitiser/_ids.js
+++ b/test/unit/sanitiser/_ids.js
@@ -69,7 +69,8 @@ module.exports.tests.invalid_ids = function(test, common) {
   test('invalid id: source name invalid', function(t) {
     var raw = { ids: 'invalidsource:venue:23' };
     var clean = {};
-    var expected_error = 'invalidsource is invalid. It must be one of these values - [' + type_mapping.sources.join(', ') + ']';
+    var expected_error = 'invalidsource is invalid. It must be one of these values - [' +
+      Object.keys(type_mapping.source_mapping).join(', ') + ']';
 
     var messages = sanitize(raw, clean);
 
@@ -107,8 +108,40 @@ module.exports.tests.valid_ids = function(test, common) {
     t.end();
   });
 
+test('ids: valid short input (openaddresses)', function(t) {
+    var raw = { ids: 'oa:address:20' };
+    var clean = {};
+
+    var messages = sanitize( raw, clean );
+
+    var expected_ids = [{
+      source: 'openaddresses',
+      layer: 'address',
+      id: '20',
+    }];
+    t.deepEqual( messages.errors, [], ' no errors');
+    t.deepEqual( clean.ids, expected_ids, 'single type value returned');
+    t.end();
+  });
+
   test('ids: valid input (osm)', function(t) {
     var raw = { ids: 'openstreetmap:venue:node:500' };
+    var clean = {};
+    var expected_ids = [{
+      source: 'openstreetmap',
+      layer: 'venue',
+      id: 'node:500',
+    }];
+
+    var messages = sanitize( raw, clean );
+
+    t.deepEqual( messages.errors, [], ' no errors');
+    t.deepEqual( clean.ids, expected_ids, 'osm has node: or way: in id field');
+    t.end();
+  });
+
+  test('ids: valid short input (osm)', function(t) {
+    var raw = { ids: 'osm:venue:node:500' };
     var clean = {};
     var expected_ids = [{
       source: 'openstreetmap',


### PR DESCRIPTION
This (hopefully) will allows someone to search using a gid typing in the short name of a source, e.g oa:venue:123456 as opposed to openaddresses:venue:123456

Fixes #441 