### PR TITLE
fix labels for dependencies for USA

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var cluster = require('cluster'),
     app = require('./app'),
     port = ( process.env.PORT || 3100 ),
-    multicore = true;
+    multicore = false;
 
 /** cluster webserver across all cores **/
 if( multicore ){

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var cluster = require('cluster'),
     app = require('./app'),
     port = ( process.env.PORT || 3100 ),
-    multicore = false;
+    multicore = true;
 
 /** cluster webserver across all cores **/
 if( multicore ){

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -58,7 +58,6 @@ module.exports.tests.geojsonify = function(test, common) {
       'postalcode': 'N1 0RW',
       'country_a': 'GBR',
       'country': 'United Kingdom',
-      'dependency': 'dependency name',
       'region': 'Islington',
       'region_a': 'ISL',
       'macroregion': 'England',
@@ -86,7 +85,6 @@ module.exports.tests.geojsonify = function(test, common) {
       },
       'country_a': 'GBR',
       'country': 'United Kingdom',
-      'dependency': 'dependency name',
       'region': 'City And County Of The City Of London',
       'region_a': 'COL',
       'macroregion': 'England',
@@ -110,7 +108,6 @@ module.exports.tests.geojsonify = function(test, common) {
       },
       'country_a': 'USA',
       'country': 'United States',
-      'dependency': 'dependency name',
       'region': 'New York',
       'region_a': 'NY',
       'county': 'New York',
@@ -147,7 +144,6 @@ module.exports.tests.geojsonify = function(test, common) {
           'name': '\'Round Midnight Jazz and Blues Bar',
           'country_a': 'GBR',
           'country': 'United Kingdom',
-          'dependency': 'dependency name',
           'macroregion': 'England',
           'region': 'Islington',
           'region_a': 'ISL',
@@ -183,7 +179,6 @@ module.exports.tests.geojsonify = function(test, common) {
           'name': 'Blues Cafe',
           'country_a': 'GBR',
           'country': 'United Kingdom',
-          'dependency': 'dependency name',
           'macroregion': 'England',
           'region': 'City And County Of The City Of London',
           'region_a': 'COL',
@@ -212,7 +207,6 @@ module.exports.tests.geojsonify = function(test, common) {
           'name': 'Empire State Building',
           'country_a': 'USA',
           'country': 'United States',
-          'dependency': 'dependency name',
           'region': 'New York',
           'region_a': 'NY',
           'county': 'New York',
@@ -273,14 +267,8 @@ module.exports.tests.geojsonify = function(test, common) {
         'country_a': [
           'USA'
         ],
-        'dependency': [
-          'dependency name'
-        ],
         'dependency_gid': [
           'dependency id'
-        ],
-        'dependency_a': [
-          'dependency abbrevation'
         ],
         'macroregion': [
           'MacroRegion Name'
@@ -356,9 +344,7 @@ module.exports.tests.geojsonify = function(test, common) {
             'country': 'United States',
             'country_gid': '85633793',
             'country_a': 'USA',
-            'dependency': 'dependency name',
             'dependency_gid': 'dependency id',
-            'dependency_a': 'dependency abbrevation',
             'macroregion': 'MacroRegion Name',
             'macroregion_gid': 'MacroRegion Id',
             'macroregion_a': 'MacroRegion Abbreviation',

--- a/test/unit/helper/labelGenerator_USA.js
+++ b/test/unit/helper/labelGenerator_USA.js
@@ -249,6 +249,57 @@ test('county value should be used when there is no localadmin', function(t) {
     t.end();
   });
 
+  test('dependency layer should use full name instead of abbreviation', function(t) {
+    var doc = {
+      'name': 'dependency name',
+      'layer': 'dependency',
+      'dependency_a': 'dependency abbr',
+      'dependency': 'dependency name',
+      'country_a': 'USA',
+      'country': 'United States'
+    };
+    t.equal(generator(doc),'dependency name', 'dependency should be used');
+    t.end();
+
+  });
+
+  test('dependency abbreviation should be used instead of dependency name or country and skip region', function(t) {
+    var doc = {
+      'name': 'locality name',
+      'locality': 'locality name',
+      'localadmin': 'localadmin name',
+      'county': 'county name',
+      'macrocounty': 'macrocounty name',
+      'region': 'region name',
+      'macroregion': 'macroregion name',
+      'dependency_a': 'dependency abbr',
+      'dependency': 'dependency name',
+      'country_a': 'USA',
+      'country': 'United States'
+    };
+    t.equal(generator(doc),'locality name, dependency abbr', 'dependency_a should be used');
+    t.end();
+
+  });
+
+  test('dependency name should be used instead of country when dep abbr is unavailable and skip region', function(t) {
+    var doc = {
+      'name': 'locality name',
+      'locality': 'locality name',
+      'localadmin': 'localadmin name',
+      'county': 'county name',
+      'macrocounty': 'macrocounty name',
+      'region': 'region name',
+      'macroregion': 'macroregion name',
+      'dependency': 'dependency name',
+      'country_a': 'USA',
+      'country': 'United States'
+    };
+    t.equal(generator(doc),'locality name, dependency name', 'dependency should be used');
+    t.end();
+
+  });
+
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Treats existence of dependency fields as more important than country fields.  Examples:

`San Juan, PR` (abbreviation exists)
`Aasu, AS` (abbreviation exists)
`Altona, United States Virgin Islands` (abbreviation doesn't exist)
`Puerto Rico` (result was `dependency` layer)

This change also excludes `region` if `dependency` fields exist, for example, [San Juan](https://whosonfirst.mapzen.com/spelunker/id/101919427/#11/18.4050/-66.0604) is in the region of [San Juan](https://whosonfirst.mapzen.com/spelunker/id/85687331/#9/18.2001/-66.5836).  Without this exclusion, the label would be `San Juan, PR, PR`.  This exclusion shortens the label to `San Juan, PR`.  

Fixes #628 

While this fixes the source issue, the example in #628 is not fixed because [Pago Pago](https://whosonfirst.mapzen.com/spelunker/id/101734459/#12/-14.2512/-170.7168) has a broken hierarchy.  
