### PR TITLE
Add street to trim by granularity

### DIFF
--- a/middleware/trimByGranularity.js
+++ b/middleware/trimByGranularity.js
@@ -16,6 +16,7 @@ var _ = require('lodash');
 var layers = [
   'venue',
   'address',
+  'street',
   'neighbourhood',
   'borough',
   'locality',

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pelias-config": "2.1.0",
     "pelias-logger": "0.0.8",
     "pelias-model": "4.2.0",
-    "pelias-query": "pelias/query#reorganize-queries-for-scoring",
+    "pelias-query": "pelias/query#reorganize-queries-for-scoring", 
     "pelias-text-analyzer": "1.3.0",
     "stats-lite": "2.0.3",
     "through2": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pelias-config": "2.1.0",
     "pelias-logger": "0.0.8",
     "pelias-model": "4.2.0",
-    "pelias-query": "pelias/query#reorganize-queries-for-scoring", 
+    "pelias-query": "pelias/query#reorganize-queries-for-scoring",
     "pelias-text-analyzer": "1.3.0",
     "stats-lite": "2.0.3",
     "through2": "2.0.1"

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -110,8 +110,95 @@ module.exports = {
                         }
                       },
                       {
+                        'multi_match': {
+                          'query': 'neighbourhood value',
+                          'type': 'phrase',
+                          'fields': [
+                            'parent.neighbourhood',
+                            'parent.neighbourhood_a'
+                          ]
+                        }
+                      },
+                      {
+                        'multi_match': {
+                          'query': 'borough value',
+                          'type': 'phrase',
+                          'fields': [
+                            'parent.borough',
+                            'parent.borough_a'
+                          ]
+                        }
+                      },
+                      {
+                        'multi_match': {
+                          'query': 'city value',
+                          'type': 'phrase',
+                          'fields': [
+                            'parent.locality',
+                            'parent.locality_a',
+                            'parent.localadmin',
+                            'parent.localadmin_a'
+                          ]
+                        }
+                      },
+                      {
+                        'multi_match': {
+                          'query': 'county value',
+                          'type': 'phrase',
+                          'fields': [
+                            'parent.county',
+                            'parent.county_a',
+                            'parent.macrocounty',
+                            'parent.macrocounty_a'
+                          ]
+                        }
+                      },
+                      {
+                        'multi_match': {
+                          'query': 'state value',
+                          'type': 'phrase',
+                          'fields': [
+                            'parent.region',
+                            'parent.region_a',
+                            'parent.macroregion',
+                            'parent.macroregion_a'
+                          ]
+                        }
+                      },
+                      {
+                        'multi_match': {
+                          'query': 'country value',
+                          'type': 'phrase',
+                          'fields': [
+                            'parent.country',
+                            'parent.country_a',
+                            'parent.dependency',
+                            'parent.dependency_a'
+                          ]
+                        }
+                      }
+                    ],
+                    'should': [
+                      {
                         'match_phrase': {
                           'address_parts.zip': 'postalcode value'
+                        }
+                      }
+                    ],
+                    'filter': {
+                      'term': {
+                        'layer': 'address'
+                      }
+                    }
+                  }
+                },
+                {
+                  'bool': {
+                    '_name': 'fallback.street',
+                    'must': [
+                      {
+                        'match_phrase': {
+                          'address_parts.street': 'street value'
                         }
                       },
                       {
@@ -183,9 +270,16 @@ module.exports = {
                         }
                       }
                     ],
+                    'should': [
+                      {
+                        'match_phrase': {
+                          'address_parts.zip': 'postalcode value'
+                        }
+                      }
+                    ],
                     'filter': {
                       'term': {
-                        'layer': 'address'
+                        'layer': 'street'
                       }
                     }
                   }

--- a/test/unit/middleware/trimByGranularity.js
+++ b/test/unit/middleware/trimByGranularity.js
@@ -20,6 +20,7 @@ module.exports.tests.trimByGranularity = function(test, common) {
         { name: 'venue 1', _matched_queries: ['fallback.venue'] },
         { name: 'venue 2', _matched_queries: ['fallback.venue'] },
         { name: 'address 1', _matched_queries: ['fallback.address'] },
+        { name: 'street 1', _matched_queries: ['fallback.street'] },
         { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
         { name: 'locality 1', _matched_queries: ['fallback.locality'] },
         { name: 'localadmin 1', _matched_queries: ['fallback.localadmin'] },
@@ -55,6 +56,7 @@ module.exports.tests.trimByGranularity = function(test, common) {
       data: [
         { name: 'address 1', _matched_queries: ['fallback.address'] },
         { name: 'address 2', _matched_queries: ['fallback.address'] },
+        { name: 'street 1', _matched_queries: ['fallback.street'] },
         { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
         { name: 'locality 1', _matched_queries: ['fallback.locality'] },
         { name: 'localadmin 1', _matched_queries: ['fallback.localadmin'] },
@@ -76,6 +78,41 @@ module.exports.tests.trimByGranularity = function(test, common) {
     function testIt() {
       trimByGranularity(req, res, function() {
         t.deepEquals(res.data, expected_data, 'only address records should be here');
+        t.end();
+      });
+    }
+
+    testIt();
+  });
+
+  test('all records with fallback.* matched_queries name should retain only streets when they are most granular', function(t) {
+    var req = { clean: {} };
+
+    var res = {
+      data: [
+        { name: 'street 1', _matched_queries: ['fallback.street'] },
+        { name: 'street 2', _matched_queries: ['fallback.street'] },
+        { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
+        { name: 'locality 1', _matched_queries: ['fallback.locality'] },
+        { name: 'localadmin 1', _matched_queries: ['fallback.localadmin'] },
+        { name: 'county 1', _matched_queries: ['fallback.county'] },
+        { name: 'macrocounty 1', _matched_queries: ['fallback.macrocounty'] },
+        { name: 'region 1', _matched_queries: ['fallback.region'] },
+        { name: 'macroregion 1', _matched_queries: ['fallback.macroregion'] },
+        { name: 'dependency 1', _matched_queries: ['fallback.dependency'] },
+        { name: 'country 1', _matched_queries: ['fallback.country'] },
+        { name: 'unknown', _matched_queries: ['fallback.unknown'] }
+      ]
+    };
+
+    var expected_data = [
+      { name: 'street 1', _matched_queries: ['fallback.street'] },
+      { name: 'street 2', _matched_queries: ['fallback.street'] },
+    ];
+
+    function testIt() {
+      trimByGranularity(req, res, function() {
+        t.deepEquals(res.data, expected_data, 'only street records should be here');
         t.end();
       });
     }


### PR DESCRIPTION
`street` results weren't being returned because trimByGranularity wasn't saving them.  Requires pelias/query#47.  