### PR TITLE
Allow Elasticsearch index name to be set from pelias-config

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -1,7 +1,7 @@
 var service = { mget: require('../service/mget') };
 var logger = require('pelias-logger').get('api:controller:place');
 
-function setup( backend ){
+function setup( config, backend ){
 
   // allow overriding of dependencies
   backend = backend || require('../src/backend');
@@ -16,7 +16,7 @@ function setup( backend ){
 
     var query = req.clean.ids.map( function(id) {
       return {
-        _index: 'pelias',
+        _index: config.indexName,
         _type: id.layers,
         _id: id.id
       };

--- a/controller/search.js
+++ b/controller/search.js
@@ -4,7 +4,7 @@ var service = { search: require('../service/search') };
 var logger = require('pelias-logger').get('api:controller:search');
 var logging = require( '../helper/logging' );
 
-function setup( backend, query ){
+function setup( config, backend, query ){
 
   // allow overriding of dependencies
   backend = backend || require('../src/backend');
@@ -26,7 +26,7 @@ function setup( backend, query ){
 
     // backend command
     var cmd = {
-      index: 'pelias',
+      index: config.indexName,
       searchType: 'dfs_query_then_fetch',
       body: query( req.clean )
     };

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -61,7 +61,7 @@ function addRoutes(app, peliasConfig) {
     search: createRouter([
       sanitisers.search.middleware,
       middleware.calcSize(),
-      controllers.search(),
+      controllers.search(peliasConfig),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig),
       postProc.dedupe(),
@@ -74,7 +74,7 @@ function addRoutes(app, peliasConfig) {
     ]),
     autocomplete: createRouter([
       sanitisers.autocomplete.middleware,
-      controllers.search(null, require('../query/autocomplete')),
+      controllers.search(peliasConfig, null, require('../query/autocomplete')),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig),
       postProc.dedupe(),
@@ -88,7 +88,7 @@ function addRoutes(app, peliasConfig) {
     reverse: createRouter([
       sanitisers.reverse.middleware,
       middleware.calcSize(),
-      controllers.search(undefined, reverseQuery),
+      controllers.search(peliasConfig, undefined, reverseQuery),
       postProc.distances('point.'),
       // reverse confidence scoring depends on distance from origin
       //  so it must be calculated first

--- a/test/ciao_test_data.js
+++ b/test/ciao_test_data.js
@@ -15,6 +15,7 @@
 var client = require('elasticsearch').Client(),
     async = require('async'),
     actions = [];
+var config = require('pelias-config').generate().api;
 
 // add one record per 'type' in order to cause the _default_ mapping
 // to be copied when the new type is created.
@@ -28,7 +29,7 @@ types.forEach( function( type, i1 ){
     layers.forEach( function( layer, i3 ){
       actions.push( function( done ){
         client.index({
-          index: 'pelias',
+          index: config.indexName,
           type: type,
           id: [i1,i2,i3].join(':'),
           body: {
@@ -49,7 +50,7 @@ types.forEach( function( type, i1 ){
 
 // call refresh so the index merges the changes
 actions.push( function( done ){
-  client.indices.refresh( { index: 'pelias' }, done);
+  client.indices.refresh( { index: config.indexName }, done);
 });
 
 // perform all actions in series

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -12,6 +12,11 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
+// reminder: this is only the api subsection of the full config
+var fakeDefaultConfig = {
+  indexName: 'pelias'
+};
+
 // functionally test controller (backend success)
 module.exports.tests.functional_success = function(test, common) {
 
@@ -81,7 +86,7 @@ module.exports.tests.functional_success = function(test, common) {
         searchType: 'dfs_query_then_fetch'
       }, 'correct backend command');
     });
-    var controller = setup(backend, mockQuery());
+    var controller = setup(fakeDefaultConfig, backend, mockQuery());
     var res = {
       status: function (code) {
         t.equal(code, 200, 'status set');
@@ -104,6 +109,33 @@ module.exports.tests.functional_success = function(test, common) {
     };
     controller(req, res, next);
   });
+
+  test('functional success with alternate index name', function(t) {
+    var fakeCustomizedConfig = {
+      indexName: 'alternateindexname'
+    };
+
+    var backend = mockBackend('client/search/ok/1', function (cmd) {
+      t.deepEqual(cmd, {
+        body: {a: 'b'},
+        index: 'alternateindexname',
+        searchType: 'dfs_query_then_fetch'
+      }, 'correct backend command');
+    });
+    var controller = setup(fakeCustomizedConfig, backend, mockQuery());
+    var res = {
+      status: function (code) {
+        t.equal(code, 200, 'status set');
+        return res;
+      }
+    };
+    var req = { clean: { a: 'b' }, errors: [], warnings: [] };
+    var next = function next() {
+      t.equal(req.errors.length, 0, 'next was called without error');
+      t.end();
+    };
+    controller(req, res, next);
+  });
 };
 
 // functionally test controller (backend failure)
@@ -112,7 +144,7 @@ module.exports.tests.functional_failure = function(test, common) {
     var backend = mockBackend( 'client/search/fail/1', function( cmd ){
       t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias', searchType: 'dfs_query_then_fetch' }, 'correct backend command');
     });
-    var controller = setup( backend, mockQuery() );
+    var controller = setup( fakeDefaultConfig, backend, mockQuery() );
     var req = { clean: { a: 'b' }, errors: [], warnings: [] };
     var next = function(){
       t.equal(req.errors[0],'a backend error occurred');
@@ -127,7 +159,7 @@ module.exports.tests.timeout = function(test, common) {
     var backend = mockBackend( 'client/search/timeout/1', function( cmd ){
       t.deepEqual(cmd, { body: { a: 'b' }, index: 'pelias', searchType: 'dfs_query_then_fetch' }, 'correct backend command');
     });
-    var controller = setup( backend, mockQuery() );
+    var controller = setup( fakeDefaultConfig, backend, mockQuery() );
     var req = { clean: { a: 'b' }, errors: [], warnings: [] };
     var next = function(){
       t.equal(req.errors[0],'Request Timeout after 5000ms');

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -1,4 +1,3 @@
-
 var setup = require('../../../controller/search'),
     mockBackend = require('../mock/backend'),
     mockQuery = require('../mock/query');


### PR DESCRIPTION
The index name value will be read from pelias config, under the `config.api.indexName` property. https://github.com/pelias/config/pull/30 (released in pelias-config-2.1.0) sets the default for this value to `pelias`, so it will always be defined and will have the same behavior as before with no changes in `~/pelias.json`.

I've tested this locally quite a bit in addition to the unit tests which should cover everything, but am especially curious to know if there's anything I missed.

Connects https://github.com/pelias/api/issues/334