### PR TITLE
npm start fix for Ubuntu 14.04.5 running node v6.9.1 & npm  v3.10.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash": "^4.5.0",
     "markdown": "0.5.0",
     "morgan": "1.7.0",
+    "node-postal": "0.3.0",
     "pelias-categories": "1.1.0",
     "pelias-config": "2.3.1",
     "pelias-labels": "1.5.1",


### PR DESCRIPTION
To fix the following error on Ubuntu 14.04.5 when running npm start.

> pelias-api@0.0.0-semantic-release start /data/code/api
> node index.js

/data/code/api/node_modules/bindings/bindings.js:91
  throw err
  ^
Error: Could not locate the bindings file. Tried:
 → /data/code/api/node_modules/node-postal/build/expand.node
 → /data/code/api/node_modules/node-postal/build/Debug/expand.node
 → /data/code/api/node_modules/node-postal/build/Release/expand.node
 → /data/code/api/node_modules/node-postal/out/Debug/expand.node
 → /data/code/api/node_modules/node-postal/Debug/expand.node
 → /data/code/api/node_modules/node-postal/out/Release/expand.node
 → /data/code/api/node_modules/node-postal/Release/expand.node
 → /data/code/api/node_modules/node-postal/build/default/expand.node

▽
 → /data/code/api/node_modules/node-postal/compiled/6.9.1/linux/x64/expand.node
    at bindings (/data/code/api/node_modules/bindings/bindings.js:88:9)
    at Object.<anonymous> (/data/code/api/node_modules/node-postal/index.js:3:32)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/data/code/api/node_modules/pelias-text-analyzer/index.js:9:16)

npm ERR! Linux 3.13.0-101-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "start"
npm ERR! node v6.9.1
npm ERR! npm  v3.10.8
npm ERR! code ELIFECYCLE
npm ERR! pelias-api@0.0.0-semantic-release start: `node index.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the pelias-api@0.0.0-semantic-release start script 'node index.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the pelias-api package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node index.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs pelias-api
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls pelias-api
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /data/code/api/npm-debug.log