### PR TITLE
Move request to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "pelias-text-analyzer": "1.7.2",
     "predicates": "^1.0.1",
     "retry": "^0.10.1",
+    "request": "^2.79.0",
     "stats-lite": "^2.0.4",
     "superagent": "^3.2.1",
     "through2": "^2.0.3"
@@ -76,7 +77,6 @@
     "nsp": "^2.2.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^1.7.10",
-    "request": "^2.79.0",
     "semantic-release": "^6.3.2",
     "source-map": "^0.5.6",
     "tap-dot": "1.0.5",


### PR DESCRIPTION
It's now required for the pip-service, not just tests (see https://github.com/pelias/api/blob/fix-request-dependency/service/pointinpolygon.js#L2)