### PR TITLE
Add query support to structured

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-labels": "1.5.1",
     "pelias-logger": "0.1.0",
     "pelias-model": "4.4.0",
-    "pelias-query": "pelias/query#fe42de6",
+    "pelias-query": "8.12.0",
     "pelias-text-analyzer": "1.7.0",
     "stats-lite": "2.0.3",
     "through2": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-labels": "1.5.1",
     "pelias-logger": "0.1.0",
     "pelias-model": "4.4.0",
-    "pelias-query": "8.11.0",
+    "pelias-query": "pelias/query#b3e2ef7",
     "pelias-text-analyzer": "1.7.0",
     "stats-lite": "2.0.3",
     "through2": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-labels": "1.5.1",
     "pelias-logger": "0.1.0",
     "pelias-model": "4.4.0",
-    "pelias-query": "pelias/query#b3e2ef7",
+    "pelias-query": "pelias/query#fe42de6",
     "pelias-text-analyzer": "1.7.0",
     "stats-lite": "2.0.3",
     "through2": "^2.0.3"

--- a/sanitizer/_synthesize_analysis.js
+++ b/sanitizer/_synthesize_analysis.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const text_analyzer = require('pelias-text-analyzer');
 
 const fields = {
+  'query': 'query',
   'address': 'address',
   'neighbourhood': 'neighbourhood',
   'borough': 'borough',

--- a/sanitizer/_synthesize_analysis.js
+++ b/sanitizer/_synthesize_analysis.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const text_analyzer = require('pelias-text-analyzer');
 
 const fields = {
-  'query': 'query',
+  'venue': 'query',
   'address': 'address',
   'neighbourhood': 'neighbourhood',
   'borough': 'borough',

--- a/test/unit/fixture/structured_geocoding/fallback.json
+++ b/test/unit/fixture/structured_geocoding/fallback.json
@@ -15,7 +15,8 @@
                           "query": "query value",
                           "type": "phrase",
                           "fields": [
-                            "phrase.default"
+                            "phrase.default",
+                            "category"
                           ]
                         }
                       },

--- a/test/unit/fixture/structured_geocoding/fallback.json
+++ b/test/unit/fixture/structured_geocoding/fallback.json
@@ -8,6 +8,95 @@
               "should": [
                 {
                   "bool": {
+                    "_name": "fallback.venue",
+                    "must": [
+                      {
+                        "multi_match": {
+                          "query": "query value",
+                          "type": "phrase",
+                          "fields": [
+                            "phrase.default"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "neighbourhood value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.neighbourhood",
+                            "parent.neighbourhood_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "borough value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.borough",
+                            "parent.borough_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "city value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.locality",
+                            "parent.locality_a",
+                            "parent.localadmin",
+                            "parent.localadmin_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "county value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.county",
+                            "parent.county_a",
+                            "parent.macrocounty",
+                            "parent.macrocounty_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "state value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.region",
+                            "parent.region_a",
+                            "parent.macroregion",
+                            "parent.macroregion_a"
+                          ]
+                        }
+                      },
+                      {
+                        "multi_match": {
+                          "query": "country value",
+                          "type": "phrase",
+                          "fields": [
+                            "parent.country",
+                            "parent.country_a",
+                            "parent.dependency",
+                            "parent.dependency_a"
+                          ]
+                        }
+                      }
+                    ],
+                    "filter": {
+                      "term": {
+                        "layer": "venue"
+                      }
+                    }
+                  }
+                },
+                {
+                  "bool": {
                     "_name": "fallback.address",
                     "must": [
                       {

--- a/test/unit/sanitizer/_synthesize_analysis.js
+++ b/test/unit/sanitizer/_synthesize_analysis.js
@@ -26,6 +26,7 @@ module.exports.tests.text_parser = function(test, common) {
 
     const expected_clean = {
       parsed_text: {
+        query: 'query value',
         neighbourhood: 'neighbourhood value',
         borough: 'borough value',
         city: 'locality value',
@@ -58,6 +59,7 @@ module.exports.tests.text_parser = function(test, common) {
     }
 
     const raw = {
+      query: getInvalidValue(),
       address: getInvalidValue(),
       neighbourhood: getInvalidValue(),
       borough: getInvalidValue(),
@@ -78,7 +80,7 @@ module.exports.tests.text_parser = function(test, common) {
 
     t.deepEquals(clean, expected_clean);
     t.deepEquals(messages.errors, ['at least one of the following fields is required: ' +
-      'address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
+      'query, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
     t.deepEquals(messages.warnings, [], 'no warnings');
     t.end();
 
@@ -101,7 +103,7 @@ module.exports.tests.text_parser = function(test, common) {
 
     t.deepEquals(clean, expected_clean);
     t.deepEquals(messages.errors, ['at least one of the following fields is required: ' +
-      'address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
+      'query, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
     t.deepEquals(messages.warnings, [], 'no warnings');
     t.end();
 

--- a/test/unit/sanitizer/_synthesize_analysis.js
+++ b/test/unit/sanitizer/_synthesize_analysis.js
@@ -12,7 +12,7 @@ module.exports.tests.text_parser = function(test, common) {
     }});
 
     const raw = {
-      query: ' \t query \t value \t ',
+      venue: ' \t venue \t value \t ',
       neighbourhood: ' \t neighbourhood \t value \t ',
       borough: ' \t borough \t value \t ',
       locality: ' \t locality \t value \t ',
@@ -26,7 +26,7 @@ module.exports.tests.text_parser = function(test, common) {
 
     const expected_clean = {
       parsed_text: {
-        query: 'query value',
+        query: 'venue value',
         neighbourhood: 'neighbourhood value',
         borough: 'borough value',
         city: 'locality value',
@@ -59,7 +59,7 @@ module.exports.tests.text_parser = function(test, common) {
     }
 
     const raw = {
-      query: getInvalidValue(),
+      venue: getInvalidValue(),
       address: getInvalidValue(),
       neighbourhood: getInvalidValue(),
       borough: getInvalidValue(),
@@ -80,7 +80,7 @@ module.exports.tests.text_parser = function(test, common) {
 
     t.deepEquals(clean, expected_clean);
     t.deepEquals(messages.errors, ['at least one of the following fields is required: ' +
-      'query, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
+      'venue, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
     t.deepEquals(messages.warnings, [], 'no warnings');
     t.end();
 
@@ -103,7 +103,7 @@ module.exports.tests.text_parser = function(test, common) {
 
     t.deepEquals(clean, expected_clean);
     t.deepEquals(messages.errors, ['at least one of the following fields is required: ' +
-      'query, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
+      'venue, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
     t.deepEquals(messages.warnings, [], 'no warnings');
     t.end();
 


### PR DESCRIPTION
Adds `query` parameter support to `/v1/search/structured`.  Most everything was in place before, this just adds `query` to analysis synthesis and adjusts tests to query module changes.  

Connected to pelias/pelias#483