### PR TITLE
Add non-override conditions to sanitizeall

### DIFF
--- a/sanitiser/sanitizeAll.js
+++ b/sanitiser/sanitizeAll.js
@@ -1,12 +1,10 @@
 function sanitize( req, sanitizers, cb ){
+  // init an object to store clean (sanitized) input parameters if not initialized
+  req.clean = req.clean || {};
 
-  // init an object to store clean
-  // (sanitized) input parameters
-  req.clean = {};
-
-  // init errors and warnings arrays
-  req.errors = [];
-  req.warnings = [];
+  // init errors and warnings arrays if not initialized
+  req.errors = req.errors || [];
+  req.warnings = req.warnings || [];
 
   // source of input parameters
   // (in this case from the GET querystring params)

--- a/sanitiser/sanitizeAll.js
+++ b/sanitiser/sanitizeAll.js
@@ -1,6 +1,3 @@
-
-var check = require('check-types');
-
 function sanitize( req, sanitizers, cb ){
 
   // init an object to store clean

--- a/sanitiser/sanitizeAll.js
+++ b/sanitiser/sanitizeAll.js
@@ -7,7 +7,7 @@ function sanitize( req, sanitizers, cb ){
   // (sanitized) input parameters
   req.clean = {};
 
-  // init erros and warnings arrays
+  // init errors and warnings arrays
   req.errors = [];
   req.warnings = [];
 

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -63,6 +63,7 @@ var tests = [
   require('./sanitiser/autocomplete'),
   require('./sanitiser/place'),
   require('./sanitiser/reverse'),
+  require('./sanitiser/sanitizeAll'),
   require('./sanitiser/search'),
   require('./sanitiser/search_fallback'),
   require('./sanitiser/wrap'),

--- a/test/unit/sanitiser/sanitizeAll.js
+++ b/test/unit/sanitiser/sanitizeAll.js
@@ -1,0 +1,161 @@
+var sanitizeAll = require('../../../sanitiser/sanitizeAll');
+
+module.exports.tests = {};
+
+module.exports.tests.all = function(test, common) {
+  test('req.clean/errors/warnings should be initialized when they are not', function(t) {
+    var req = {};
+    var sanitizers = [
+      function() {
+        req.clean.a = 'first sanitizer';
+        return {
+          errors: ['error 1', 'error 2'],
+          warnings: ['warning 1', 'warning 2']
+        };
+      },
+      function() {
+        req.clean.b = 'second sanitizer';
+        return {
+          errors: ['error 3'],
+          warnings: ['warning 3']
+        };
+      }
+    ];
+
+    var expected_req = {
+      clean: {
+        a: 'first sanitizer',
+        b: 'second sanitizer'
+      },
+      errors: ['error 1', 'error 2', 'error 3'],
+      warnings: ['warning 1', 'warning 2', 'warning 3']
+    };
+
+    sanitizeAll(req, sanitizers, function(){
+      t.deepEquals(req, expected_req);
+      t.end();
+    });
+
+  });
+
+  test('req.clean/errors/warnings should not be initialized when they already have been', function(t) {
+    var req = {
+      clean: {
+        alreadyInitialized: true
+      },
+      errors: ['pre-existing error'],
+      warnings: ['pre-existing warning']
+    };
+
+    var sanitizers = [
+      function() {
+        req.clean.a = 'first sanitizer';
+        return {
+          errors: ['error 1', 'error 2'],
+          warnings: ['warning 1', 'warning 2']
+        };
+      },
+      function() {
+        req.clean.b = 'second sanitizer';
+        return {
+          errors: ['error 3'],
+          warnings: ['warning 3']
+        };
+      }
+    ];
+
+    var expected_req = {
+      clean: {
+        alreadyInitialized: true,
+        a: 'first sanitizer',
+        b: 'second sanitizer'
+      },
+      errors: ['pre-existing error', 'error 1', 'error 2', 'error 3'],
+      warnings: ['pre-existing warning', 'warning 1', 'warning 2', 'warning 3']
+    };
+
+    sanitizeAll(req, sanitizers, function(){
+      t.deepEquals(req, expected_req);
+      t.end();
+    });
+
+  });
+
+  test('req.query should be passed to individual sanitizers when available', function(t) {
+    var req = {
+      query: {
+        value: 'query value'
+      }
+    };
+    var sanitizers = [
+      function(params) {
+        req.clean.query = params;
+        return {
+          errors: [],
+          warnings: []
+        };
+      }
+    ];
+
+    var expected_req = {
+      query: {
+        value: 'query value'
+      },
+      clean: {
+        query: {
+          value: 'query value'
+        }
+      },
+      errors: [],
+      warnings: []
+    };
+
+    sanitizeAll(req, sanitizers, function(){
+      t.deepEquals(req, expected_req);
+      t.end();
+    });
+
+  });
+
+  test('an empty object should be passed to individual sanitizers when req.query is unavailable', function(t) {
+    var req = {};
+    var sanitizers = [
+      function(params) {
+        if (Object.keys(params).length === 0) {
+          req.clean.empty_object_was_passed = true;
+        }
+
+        return {
+          errors: [],
+          warnings: []
+        };
+      }
+    ];
+
+    var expected_req = {
+      clean: {
+        empty_object_was_passed: true
+      },
+      errors: [],
+      warnings: []
+    };
+
+    sanitizeAll(req, sanitizers, function(){
+      t.deepEquals(req, expected_req);
+      t.end();
+    });
+
+  });
+
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('SANITIZE sanitizeAll ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};


### PR DESCRIPTION
The libpostal integration adds a fallback sanitize step between query calls that calls addressit.  The problem is that sanitizeAll initializes `req.clean` even if it already exists, so the results of all the sanitizers called before were being dropped.  This PR preserves `req.clean`, `req.errors`, and `req.warnings` if they have already been initialized.  

Also, there were no direct tests for sanitizeAll, it was being tested indirectly thru other tests.  