### PR TITLE
Empty values in parsed text caused exceptions

### DIFF
--- a/query/text_parser.js
+++ b/query/text_parser.js
@@ -1,67 +1,68 @@
 var logger = require('pelias-logger').get('api');
+var _ = require('lodash');
 
 // all the address parsing logic
 function addParsedVariablesToQueryVariables( parsed_text, vs ){
   // ==== add parsed matches [address components] ====
 
   // query - Mexitaly, Sunoco, Lowes
-  if (parsed_text.hasOwnProperty('query')) {
+  if ( ! _.isEmpty(parsed_text.query) ) {
     vs.var('input:query', parsed_text.query);
   }
 
   // categories - restaurants, hotels, bars
-  if (parsed_text.hasOwnProperty('category')) {
+  if ( ! _.isEmpty(parsed_text.category) ) {
     vs.var('input:category', parsed_text.category);
   }
 
-  if (parsed_text.hasOwnProperty('address')) {
+  if ( ! _.isEmpty(parsed_text.address) ) {
     vs.var( 'input:address', parsed_text.address );
   }
 
   // house number
-  if( parsed_text.hasOwnProperty('number') ){
+  if( ! _.isEmpty(parsed_text.number) ){
     vs.var( 'input:housenumber', parsed_text.number );
   }
 
   // street name
-  if( parsed_text.hasOwnProperty('street') ){
+  if( ! _.isEmpty(parsed_text.street) ){
     vs.var( 'input:street', parsed_text.street );
   }
 
   // neighbourhood
-  if (parsed_text.hasOwnProperty('neighbourhood')) {
+  if ( ! _.isEmpty(parsed_text.neighbourhood) ) {
     vs.var( 'input:neighbourhood', parsed_text.neighbourhood);
   }
 
   // borough
-  if (parsed_text.hasOwnProperty('borough')) {
+  if ( ! _.isEmpty(parsed_text.borough) ) {
     vs.var( 'input:borough', parsed_text.borough);
   }
 
   // postal code
-  if( parsed_text.hasOwnProperty('postalcode') ){
+  if( ! _.isEmpty(parsed_text.postalcode) ){
     vs.var( 'input:postcode', parsed_text.postalcode );
   }
 
   // ==== add parsed matches [admin components] ====
 
   // city
-  if( parsed_text.hasOwnProperty('city') ){
+  if( ! _.isEmpty(parsed_text.city) ){
     vs.var( 'input:locality', parsed_text.city );
   }
 
   // county
-  if( parsed_text.hasOwnProperty('county') ){
+  if( ! _.isEmpty(parsed_text.county) ){
     vs.var( 'input:county', parsed_text.county );
   }
 
   // state
-  if( parsed_text.hasOwnProperty('state') ){
+  if( ! _.isEmpty(parsed_text.state) ){
     vs.var( 'input:region', parsed_text.state );
   }
 
   // country
-  if( parsed_text.hasOwnProperty('country') ){
+  if( ! _.isEmpty(parsed_text.country) ){
     vs.var( 'input:country', parsed_text.country );
   }
 

--- a/test/unit/query/text_parser.js
+++ b/test/unit/query/text_parser.js
@@ -157,6 +157,48 @@ module.exports.tests.housenumber_special_cases = function(test, common) {
 
 };
 
+module.exports.tests.empty_values = function(test, common) {
+  test('empty string values not set', function (t) {
+    var parsed_text = {
+      query: '',
+      category: '',
+      number: '',
+      street: '',
+      address: '',
+      neighbourhood: '',
+      borough: '',
+      postalcode: '',
+      city: '',
+      county: '',
+      state: '',
+      country: ''
+    };
+    var vs = new VariableStore();
+
+    function testIt() {
+      text_parser(parsed_text, vs);
+    }
+
+    t.doesNotThrow(testIt, 'exception should not be thrown');
+
+    t.false(vs.isset('input:query'));
+    t.false(vs.isset('input:category'));
+    t.false(vs.isset('input:housenumber'));
+    t.false(vs.isset('input:street'));
+    t.false(vs.isset('input:address'));
+    t.false(vs.isset('input:neighbourhood'));
+    t.false(vs.isset('input:borough'));
+    t.false(vs.isset('input:postcode'));
+    t.false(vs.isset('input:locality'));
+    t.false(vs.isset('input:county'));
+    t.false(vs.isset('input:region'));
+    t.false(vs.isset('input:country'));
+    t.end();
+
+  });
+
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('text_parser ' + name, testFunction);


### PR DESCRIPTION
Using `hasOwnProperty` to check for valid values fails to catch the case of an empty string value.
Setting a query variable to an empty string rightfully causes an exception.

Fixes pelias/pelias#490