### PR TITLE
remove cluster2 module

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "async": "^1.5.2",
     "check-types": "^7.0.0",
-    "cluster2": "git://github.com/missinglink/cluster2.git#node_zero_twelve",
     "elasticsearch": "^11.0.0",
     "elasticsearch-exceptions": "0.0.4",
     "express": "^4.8.8",


### PR DESCRIPTION
remove the `cluster2` module

the package dependency was linking to a branch on my fork, so happy to remove that, also its been abandoned for some time.

I actually didn't realize it would be so easy to replace.

note: the `cluster2` module came with a healthcheck http API, I assume we don't use that?