### PR TITLE
added target that just dumps the configuration for debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The API ships with several convenience commands (runnable via `npm`):
   * `npm run ciao`: run functional tests (this requires that the server be running)
   * `npm run docs`: generate API documentation
   * `npm run coverage`: generate code coverage reports
+  * `npm run config`: dump the configuration to the command line, which is useful for debugging configuration issues
 
 ## pelias-config
 The API recognizes the following properties under the top-level `api` key in your `pelias.json` config file:
@@ -95,5 +96,3 @@ Travis tests every release against Node.js versions `4` and `6`.
 We rely on semantic-release and Greenkeeper to maintain our module and dependency versions.
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/pelias/api.svg)](https://greenkeeper.io/)
-
-

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "travis": "npm test",
     "unit": "./bin/units",
     "validate": "npm ls",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "config": "node -e \"console.log(JSON.stringify(require( 'pelias-config' ).generate(require('./schema')), null, 2))\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
run `npm run config` to dump the config to STDOUT