### PR TITLE
Set up layer filtering for autocomplete and reverse

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -47,6 +47,7 @@ query.score( peliasQuery.view.population( views.pop_subquery ) );
 
 // non-scoring hard filters
 query.filter( peliasQuery.view.sources );
+query.filter( peliasQuery.view.layers );
 
 // --------------------------------
 
@@ -61,6 +62,11 @@ function generateQuery( clean ){
   // sources
   if( check.array(clean.sources) && clean.sources.length ){
     vs.var( 'sources', clean.sources );
+  }
+
+  // layers
+  if( check.array(clean.layers) && clean.layers.length ){
+    vs.var( 'layers', clean.layers);
   }
 
   // pass the input tokens to the views so they can choose which tokens

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -16,6 +16,7 @@ query.sort( peliasQuery.view.sort_distance );
 // non-scoring hard filters
 query.filter( peliasQuery.view.boundary_circle );
 query.filter( peliasQuery.view.sources );
+query.filter( peliasQuery.view.layers );
 
 // --------------------------------
 
@@ -30,6 +31,9 @@ function generateQuery( clean ){
 
   // sources
   vs.var( 'sources', clean.sources);
+
+  // layers
+  vs.var( 'layers', clean.layers);
 
   // focus point to score by distance
   if( check.number(clean['point.lat']) &&

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -1,0 +1,66 @@
+
+module.exports = {
+  'query': {
+    'bool': {
+      'must': [{
+        'constant_score': {
+          'query': {
+            'match': {
+              'name.default': {
+                'analyzer': 'peliasQueryPartialToken',
+                'boost': 100,
+                'query': 'test',
+                'type': 'phrase',
+                'operator': 'and',
+                'slop': 3
+              }
+            }
+          }
+        }
+      }],
+      'should':[{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'popularity',
+              'missing': 1
+            },
+            'weight': 1
+          }]
+        }
+      },{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'population',
+              'missing': 1
+            },
+            'weight': 3
+          }]
+        }
+      }],
+      'filter': [{
+        'terms': {
+          'layer': ['country']
+        }
+      }]
+    }
+  },
+  'sort': [ '_score' ],
+  'size': 20,
+  'track_scores': true
+};

--- a/test/unit/fixture/reverse_with_layer_filtering.js
+++ b/test/unit/fixture/reverse_with_layer_filtering.js
@@ -1,0 +1,41 @@
+var vs = require('../../../query/reverse_defaults');
+
+module.exports = {
+  'query': {
+    'bool': {
+      'filter': [
+        {
+          'geo_distance': {
+            'distance': '500km',
+            'distance_type': 'plane',
+            'optimize_bbox': 'indexed',
+            'center_point': {
+              'lat': 29.49136,
+              'lon': -82.50622
+            }
+          }
+        },
+        {
+          'terms': {
+            'layer': ['country']
+          }
+        }
+      ]
+    }
+  },
+  'sort': [
+    '_score',
+    {
+      '_geo_distance': {
+        'center_point': {
+          'lat': 29.49136,
+          'lon': -82.50622
+        },
+        'order': 'asc',
+        'distance_type': 'plane'
+      }
+    }
+  ],
+  'size': vs.size,
+  'track_scores': true
+};

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -129,6 +129,22 @@ module.exports.tests.query = function(test, common) {
     t.end();
   });
 
+  test('valid layers filter', function(t) {
+    var query = generate({
+      'text': 'test',
+      'layers': ['country'],
+      tokens: ['test'],
+      tokens_complete: [],
+      tokens_incomplete: ['test']
+    });
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/autocomplete_with_layer_filtering');
+
+    t.deepEqual(compiled, expected, 'valid autocomplete query with layer filtering');
+    t.end();
+  });
+
   test('single character street address', function(t) {
     var query = generate({
       text: 'k road, laird',

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -125,6 +125,23 @@ module.exports.tests.query = function(test, common) {
     t.deepEqual(compiled, expected, 'valid reverse query with source filtering');
     t.end();
   });
+
+  test('valid layers filter', function(t) {
+    var query = generate({
+      'point.lat': 29.49136,
+      'point.lon': -82.50622,
+      'boundary.circle.lat': 29.49136,
+      'boundary.circle.lon': -82.50622,
+      'boundary.circle.radius': 500,
+      'layers': ['country']
+    });
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/reverse_with_layer_filtering');
+
+    t.deepEqual(compiled, expected, 'valid reverse query with source filtering');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This was missed by me when working on https://github.com/pelias/api/pull/580, but caught by the acceptance tests!

Unfortunately it was caught after going to production, so until this is merged and deployed we won't have any layer filtering in production(!).