### PR TITLE
Sort interpolated results to show address first

### DIFF
--- a/middleware/interpolate.js
+++ b/middleware/interpolate.js
@@ -43,6 +43,13 @@ function setup() {
         res.data = results;
       }
 
+      // sort the results to ensure that addresses show up higher than street centroids      
+      res.data = res.data.sort((a, b) => {
+        if (a.layer === 'address' && b.layer !== 'address') { return -1; }
+        if (a.layer !== 'address' && b.layer === 'address') { return 1; }
+        return 0;
+      });
+
       // log the execution time, continue
       logger.info( '[interpolation] [took]', (new Date()).getTime() - timer, 'ms' );
       next();


### PR DESCRIPTION
Sometimes multiple streets are sent to the interpolation service for evaluation and only one comes back with an address hit. In that case, if that successful hit was not the first street, it will remain in its position in the list, even though that's clearly the correct result and should be at the top of the list.

This change sorts the interpolated results to ensure that any address records show up above all others.