### PR TITLE
Adjust autocomplete focus boost

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -31,7 +31,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'focus:offset': '0km',
   'focus:scale': '250km',
   'focus:decay': 0.5,
-  'focus:weight': 40,
+  'focus:weight': 15,
 
   'function_score:score_mode': 'avg',
   'function_score:boost_mode': 'replace',

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -44,7 +44,7 @@ module.exports = {
                 'decay': 0.5
               }
             },
-            'weight': 40
+            'weight': 15
           }],
           'score_mode': 'avg',
           'boost_mode': 'replace',

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -44,7 +44,7 @@ module.exports = {
                 'decay': 0.5
               }
             },
-            'weight': 40
+            'weight': 15
           }],
           'score_mode': 'avg',
           'boost_mode': 'replace',


### PR DESCRIPTION
This lowers the autocomplete focus boost from 40 to 15. The idea is
that, because the boost for population is 20, the focus can't possibly
override a popular city, but it can come close.

On our default dev build, no acceptance tests fail but the san francisco
autocomplete test now passes!

It's not clear if this fixes WOF venue issues yet, since the latest
build there failed, so stay tuned :(