### PR TITLE
Add boundary.rect (bounding box) parameter to /v1/autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -49,6 +49,7 @@ query.score( peliasQuery.view.population( views.pop_subquery ) );
 // non-scoring hard filters
 query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
+query.filter( peliasQuery.view.boundary_rect );
 
 // --------------------------------
 
@@ -106,6 +107,19 @@ function generateQuery( clean ){
     vs.set({
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
+    });
+  }
+
+  // boundary rect
+  if( check.number(clean['boundary.rect.min_lat']) &&
+      check.number(clean['boundary.rect.max_lat']) &&
+      check.number(clean['boundary.rect.min_lon']) &&
+      check.number(clean['boundary.rect.max_lon']) ){
+    vs.set({
+      'boundary:rect:top': clean['boundary.rect.max_lat'],
+      'boundary:rect:right': clean['boundary.rect.max_lon'],
+      'boundary:rect:bottom': clean['boundary.rect.min_lat'],
+      'boundary:rect:left': clean['boundary.rect.min_lon']
     });
   }
 

--- a/sanitizer/_geo_autocomplete.js
+++ b/sanitizer/_geo_autocomplete.js
@@ -1,5 +1,6 @@
 var geo_common = require ('./_geo_common');
 var LAT_LON_IS_REQUIRED = false;
+var RECT_IS_REQUIRED = false;
 
 // validate inputs, convert types and apply defaults
 module.exports = function sanitize( raw, clean ){
@@ -9,6 +10,7 @@ module.exports = function sanitize( raw, clean ){
 
   try {
     geo_common.sanitize_point( 'focus.point', clean, raw, LAT_LON_IS_REQUIRED );
+    geo_common.sanitize_rect( 'boundary.rect', clean, raw, RECT_IS_REQUIRED );
   }
   catch (err) {
     messages.errors.push( err.message );

--- a/test/ciao/autocomplete/boundary_rect_valid.coffee
+++ b/test/ciao/autocomplete/boundary_rect_valid.coffee
@@ -1,0 +1,37 @@
+
+#> focus point
+path: '/v1/autocomplete?text=cairo&boundary.rect.min_lat=30&boundary.rect.max_lat=32&boundary.rect.min_lon=29&boundary.rect.max_lon=31'
+
+#? 200 ok
+response.statusCode.should.be.equal 200
+response.should.have.header 'charset', 'utf8'
+response.should.have.header 'content-type', 'application/json; charset=utf-8'
+
+#? valid geocoding block
+should.exist json.geocoding
+should.exist json.geocoding.version
+should.exist json.geocoding.attribution
+should.exist json.geocoding.query
+should.exist json.geocoding.engine
+should.exist json.geocoding.engine.name
+should.exist json.geocoding.engine.author
+should.exist json.geocoding.engine.version
+should.exist json.geocoding.timestamp
+
+#? valid geojson
+json.type.should.be.equal 'FeatureCollection'
+json.features.should.be.instanceof Array
+
+#? expected errors
+should.not.exist json.geocoding.errors
+
+#? expected warnings
+should.not.exist json.geocoding.warnings
+
+#? inputs
+json.geocoding.query['text'].should.eql 'cairo'
+json.geocoding.query['size'].should.eql 10
+json.geocoding.query['boundary.rect.min_lat'].should.eql 30
+json.geocoding.query['boundary.rect.max_lat'].should.eql 32
+json.geocoding.query['boundary.rect.min_lon'].should.eql 29
+json.geocoding.query['boundary.rect.max_lon'].should.eql 31

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -1,0 +1,71 @@
+module.exports = {
+  'query': {
+    'bool': {
+      'must': [{
+        'constant_score': {
+          'query': {
+            'match': {
+              'name.default': {
+                'analyzer': 'peliasQueryPartialToken',
+                'boost': 100,
+                'query': 'test',
+                'type': 'phrase',
+                'operator': 'and',
+                'slop': 3
+              }
+            }
+          }
+        }
+      }],
+      'should':[{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'popularity',
+              'missing': 1
+            },
+            'weight': 1
+          }]
+        }
+      },{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'population',
+              'missing': 1
+            },
+            'weight': 3
+          }]
+        }
+      }],
+      'filter': [{
+        'geo_bounding_box': {
+          'type': 'indexed',
+          'center_point': {
+            'top': 37.83239,
+            'right': -122.35698,
+            'bottom': 37.70808,
+            'left': -122.51489
+          }
+        }
+      }]
+    }
+  },
+  'sort': [ '_score' ],
+  'size': 20,
+  'track_scores': true
+};

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -189,6 +189,26 @@ module.exports.tests.query = function(test, common) {
     t.deepEqual(compiled.body, expected, 'autocomplete: valid boundary.country query');
     t.end();
   });
+
+  test('autocomplete + bbox around San Francisco', function(t) {
+    var query = generate({
+      text: 'test',
+      'boundary.rect.max_lat': 37.83239,
+      'boundary.rect.max_lon': -122.35698,
+      'boundary.rect.min_lat': 37.70808,
+      'boundary.rect.min_lon': -122.51489,
+      tokens: ['test'],
+      tokens_complete: [],
+      tokens_incomplete: ['test']
+    });
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/autocomplete_linguistic_bbox_san_francisco');
+
+    t.deepEqual(compiled.type, 'autocomplete', 'query type set');
+    t.deepEqual(compiled.body, expected, 'autocomplete_linguistic_focus_null_island');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This came up in a discussion comparing the search and autocomplete endpoints (https://github.com/pelias/pelias/issues/436).

In the past we've talked about wanting to keep the autocomplete endpoint very minimalistic in order to ensure good caching (and therefore good performance). However there are a couple good arguments that have arisen that make that feel like the wrong choice

1.) The autocomplete endpoint is already really fast.
2.) People are using the search endpoint when they should use autocomplete, because autocomplete doesn't have the filters they want
3.) If anything, having bounding boxes (as long as they're small), will only make autocomplete even faster
4.) The majority of queries will probably not use any fancy filters, and will still be easily cache-able 