### PR TITLE
Minimize debug logging

### DIFF
--- a/query/text_parser_addressit.js
+++ b/query/text_parser_addressit.js
@@ -31,7 +31,7 @@ function addParsedVariablesToQueryVariables( parsed_text, vs ){
 
   // ?
   else {
-    logger.warn( 'chaos monkey asks: what happens now?', parsed_text );
+    logger.warn( 'chaos monkey asks: what happens now?' );
   }
 
   // ==== add parsed matches [address components] ====

--- a/query/text_parser_addressit.js
+++ b/query/text_parser_addressit.js
@@ -31,9 +31,7 @@ function addParsedVariablesToQueryVariables( parsed_text, vs ){
 
   // ?
   else {
-    logger.warn( 'chaos monkey asks: what happens now?' );
-    logger.warn( parsed_text );
-    try{ throw new Error(); } catch(e){ logger.warn( e.stack ); } // print a stack trace
+    logger.warn( 'chaos monkey asks: what happens now?', parsed_text );
   }
 
   // ==== add parsed matches [address components] ====


### PR DESCRIPTION
The chaos monkey log statement in addressit code doesn't need to report the full stack every time it happens. We already know where in the code it's taking place, so keeping the log free of an unnecessary `Error` strings would be helpful for debugging of other conditions.