### PR TITLE
Handle empty parent properties

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -219,8 +219,8 @@ function checkAddress(text, hit) {
     res += propMatch(text.number, (hit.address_parts ? hit.address_parts.number : null), false);
     res += propMatch(text.street, (hit.address_parts ? hit.address_parts.street : null), false);
     res += propMatch(text.postalcode, (hit.address_parts ? hit.address_parts.zip: null), true);
-    res += propMatch(text.state, hit.parent.region_a[0], true);
-    res += propMatch(text.country, hit.parent.country_a[0], true);
+    res += propMatch(text.state, (hit.parent.region_a ? hit.parent.region_a[0] : null), true);
+    res += propMatch(text.country, (hit.parent.country_a ? hit.parent.country_a[0] :null), true);
 
     res /= checkCount;
   }

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -93,7 +93,7 @@ function checkForDealBreakers(req, hit) {
     return false;
   }
 
-  if (check.assigned(req.clean.parsed_text.state) && req.clean.parsed_text.state !== hit.parent.region_a[0]) {
+  if (check.assigned(req.clean.parsed_text.state) && hit.parent.region_a && req.clean.parsed_text.state !== hit.parent.region_a[0]) {
     logger.debug('[confidence][deal-breaker]: state !== region_a');
     return true;
   }

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -97,9 +97,11 @@ module.exports.tests.confidenceScore = function(test, common) {
   test('undefined region fields should be handled gracefully', function(t) {
     var req = {
       clean: {
-        text: 'test name1, TX',
+        text: '123 Main St, City, NM',
         parsed_text: {
-          state: 'TX'
+          number: 123,
+          street: 'Main St',
+          state: 'NM'
         }
       }
     };
@@ -121,7 +123,7 @@ module.exports.tests.confidenceScore = function(test, common) {
     };
 
     confidenceScore(req, res, function() {});
-    t.equal(res.data[0].confidence, 0.54, 'score was set');
+    t.equal(res.data[0].confidence, 0.28, 'score was set');
     t.end();
   });
 };

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -94,6 +94,36 @@ module.exports.tests.confidenceScore = function(test, common) {
     t.end();
   });
 
+  test('undefined region fields should be handled gracefully', function(t) {
+    var req = {
+      clean: {
+        text: 'test name1, TX',
+        parsed_text: {
+          state: 'TX'
+        }
+      }
+    };
+    var res = {
+      data: [{
+        _score: 10,
+        found: true,
+        value: 1,
+        center_point: { lat: 100.1, lon: -50.5 },
+        name: { default: 'test name1' },
+        parent: {
+          country: ['country1'],
+          region: undefined,
+          region_a: undefined,
+          county: ['city1']
+        }
+      }],
+      meta: {scores: [10]}
+    };
+
+    confidenceScore(req, res, function() {});
+    t.equal(res.data[0].confidence, 0.54, 'score was set');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
After https://github.com/pelias/model/pull/37, we have significantly cleaner Elasticsearch documents that don't have empty values for every possible field when there's no data. This is good.

However, some places in the API code were still relying on these empty arrays always being present. It takes some careful query crafting, but it's possible to cause the API to return a 500 error with the right combination of query and data.

I believe this PR fixes all cases where a property on the parent object in an Easticsearch document was assumed to be an array. These properties can now be undefined, so a quick check has to be added.