### PR TITLE
Add boundary.country filter to /v1/autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -22,6 +22,7 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 // mandatory matches
 query.score( views.phrase_first_tokens_only, 'must' );
 query.score( views.ngrams_last_token_only, 'must' );
+query.score( peliasQuery.view.boundary_country, 'must' );
 
 // address components
 query.score( peliasQuery.view.address('housenumber') );
@@ -67,6 +68,13 @@ function generateQuery( clean ){
   // layers
   if( check.array(clean.layers) && clean.layers.length ){
     vs.var( 'layers', clean.layers);
+  }
+
+  // boundary country
+  if( check.string(clean['boundary.country']) ){
+    vs.set({
+      'boundary:country': clean['boundary.country']
+    });
   }
 
   // pass the input tokens to the views so they can choose which tokens

--- a/sanitiser/autocomplete.js
+++ b/sanitiser/autocomplete.js
@@ -12,6 +12,7 @@ var sanitizeAll = require('../sanitiser/sanitizeAll'),
       sources_and_layers: require('../sanitiser/_sources_and_layers'),
       private: require('../sanitiser/_flag_bool')('private', false),
       geo_autocomplete: require('../sanitiser/_geo_autocomplete'),
+      boundary_country: require('../sanitiser/_boundary_country'),
       categories: require('../sanitiser/_categories')
     };
 

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -1,0 +1,68 @@
+
+module.exports = {
+  'query': {
+    'bool': {
+      'must': [{
+        'constant_score': {
+          'query': {
+            'match': {
+              'name.default': {
+                'analyzer': 'peliasQueryPartialToken',
+                'boost': 100,
+                'query': 'test',
+                'type': 'phrase',
+                'operator': 'and',
+                'slop': 3
+              }
+            }
+          }
+        }
+      }, {
+        'match': {
+          'parent.country_a': {
+            'analyzer': 'standard',
+            'query': 'ABC'
+          }
+        }
+      }],
+      'should':[{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'popularity',
+              'missing': 1
+            },
+            'weight': 1
+          }]
+        }
+      },{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'population',
+              'missing': 1
+            },
+            'weight': 3
+          }]
+        }
+      }]
+    }
+  },
+  'sort': [ '_score' ],
+  'size': 20,
+  'track_scores': true
+};

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -164,6 +164,22 @@ module.exports.tests.query = function(test, common) {
     t.deepEqual(compiled, expected, 'autocomplete_single_character_street');
     t.end();
   });
+
+  test('valid boundary.country search', function(t) {
+    var query = generate({
+      text: 'test',
+      tokens: ['test'],
+      tokens_complete: [],
+      tokens_incomplete: ['test'],
+      'boundary.country': 'ABC'
+    });
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/autocomplete_boundary_country');
+
+    t.deepEqual(compiled, expected, 'autocomplete: valid boundary.country query');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/sanitiser/autocomplete.js
+++ b/test/unit/sanitiser/autocomplete.js
@@ -6,7 +6,7 @@ module.exports.tests.sanitisers = function(test, common) {
   test('check sanitiser list', function (t) {
     var expected = [
       'singleScalarParameters', 'text', 'tokenizer', 'size', 'layers', 'sources',
-      'sources_and_layers', 'private', 'geo_autocomplete', 'categories'
+      'sources_and_layers', 'private', 'geo_autocomplete', 'boundary_country', 'categories'
     ];
     t.deepEqual(Object.keys(autocomplete.sanitiser_list), expected);
     t.end();


### PR DESCRIPTION
It works exactly the same as in `/search`, no surprises here!

Connects https://github.com/pelias/pelias/issues/403