### PR TITLE
fix ciao tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "through2": "^2.0.3"
   },
   "devDependencies": {
-    "ciao": "git://github.com/missinglink/ciao.git#sync",
+    "ciao": "^1.0.0",
     "difflet": "^1.0.1",
     "istanbul": "^0.4.2",
     "jshint": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "through2": "^2.0.3"
   },
   "devDependencies": {
-    "ciao": "^0.6.0",
+    "ciao": "git://github.com/missinglink/ciao.git#sync",
     "difflet": "^1.0.1",
     "istanbul": "^0.4.2",
     "jshint": "^2.5.6",

--- a/test/ciao/autocomplete/layers_alias_coarse.coffee
+++ b/test/ciao/autocomplete/layers_alias_coarse.coffee
@@ -44,5 +44,6 @@ json.geocoding.query.layers.should.eql [ "continent",
   "borough",
   "neighbourhood",
   "microhood",
-  "disputed"
+  "disputed",
+  "postalcode"
 ]

--- a/test/ciao/autocomplete/layers_invalid.coffee
+++ b/test/ciao/autocomplete/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed,postalcode' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/autocomplete/layers_mix_invalid_valid.coffee
+++ b/test/ciao/autocomplete/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed,postalcode' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/layers_alias_coarse.coffee
+++ b/test/ciao/reverse/layers_alias_coarse.coffee
@@ -43,5 +43,6 @@ json.geocoding.query.layers.should.eql [ "continent",
   "borough",
   "neighbourhood",
   "microhood",
-  "disputed"
+  "disputed",
+  "postalcode"
 ]

--- a/test/ciao/reverse/layers_invalid.coffee
+++ b/test/ciao/reverse/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed,postalcode' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/reverse/layers_mix_invalid_valid.coffee
+++ b/test/ciao/reverse/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed,postalcode' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/address_parsing.coffee
+++ b/test/ciao/search/address_parsing.coffee
@@ -35,7 +35,7 @@ json.geocoding.query['size'].should.eql 10
 #? address parsing
 json.geocoding.query.parsed_text['number'].should.eql '30'
 json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
-json.geocoding.query.parsed_text['state'].should.eql 'NY'
+json.geocoding.query.parsed_text['state'].should.eql 'ny'
 
 json.features[0].properties.confidence.should.eql 1
 json.features[0].properties.match_type.should.eql "exact"

--- a/test/ciao/search/layers_alias_coarse.coffee
+++ b/test/ciao/search/layers_alias_coarse.coffee
@@ -44,5 +44,6 @@ json.geocoding.query.layers.should.eql [ "continent",
   "borough",
   "neighbourhood",
   "microhood",
-  "disputed"
+  "disputed",
+  "postalcode"
 ]

--- a/test/ciao/search/layers_invalid.coffee
+++ b/test/ciao/search/layers_invalid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed,postalcode' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings

--- a/test/ciao/search/layers_mix_invalid_valid.coffee
+++ b/test/ciao/search/layers_mix_invalid_valid.coffee
@@ -24,7 +24,7 @@ json.features.should.be.instanceof Array
 
 #? expected errors
 should.exist json.geocoding.errors
-json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed' ]
+json.geocoding.errors.should.eql [ '\'notlayer\' is an invalid layers parameter. Valid options: coarse,address,venue,street,country,macroregion,region,county,localadmin,locality,borough,neighbourhood,continent,dependency,macrocounty,macrohood,microhood,disputed,postalcode' ]
 
 #? expected warnings
 should.not.exist json.geocoding.warnings


### PR DESCRIPTION
- fix ciao tests for postalcode layer added
- run ciao tests syncronously

this PR also fixes the 100% cpu issues with ciao and allows it to run on node versions 0.10, 0.12, 4 & 6!