### PR TITLE
improvements for handling non-scalar request params. fixes #744

### DIFF
--- a/sanitizer/_single_scalar_parameters.js
+++ b/sanitizer/_single_scalar_parameters.js
@@ -10,8 +10,10 @@ function sanitize( raw, clean ){
   Object.keys(raw).forEach(function(key) {
     if (_.isArray(raw[key])) {
       messages.errors.push('\'' + key + '\' parameter can only have one value');
+      delete raw[key];
     } else if (_.isObject(raw[key])) {
       messages.errors.push('\'' + key + '\' parameter must be a scalar');
+      delete raw[key];
     }
 
   });

--- a/sanitizer/component_geocoding.js
+++ b/sanitizer/component_geocoding.js
@@ -2,8 +2,8 @@ var type_mapping = require('../helper/type_mapping');
 
 var sanitizeAll = require('../sanitizer/sanitizeAll'),
     sanitizers = {
-      quattroshapes_deprecation: require('../sanitizer/_deprecate_quattroshapes'),
       singleScalarParameters: require('../sanitizer/_single_scalar_parameters'),
+      quattroshapes_deprecation: require('../sanitizer/_deprecate_quattroshapes'),
       synthesize_analysis: require('../sanitizer/_synthesize_analysis'),
       iso2_to_iso3: require('../sanitizer/_iso2_to_iso3'),
       size: require('../sanitizer/_size')(/* use defaults*/),

--- a/sanitizer/reverse.js
+++ b/sanitizer/reverse.js
@@ -2,8 +2,8 @@
 var type_mapping = require('../helper/type_mapping');
 var sanitizeAll = require('../sanitizer/sanitizeAll'),
     sanitizers = {
-      quattroshapes_deprecation: require('../sanitizer/_deprecate_quattroshapes'),
       singleScalarParameters: require('../sanitizer/_single_scalar_parameters'),
+      quattroshapes_deprecation: require('../sanitizer/_deprecate_quattroshapes'),
       layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),
       sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
       // depends on the layers and sources sanitizers, must be run after them

--- a/sanitizer/search.js
+++ b/sanitizer/search.js
@@ -2,8 +2,8 @@ var type_mapping = require('../helper/type_mapping');
 
 var sanitizeAll = require('../sanitizer/sanitizeAll'),
     sanitizers = {
-      quattroshapes_deprecation: require('../sanitizer/_deprecate_quattroshapes'),
       singleScalarParameters: require('../sanitizer/_single_scalar_parameters'),
+      quattroshapes_deprecation: require('../sanitizer/_deprecate_quattroshapes'),
       text: require('../sanitizer/_text'),
       iso2_to_iso3: require('../sanitizer/_iso2_to_iso3'),
       size: require('../sanitizer/_size')(/* use defaults*/),

--- a/test/ciao/autocomplete/non_scalar_parameter_array.coffee
+++ b/test/ciao/autocomplete/non_scalar_parameter_array.coffee
@@ -1,9 +1,9 @@
 
-#> address parsing
-path: '/v1/search?text=30%20w%2026th%20st%2C%20ny'
+#> define two sources
+path: '/v1/autocomplete?text=A&sources=A&sources=B'
 
 #? 200 ok
-response.statusCode.should.be.equal 200
+response.statusCode.should.be.equal 400
 response.should.have.header 'charset', 'utf8'
 response.should.have.header 'content-type', 'application/json; charset=utf-8'
 
@@ -22,21 +22,9 @@ should.exist json.geocoding.timestamp
 json.type.should.be.equal 'FeatureCollection'
 json.features.should.be.instanceof Array
 
-#? expected errors
-should.not.exist json.geocoding.errors
-
 #? expected warnings
 should.not.exist json.geocoding.warnings
 
-#? inputs
-json.geocoding.query['text'].should.eql '30 w 26th st, ny'
-json.geocoding.query['size'].should.eql 10
-
-#? address parsing
-json.geocoding.query.parsed_text['number'].should.eql '30'
-json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
-json.geocoding.query.parsed_text['state'].should.eql 'NY'
-
-json.features[0].properties.confidence.should.eql 1
-json.features[0].properties.match_type.should.eql "exact"
-json.features[0].properties.accuracy.should.eql "point"
+#? expected errors
+should.exist json.geocoding.errors
+json.geocoding.errors.should.eql [ '\'sources\' parameter can only have one value' ]

--- a/test/ciao/autocomplete/non_scalar_parameter_object.coffee
+++ b/test/ciao/autocomplete/non_scalar_parameter_object.coffee
@@ -1,9 +1,9 @@
 
-#> address parsing
-path: '/v1/search?text=30%20w%2026th%20st%2C%20ny'
+#> define parameter as object
+path: '/v1/autocomplete?text=A&parameter[idx]=value'
 
 #? 200 ok
-response.statusCode.should.be.equal 200
+response.statusCode.should.be.equal 400
 response.should.have.header 'charset', 'utf8'
 response.should.have.header 'content-type', 'application/json; charset=utf-8'
 
@@ -22,21 +22,9 @@ should.exist json.geocoding.timestamp
 json.type.should.be.equal 'FeatureCollection'
 json.features.should.be.instanceof Array
 
-#? expected errors
-should.not.exist json.geocoding.errors
-
 #? expected warnings
 should.not.exist json.geocoding.warnings
 
-#? inputs
-json.geocoding.query['text'].should.eql '30 w 26th st, ny'
-json.geocoding.query['size'].should.eql 10
-
-#? address parsing
-json.geocoding.query.parsed_text['number'].should.eql '30'
-json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
-json.geocoding.query.parsed_text['state'].should.eql 'NY'
-
-json.features[0].properties.confidence.should.eql 1
-json.features[0].properties.match_type.should.eql "exact"
-json.features[0].properties.accuracy.should.eql "point"
+#? expected errors
+should.exist json.geocoding.errors
+json.geocoding.errors.should.eql [ '\'parameter\' parameter must be a scalar' ]

--- a/test/ciao/reverse/non_scalar_parameter_array.coffee
+++ b/test/ciao/reverse/non_scalar_parameter_array.coffee
@@ -1,6 +1,6 @@
 
-#> set size
-path: '/v1/reverse?point.lat=1&point.lon=1&parameter[idx]=value'
+#> define two sources
+path: '/v1/reverse?point.lat=1&point.lon=1&sources=A&sources=B'
 
 #? 200 ok
 response.statusCode.should.be.equal 400
@@ -27,4 +27,4 @@ should.not.exist json.geocoding.warnings
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'parameter\' parameter must be a scalar' ]
+json.geocoding.errors.should.eql [ '\'sources\' parameter can only have one value' ]

--- a/test/ciao/reverse/non_scalar_parameter_object.coffee
+++ b/test/ciao/reverse/non_scalar_parameter_object.coffee
@@ -1,9 +1,9 @@
 
-#> address parsing
-path: '/v1/search?text=30%20w%2026th%20st%2C%20ny'
+#> define parameter as object
+path: '/v1/reverse?point.lat=1&point.lon=1&parameter[idx]=value'
 
 #? 200 ok
-response.statusCode.should.be.equal 200
+response.statusCode.should.be.equal 400
 response.should.have.header 'charset', 'utf8'
 response.should.have.header 'content-type', 'application/json; charset=utf-8'
 
@@ -22,21 +22,9 @@ should.exist json.geocoding.timestamp
 json.type.should.be.equal 'FeatureCollection'
 json.features.should.be.instanceof Array
 
-#? expected errors
-should.not.exist json.geocoding.errors
-
 #? expected warnings
 should.not.exist json.geocoding.warnings
 
-#? inputs
-json.geocoding.query['text'].should.eql '30 w 26th st, ny'
-json.geocoding.query['size'].should.eql 10
-
-#? address parsing
-json.geocoding.query.parsed_text['number'].should.eql '30'
-json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
-json.geocoding.query.parsed_text['state'].should.eql 'NY'
-
-json.features[0].properties.confidence.should.eql 1
-json.features[0].properties.match_type.should.eql "exact"
-json.features[0].properties.accuracy.should.eql "point"
+#? expected errors
+should.exist json.geocoding.errors
+json.geocoding.errors.should.eql [ '\'parameter\' parameter must be a scalar' ]

--- a/test/ciao/search/non_scalar_parameter_array.coffee
+++ b/test/ciao/search/non_scalar_parameter_array.coffee
@@ -1,9 +1,9 @@
 
-#> address parsing
-path: '/v1/search?text=30%20w%2026th%20st%2C%20ny'
+#> define two sources
+path: '/v1/search?text=A&sources=A&sources=B'
 
 #? 200 ok
-response.statusCode.should.be.equal 200
+response.statusCode.should.be.equal 400
 response.should.have.header 'charset', 'utf8'
 response.should.have.header 'content-type', 'application/json; charset=utf-8'
 
@@ -22,21 +22,9 @@ should.exist json.geocoding.timestamp
 json.type.should.be.equal 'FeatureCollection'
 json.features.should.be.instanceof Array
 
-#? expected errors
-should.not.exist json.geocoding.errors
-
 #? expected warnings
 should.not.exist json.geocoding.warnings
 
-#? inputs
-json.geocoding.query['text'].should.eql '30 w 26th st, ny'
-json.geocoding.query['size'].should.eql 10
-
-#? address parsing
-json.geocoding.query.parsed_text['number'].should.eql '30'
-json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
-json.geocoding.query.parsed_text['state'].should.eql 'NY'
-
-json.features[0].properties.confidence.should.eql 1
-json.features[0].properties.match_type.should.eql "exact"
-json.features[0].properties.accuracy.should.eql "point"
+#? expected errors
+should.exist json.geocoding.errors
+json.geocoding.errors.should.eql [ '\'sources\' parameter can only have one value' ]

--- a/test/ciao/search/non_scalar_parameter_object.coffee
+++ b/test/ciao/search/non_scalar_parameter_object.coffee
@@ -1,9 +1,9 @@
 
-#> address parsing
-path: '/v1/search?text=30%20w%2026th%20st%2C%20ny'
+#> define parameter as object
+path: '/v1/search?text=A&parameter[idx]=value'
 
 #? 200 ok
-response.statusCode.should.be.equal 200
+response.statusCode.should.be.equal 400
 response.should.have.header 'charset', 'utf8'
 response.should.have.header 'content-type', 'application/json; charset=utf-8'
 
@@ -22,21 +22,9 @@ should.exist json.geocoding.timestamp
 json.type.should.be.equal 'FeatureCollection'
 json.features.should.be.instanceof Array
 
-#? expected errors
-should.not.exist json.geocoding.errors
-
 #? expected warnings
 should.not.exist json.geocoding.warnings
 
-#? inputs
-json.geocoding.query['text'].should.eql '30 w 26th st, ny'
-json.geocoding.query['size'].should.eql 10
-
-#? address parsing
-json.geocoding.query.parsed_text['number'].should.eql '30'
-json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
-json.geocoding.query.parsed_text['state'].should.eql 'NY'
-
-json.features[0].properties.confidence.should.eql 1
-json.features[0].properties.match_type.should.eql "exact"
-json.features[0].properties.accuracy.should.eql "point"
+#? expected errors
+should.exist json.geocoding.errors
+json.geocoding.errors.should.eql [ '\'parameter\' parameter must be a scalar' ]

--- a/test/unit/sanitizer/_single_scalar_parameters.js
+++ b/test/unit/sanitizer/_single_scalar_parameters.js
@@ -18,6 +18,11 @@ module.exports.tests.single_scalar_parameters = function(test, common) {
       ],
       warnings: []
     });
+
+    // erroneous params should be deleted to avoid middleware errors
+    t.false(raw.arrayParameter1);
+    t.false(raw.arrayParameter2);
+
     t.end();
   });
 
@@ -36,6 +41,10 @@ module.exports.tests.single_scalar_parameters = function(test, common) {
       ],
       warnings: []
     });
+
+    // erroneous params should be deleted to avoid middleware errors
+    t.false(raw.objectParameter1);
+    t.false(raw.objectParameter2);
     t.end();
   });
 

--- a/test/unit/sanitizer/component_geocoding.js
+++ b/test/unit/sanitizer/component_geocoding.js
@@ -82,8 +82,8 @@ module.exports.tests.sanitize = function(test, common) {
     });
 
     var expected_sanitizers = [
-      '_deprecate_quattroshapes',
       '_single_scalar_parameters',
+      '_deprecate_quattroshapes',
       '_synthesize_analysis',
       '_iso2_to_iso3',
       '_size',

--- a/test/unit/sanitizer/nearby.js
+++ b/test/unit/sanitizer/nearby.js
@@ -30,7 +30,7 @@ module.exports.tests.interface = function(test, common) {
 
 module.exports.tests.sanitizers = function(test, common) {
   test('check sanitizer list', function (t) {
-    var expected = ['quattroshapes_deprecation', 'singleScalarParameters', 'layers',
+    var expected = ['singleScalarParameters', 'quattroshapes_deprecation', 'layers',
       'sources', 'sources_and_layers', 'size', 'private', 'geo_reverse', 'boundary_country', 'categories'];
     t.deepEqual(Object.keys(nearby.sanitizer_list), expected);
     t.end();

--- a/test/unit/sanitizer/reverse.js
+++ b/test/unit/sanitizer/reverse.js
@@ -36,7 +36,7 @@ module.exports.tests.interface = function(test, common) {
 
 module.exports.tests.sanitizers = function(test, common) {
   test('check sanitizer list', function (t) {
-    var expected = ['quattroshapes_deprecation', 'singleScalarParameters', 'layers',
+    var expected = ['singleScalarParameters', 'quattroshapes_deprecation', 'layers',
       'sources', 'sources_and_layers', 'size', 'private', 'geo_reverse', 'boundary_country'];
     t.deepEqual(Object.keys(reverse.sanitizer_list), expected);
     t.end();

--- a/test/unit/sanitizer/search.js
+++ b/test/unit/sanitizer/search.js
@@ -82,8 +82,8 @@ module.exports.tests.sanitize = function(test, common) {
     });
 
     var expected_sanitizers = [
-      '_deprecate_quattroshapes',
       '_single_scalar_parameters',
+      '_deprecate_quattroshapes',
       '_text',
       '_iso2_to_iso3',
       '_size',


### PR DESCRIPTION
improvements for handling non-scalar request params. fixes #744

this PR moves the `_single_scalar_parameters` sanitizer before all others and deletes any non-scalar parameters so they cannot cause issues in other sanitizers/middleware.

added more ciao tests to cover these cases