### PR TITLE
Removed pelias-text-analyzer requirement in test

### DIFF
--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -1,5 +1,4 @@
 var generate = require('../../../query/search');
-var text_analyzer = require('pelias-text-analyzer');
 
 module.exports.tests = {};
 
@@ -88,11 +87,17 @@ module.exports.tests.query = function(test, common) {
   });
 
   test('valid query with a full valid address', function(t) {
-    var address = '123 main st new york ny 10010 US';
-    var query = generate({ text: address,
+    var query = generate({ text: '123 main st new york ny 10010 US',
       layers: [ 'address', 'venue', 'country', 'region', 'county', 'neighbourhood', 'locality', 'localadmin' ],
       querySize: 10,
-      parsed_text: text_analyzer.parse(address),
+      parsed_text: {
+        number: '123',
+        street: 'main st',
+        state: 'NY',
+        country: 'USA',
+        postalcode: '10010',
+        regions: [ 'new york' ]
+      }
     });
 
     var compiled = JSON.parse( JSON.stringify( query ) );
@@ -103,11 +108,14 @@ module.exports.tests.query = function(test, common) {
   });
 
   test('valid query with partial address', function(t) {
-    var partial_address = 'soho grand, new york';
-    var query = generate({ text: partial_address,
+    var query = generate({ text: 'soho grand, new york',
       layers: [ 'address', 'venue', 'country', 'region', 'county', 'neighbourhood', 'locality', 'localadmin' ],
       querySize: 10,
-      parsed_text: text_analyzer.parse(partial_address),
+      parsed_text: { name: 'soho grand',
+        state: 'NY',
+        regions: [ 'soho grand' ],
+        admin_parts: 'new york'
+      }
     });
 
     var compiled = JSON.parse( JSON.stringify( query ) );
@@ -118,11 +126,14 @@ module.exports.tests.query = function(test, common) {
   });
 
   test('valid query with regions in address', function(t) {
-    var partial_address = '1 water st manhattan ny';
-    var query = generate({ text: partial_address,
+    var query = generate({ text: '1 water st manhattan ny',
       layers: [ 'address', 'venue', 'country', 'region', 'county', 'neighbourhood', 'locality', 'localadmin' ],
       querySize: 10,
-      parsed_text: text_analyzer.parse(partial_address),
+      parsed_text: { number: '1',
+        street: 'water st',
+        state: 'NY',
+        regions: [ 'manhattan' ]
+      },
     });
 
     var compiled = JSON.parse( JSON.stringify( query ) );


### PR DESCRIPTION
Replaced called to pelias-text-analyzer (which could be libpostal or addressit) with hard-coded addressit responses. 