### PR TITLE
Add Czech Republic

### DIFF
--- a/middleware/localNamingConventions.js
+++ b/middleware/localNamingConventions.js
@@ -1,7 +1,7 @@
 var check = require('check-types');
 var _ = require('lodash');
 
-var flipNumberAndStreetCountries = ['DEU', 'FIN', 'SWE', 'NOR', 'DNK', 'ISL'];
+var flipNumberAndStreetCountries = ['DEU', 'FIN', 'SWE', 'NOR', 'DNK', 'ISL', 'CZE'];
 
 function setup() {
   var api = require('pelias-config').generate().api;


### PR DESCRIPTION
Czech Republic addresses have housenumbers after street names, similar to Germany. This will add it to the list of countries where we need to handle that behavior.