### PR TITLE
disable calling GeodisambiguationQuery

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -31,11 +31,18 @@ function setup( config, backend, query ){
     // log clean parameters for stats
     logger.info('[req]', 'endpoint=' + req.path, cleanOutput);
 
+    var query_body = query(req.clean);
+
+    // if there's no query to call ES with, skip the service
+    if (_.isUndefined(query_body)) {
+      return next();
+    }
+
     // backend command
     var cmd = {
       index: config.indexName,
       searchType: 'dfs_query_then_fetch',
-      body: query( req.clean )
+      body: query_body
     };
 
     logger.debug( '[ES req]', cmd );

--- a/query/search.js
+++ b/query/search.js
@@ -121,7 +121,8 @@ function generateQuery( clean ){
 
 function getQuery(vs) {
   if (isSingleFieldGeoambiguity(vs) && !hasQueryOrAddress(vs)) {
-    return geodisambiguationQuery.render(vs);
+    // return `undefined` for now until we exorcise the geodisambiguation demons
+    return;
   } else {
     return fallbackQuery.render(vs);
   }

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -1,6 +1,7 @@
 var setup = require('../../../controller/search'),
     mockBackend = require('../mock/backend'),
     mockQuery = require('../mock/query');
+var proxyquire =  require('proxyquire').noCallThru();
 
 module.exports.tests = {};
 
@@ -191,6 +192,32 @@ module.exports.tests.existing_results = function(test, common) {
 
   });
 
+};
+
+module.exports.tests.undefined_query = function(test, common) {
+  test('query returning undefined should not call service', function(t) {
+    // a function that returns undefined
+    var query = function() {
+      return;
+    };
+
+    var search_service_was_called = false;
+
+    var controller = proxyquire('../../../controller/search', {
+      '../service/search': function() {
+        search_service_was_called = true;
+        throw new Error('search service should not have been called');
+      }
+    })(undefined, undefined, query);
+
+    var next = function() {
+      t.notOk(search_service_was_called, 'should have returned before search service was called');
+      t.end();
+    };
+
+    controller({}, {}, next);
+
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -150,19 +150,20 @@ module.exports.tests.query = function(test, common) {
 
   });
 
-  test('parsed_text with single admin field should use GeodisambiguationQuery', function(t) {
-    var clean = {
-      parsed_text: {
-        neighbourhood: 'neighbourhood value'
-      }
-    };
+  test('parsed_text with single admin field should return undefined', function(t) {
+    ['neighbourhood', 'borough', 'city', 'county', 'state', 'country'].forEach(function(placeType) {
+        var clean = {
+          parsed_text: {}
+        };
 
-    var query = generate(clean);
+        clean.parsed_text[placeType] = placeType + ' value';
 
-    var compiled = JSON.parse(JSON.stringify(query));
-    var expected = require('../fixture/search_geodisambiguation');
+        var query = generate(clean);
 
-    t.deepEqual(compiled, expected, 'geodisambiguationQuery');
+        t.equals(query, undefined, 'geodisambiguationQuery');
+
+      });
+
     t.end();
 
   });


### PR DESCRIPTION
This PR disables calling the GeodisambiguationQuery by having query/search.js return `undefined` in the geodisambiguation criteria case.  controller/search.js then skips execution if the query to ES is `undefined`.  **With all the tests!**