### PR TITLE
Use libpostal to parse address field

### DIFF
--- a/middleware/trimByGranularityComponent.js
+++ b/middleware/trimByGranularityComponent.js
@@ -22,8 +22,8 @@ const _ = require('lodash');
 //   supplied we want to retain borough=Manhattan and city=Manhattan results
 const layers = [
   'venue',
-  'street',
   'address',
+  'street',
   'neighbourhood',
   ['borough', 'locality'],
   'localadmin',
@@ -44,8 +44,8 @@ const layers = [
 // city=Manhattan
 const explicit_borough_layers = [
   'venue',
-  'street',
   'address',
+  'street',
   'neighbourhood',
   'borough',
   'locality',

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-labels": "1.5.1",
     "pelias-logger": "0.1.0",
     "pelias-model": "4.3.0",
-    "pelias-query": "pelias/query#5338af9",
+    "pelias-query": "8.10.0",
     "pelias-text-analyzer": "1.6.0",
     "stats-lite": "2.0.3",
     "through2": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-labels": "1.5.1",
     "pelias-logger": "0.1.0",
     "pelias-model": "4.3.0",
-    "pelias-query": "8.9.0",
+    "pelias-query": "pelias/query#5338af9",
     "pelias-text-analyzer": "1.6.0",
     "stats-lite": "2.0.3",
     "through2": "2.0.1"

--- a/sanitizer/_synthesize_analysis.js
+++ b/sanitizer/_synthesize_analysis.js
@@ -21,6 +21,10 @@ function isPostalCodeOnly(parsed_text) {
           parsed_text.hasOwnProperty('postalcode');
 }
 
+// figure out which field contains the probable house number, prefer number
+// libpostal parses some inputs, like `3370 cobbe ave`, as a postcode+street
+// so because we're treating the entire field as a street address, it's safe
+// to assume that an identified postcode is actually a house number.
 function getHouseNumberField(analyzed_address) {
   for (var field of ['number', 'postalcode']) {
     if (analyzed_address.hasOwnProperty(field)) {
@@ -54,20 +58,30 @@ function sanitize( raw, clean ){
   }
 
   if (clean.parsed_text.hasOwnProperty('address')) {
-    var analyzed_address = text_analyzer.parse(clean.parsed_text.address);
+    const analyzed_address = text_analyzer.parse(clean.parsed_text.address);
 
     const house_number_field = getHouseNumberField(analyzed_address);
 
+    // if we're fairly certain that libpostal identified a house number
+    // (from either the house_number or postcode field), place it into the
+    // number field and remove the first instance of that value from address
+    // and assign to street
+    // eg - '1090 N Charlotte St' becomes number=1090 and street=N Charlotte St
     if (house_number_field) {
       clean.parsed_text.number = analyzed_address[house_number_field];
 
+      // remove the first instance of the number and trim whitespace
       clean.parsed_text.street = _.trim(_.replace(clean.parsed_text.address, clean.parsed_text.number, ''));
-      delete clean.parsed_text.address;
 
     } else {
+      // otherwise no house number was identifiable, so treat the entire input
+      // as a street
       clean.parsed_text.street = clean.parsed_text.address;
-      delete clean.parsed_text.address;
+
     }
+
+    // the address field no longer means anything since it's been parsed, so remove it
+    delete clean.parsed_text.address;
 
   }
 

--- a/test/unit/fixture/component_geocoding/fallback.json
+++ b/test/unit/fixture/component_geocoding/fallback.json
@@ -8,6 +8,197 @@
               "should": [
                 {
                   "bool": {
+                    "_name": "fallback.address",
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.number": "number value"
+                        }
+                      },
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "city value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "state value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "should": [
+                      {
+                        "match_phrase": {
+                          "address_parts.zip": "postalcode value"
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "address"
+                      }
+                    },
+                    "boost": 50
+                  }
+                },
+                {
+                  "bool": {
+                    "_name": "fallback.street",
+                    "must": [
+                      {
+                        "match_phrase": {
+                          "address_parts.street": "street value"
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "city value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "state value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "should": [
+                      {
+                        "match_phrase": {
+                          "address_parts.zip": "postalcode value"
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "street"
+                      }
+                    },
+                    "boost": 100
+                  }
+                },
+                {
+                  "bool": {
                     "_name": "fallback.neighbourhood",
                     "must": [
                       {

--- a/test/unit/middleware/trimByGranularityComponent.js
+++ b/test/unit/middleware/trimByGranularityComponent.js
@@ -19,8 +19,8 @@ module.exports.tests.trimByGranularity = function(test, common) {
       data: [
         { name: 'venue 1', _matched_queries: ['fallback.venue'] },
         { name: 'venue 2', _matched_queries: ['fallback.venue'] },
-        { name: 'street 1', _matched_queries: ['fallback.street'] },
         { name: 'address 1', _matched_queries: ['fallback.address'] },
+        { name: 'street 1', _matched_queries: ['fallback.street'] },
         { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
         { name: 'borough 1', _matched_queries: ['fallback.borough'] },
         { name: 'locality 1', _matched_queries: ['fallback.locality'] },
@@ -55,45 +55,9 @@ module.exports.tests.trimByGranularity = function(test, common) {
 
     var res = {
       data: [
-        { name: 'street 1', _matched_queries: ['fallback.street'] },
-        { name: 'street 2', _matched_queries: ['fallback.street'] },
-        { name: 'address 1', _matched_queries: ['fallback.address'] },
-        { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
-        { name: 'borough 1', _matched_queries: ['fallback.borough'] },
-        { name: 'locality 1', _matched_queries: ['fallback.locality'] },
-        { name: 'localadmin 1', _matched_queries: ['fallback.localadmin'] },
-        { name: 'county 1', _matched_queries: ['fallback.county'] },
-        { name: 'macrocounty 1', _matched_queries: ['fallback.macrocounty'] },
-        { name: 'region 1', _matched_queries: ['fallback.region'] },
-        { name: 'macroregion 1', _matched_queries: ['fallback.macroregion'] },
-        { name: 'dependency 1', _matched_queries: ['fallback.dependency'] },
-        { name: 'country 1', _matched_queries: ['fallback.country'] },
-        { name: 'unknown', _matched_queries: ['fallback.unknown'] }
-      ]
-    };
-
-    var expected_data = [
-      { name: 'street 1', _matched_queries: ['fallback.street'] },
-      { name: 'street 2', _matched_queries: ['fallback.street'] }
-    ];
-
-    function testIt() {
-      trimByGranularity(req, res, function() {
-        t.deepEquals(res.data, expected_data, 'only street records should be here');
-        t.end();
-      });
-    }
-
-    testIt();
-  });
-
-  test('all records with fallback.* matched_queries name should retain only address when they are most granular', function(t) {
-    var req = { clean: {} };
-
-    var res = {
-      data: [
         { name: 'address 1', _matched_queries: ['fallback.address'] },
         { name: 'address 2', _matched_queries: ['fallback.address'] },
+        { name: 'street 1', _matched_queries: ['fallback.street'] },
         { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
         { name: 'borough 1', _matched_queries: ['fallback.borough'] },
         { name: 'locality 1', _matched_queries: ['fallback.locality'] },
@@ -110,12 +74,48 @@ module.exports.tests.trimByGranularity = function(test, common) {
 
     var expected_data = [
       { name: 'address 1', _matched_queries: ['fallback.address'] },
-      { name: 'address 2', _matched_queries: ['fallback.address'] },
+      { name: 'address 2', _matched_queries: ['fallback.address'] }
     ];
 
     function testIt() {
       trimByGranularity(req, res, function() {
         t.deepEquals(res.data, expected_data, 'only address records should be here');
+        t.end();
+      });
+    }
+
+    testIt();
+  });
+
+  test('all records with fallback.* matched_queries name should retain only street when they are most granular', function(t) {
+    var req = { clean: {} };
+
+    var res = {
+      data: [
+        { name: 'street 1', _matched_queries: ['fallback.street'] },
+        { name: 'street 2', _matched_queries: ['fallback.street'] },
+        { name: 'neighbourhood 1', _matched_queries: ['fallback.neighbourhood'] },
+        { name: 'borough 1', _matched_queries: ['fallback.borough'] },
+        { name: 'locality 1', _matched_queries: ['fallback.locality'] },
+        { name: 'localadmin 1', _matched_queries: ['fallback.localadmin'] },
+        { name: 'county 1', _matched_queries: ['fallback.county'] },
+        { name: 'macrocounty 1', _matched_queries: ['fallback.macrocounty'] },
+        { name: 'region 1', _matched_queries: ['fallback.region'] },
+        { name: 'macroregion 1', _matched_queries: ['fallback.macroregion'] },
+        { name: 'dependency 1', _matched_queries: ['fallback.dependency'] },
+        { name: 'country 1', _matched_queries: ['fallback.country'] },
+        { name: 'unknown', _matched_queries: ['fallback.unknown'] }
+      ]
+    };
+
+    var expected_data = [
+      { name: 'street 1', _matched_queries: ['fallback.street'] },
+      { name: 'street 2', _matched_queries: ['fallback.street'] },
+    ];
+
+    function testIt() {
+      trimByGranularity(req, res, function() {
+        t.deepEquals(res.data, expected_data, 'only street records should be here');
         t.end();
       });
     }

--- a/test/unit/query/component_geocoding.js
+++ b/test/unit/query/component_geocoding.js
@@ -14,7 +14,6 @@ module.exports.tests.query = function(test, common) {
   test('valid search + focus + bbox', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test',
       querySize: 10,
@@ -39,7 +38,6 @@ module.exports.tests.query = function(test, common) {
   test('valid search + bbox', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test',
       querySize: 10,
@@ -63,7 +61,6 @@ module.exports.tests.query = function(test, common) {
   test('valid lingustic-only search', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test', querySize: 10,
       layers: ['test']
@@ -82,7 +79,6 @@ module.exports.tests.query = function(test, common) {
   test('search search + focus', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test', querySize: 10,
       'focus.point.lat': 29.49136, 'focus.point.lon': -82.50622,
@@ -102,7 +98,6 @@ module.exports.tests.query = function(test, common) {
   test('search search + viewport', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test', querySize: 10,
       'focus.viewport.min_lat': 28.49136,
@@ -127,7 +122,6 @@ module.exports.tests.query = function(test, common) {
   test('search with viewport diagonal < 1km should set scale to 1km', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test', querySize: 10,
       'focus.viewport.min_lat': 28.49135,
@@ -150,7 +144,6 @@ module.exports.tests.query = function(test, common) {
   test('search search + focus on null island', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test', querySize: 10,
       'focus.point.lat': 0, 'focus.point.lon': 0,
@@ -198,7 +191,6 @@ module.exports.tests.query = function(test, common) {
   test('valid boundary.country search', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       text: 'test', querySize: 10,
       layers: ['test'],
@@ -218,7 +210,6 @@ module.exports.tests.query = function(test, common) {
   test('valid sources filter', function(t) {
     var clean = {
       parsed_text: {
-        street: 'street value'
       },
       'text': 'test',
       'sources': ['test_source']


### PR DESCRIPTION
This PR adds support to call text-analyzer (effectively libpostal) to parse the `address` field into `number` and `street` fields.  Libpostal isn't fool-proof for this task, so there are 2 scenarios that this covers:

- `number` can be parsed from `address` field as expected:

```
> 1220 calle de lago

Result:

{
  "house_number": "1220",
  "road": "calle de lago"
}
```

- `number` is identified as `postcode` (`postcode` can be reasonably safely assumed to be the `number` since the caller has already stated that the input is the address portion):

```
> 1338 kobbe ave

Result:

{
  "postcode": "1338",
  "road": "kobbe ave"
}
```

Text analysis is only called if an `address` field was supplied.  If libpostal identifies both a `house_number` *and* `postcode` fields, `house_number` is used for the `number` field.  Regardless of field, if a `number` has been identified, the *first* instance of this value is removed from `address`.  If no `number` can be extracted from the `address` field, the entire `address` field is moved to the `street` field.  

For example:

```
> 15 us route 15

Result:

{
  "house_number": "15",
  "road": "us route 15"
}
```

The result will be that `number` is now `15`, `street` is now `us route 15`, and `address` is removed.  There's no guarantee that this will work in all cases.  

It does not matter what libpostal parses the rest of the `address` field as, the remainder after the `number` value is removed is assigned to `street`.  

For example:

```
> 5 russian hill pl

Result:

{
  "house_number": "5",
  "suburb": "russian hill",
  "road": "pl"
}
```

assigns "russian hill pl" to `street`.  

Fixes pelias/pelias#454
See pelias/query#52