### PR TITLE
Update Dockerfile to avoid npm install fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12
+FROM node:4.6.0
 MAINTAINER Pelias
 
 EXPOSE 3100


### PR DESCRIPTION
I was trying to build the image and it actually fails on NPM of Node 0.12 doesn't support some of the packages needed. 