### PR TITLE
Support "county, region" in FallbackQuery with edge case for Hawaii

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -120,7 +120,7 @@ function generateQuery( clean ){
 }
 
 function getQuery(vs) {
-  if (hasStreet(vs) || isCityStateOnlyWithOptionalCountry(vs)) {
+  if (hasStreet(vs) || isCountyRegion(vs) || isCityStateOnlyWithOptionalCountry(vs)) {
     return {
       type: 'fallback',
       body: fallbackQuery.render(vs)
@@ -130,11 +130,22 @@ function getQuery(vs) {
   // returning undefined is a signal to a later step that the addressit-parsed
   // query should be queried for
   return undefined;
-
 }
 
 function hasStreet(vs) {
   return vs.isset('input:street');
+}
+
+function isCountyRegion(vs) {
+  var isSet = function(layer) {
+    return vs.isset('input:' + layer);
+  };
+
+  var allowedFields = ['county', 'region'];
+  var disallowedFields = ['query', 'category', 'housenumber', 'street',
+                          'neighbourhood', 'borough', 'postcode', 'locality'];
+
+  return allowedFields.every(isSet) && !disallowedFields.some(isSet);
 }
 
 function isCityStateOnlyWithOptionalCountry(vs) {

--- a/query/text_parser.js
+++ b/query/text_parser.js
@@ -39,6 +39,12 @@ function addParsedVariablesToQueryVariables( parsed_text, vs ){
     vs.var( 'input:postcode', parsed_text.postalcode );
   }
 
+
+  // island
+  if( parsed_text.hasOwnProperty('island') ){
+    vs.var( 'input:island', parsed_text.island );
+  }
+
   // ==== add parsed matches [admin components] ====
 
   // city
@@ -83,12 +89,24 @@ function addParsedVariablesToQueryVariables( parsed_text, vs ){
     vs.unset( 'input:query' );
   }
 
+
+  if (shouldTreatIslandAsCounty(vs)) {
+    vs.var( 'input:county', vs.var('input:island').toString());
+    vs.unset('input:island');
+  }
 }
 
 function shouldSetQueryIntoHouseNumber(vs) {
   return !vs.isset('input:housenumber') &&
           vs.isset('input:street') &&
           /^[0-9]+$/.test(vs.var('input:query').toString());
+}
+
+function shouldTreatIslandAsCounty(vs) {
+  return vs.isset('input:island') &&
+    vs.isset('input:region') &&
+    !vs.isset('input:county') &&
+    vs.var('input:region').toString() === 'hawaii';
 }
 
 module.exports = addParsedVariablesToQueryVariables;

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -445,6 +445,19 @@ module.exports.tests.city_state = function(test, common) {
 
   });
 
+  test('county/region(state) should return a query', function(t) {
+    var clean = {
+      parsed_text: {
+        county: 'county value',
+        state: 'state value'
+      }
+    };
+
+    var query = generate(clean);
+
+    t.ok(query, 'should return a query');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/query/text_parser.js
+++ b/test/unit/query/text_parser.js
@@ -154,6 +154,37 @@ module.exports.tests.housenumber_special_cases = function(test, common) {
 
 };
 
+module.exports.tests.islands = function(test, common) {
+  test('island normally left untouched', function(t) {
+    var parsed_text = {
+      island: 'an island',
+      state: 'somewhere'
+    };
+    var vs = new VariableStore();
+
+    text_parser(parsed_text, vs);
+
+    t.equals(vs.var('input:island').toString(), 'an island');
+    t.equals(vs.var('input:region').toString(), 'somewhere');
+    t.end();
+  });
+
+  test('islands in hawaii should have island changed to county', function(t) {
+    var parsed_text = {
+      island: 'maui',
+      state: 'hawaii'
+    };
+    var vs = new VariableStore();
+
+    text_parser(parsed_text, vs);
+
+    t.equals(vs.var('input:county').toString(), 'maui');
+    t.false(vs.isset('input:island'));
+    t.equals(vs.var('input:region').toString(), 'hawaii');
+    t.end();
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('text_parser ' + name, testFunction);


### PR DESCRIPTION
To help with the [Maui, Hawaii](https://github.com/pelias/whosonfirst/issues/94#issuecomment-253669462) query issues for WOF venues, this PR enables "county, region" queries in FallbackQuery.

Additionally, because libpostal parses Maui as an island, there is some special handling: the `island` field is moved to `county` if the `region` field is `hawaii`.
```
> maui, hawaii

Result:

{
  "island": "maui",
  "state": "hawaii"
}
```

These changes together allow us to properly return Maui County. No other acceptance-tests are affected!
![screenshot from 2016-11-04 15-07-40](https://cloud.githubusercontent.com/assets/111716/20018956/73f7a3b6-a2a0-11e6-8932-ecc38a3c0a1b.png)

Requires https://github.com/pelias/text-analyzer/pull/15 to be merged.
