### PR TITLE
fix: URL for Gitter does not appear correctly on NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This is the API server for the Pelias project. It's the service that runs to process user HTTP requests and return results as GeoJSON by querying Elasticsearch.
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/pelias/api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/pelias/api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/pelias/api.png?branch=master)](https://travis-ci.org/pelias/api)
 
 ## Documentation


### PR DESCRIPTION
NPM's markdown parser doesn't work the same as Github's it seems. The space in the URL causes things to look bad:
![screenshot from 2016-07-28 19-28-58](https://cloud.githubusercontent.com/assets/111716/17232912/8fe98d5e-54f9-11e6-90b9-b2f27a4f27d5.png)
