### PR TITLE
hardcode size to 50 for FallbackQuery

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -59,7 +59,7 @@ function generateQuery( clean ){
 
   // size
   if( clean.querySize ) {
-    vs.var( 'size', clean.querySize );
+    vs.var( 'size', 100 );
   }
 
   // focus point

--- a/query/search.js
+++ b/query/search.js
@@ -59,7 +59,7 @@ function generateQuery( clean ){
 
   // size
   if( clean.querySize ) {
-    vs.var( 'size', 100 );
+    vs.var( 'size', 50 );
   }
 
   // focus point

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -73,7 +73,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -73,7 +73,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -76,7 +76,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -76,7 +76,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -79,7 +79,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -79,7 +79,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -90,7 +90,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -90,7 +90,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -79,7 +79,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -79,7 +79,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -65,7 +65,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -65,7 +65,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_viewport.js
+++ b/test/unit/fixture/search_linguistic_viewport.js
@@ -65,7 +65,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_viewport.js
+++ b/test/unit/fixture/search_linguistic_viewport.js
@@ -65,7 +65,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
+++ b/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
@@ -65,7 +65,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 100,
+  'size': 50,
   'track_scores': true,
   'sort': [
     {

--- a/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
+++ b/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
@@ -65,7 +65,7 @@ module.exports = {
       'boost_mode': 'multiply'
     }
   },
-  'size': 10,
+  'size': 100,
   'track_scores': true,
   'sort': [
     {


### PR DESCRIPTION
Fixes pelias/pelias#434. 

Previously, if the user specified a `size` parameter, Pelias would query ES for that many results.  This doesn't work well with the new fallback query model since an `address` layer document may match but scores lower than a fallback `city` layer document.  While the default `size` value is `10`, it was sufficiently high enough to return the `address` layer document.  

We should add an acceptance test or two that checks for this.  