### PR TITLE
pass DNT to pip service and sanitize error messages

### DIFF
--- a/test/unit/service/pointinpolygon.js
+++ b/test/unit/service/pointinpolygon.js
@@ -25,11 +25,28 @@ module.exports.tests.do_nothing_service = (test, common) => {
       'pelias-logger': logger
     })();
 
-    service({ lat: 12.121212, lon: 21.212121 }, (err) => {
+    service({ lat: 12.121212, lon: 21.212121 }, false, (err) => {
       t.deepEquals(logger.getWarnMessages(), [
         'point-in-polygon service disabled'
       ]);
       t.equals(err, 'point-in-polygon service disabled, unable to resolve {"lat":12.121212,"lon":21.212121}');
+      t.end();
+    });
+
+  });
+
+  test('service unavailable message should not output centroid when do_not_track is true', (t) => {
+    const logger = require('pelias-mock-logger')();
+
+    const service = proxyquire('../../../service/pointinpolygon', {
+      'pelias-logger': logger
+    })();
+
+    service({ lat: 12.121212, lon: 21.212121 }, true, (err) => {
+      t.deepEquals(logger.getWarnMessages(), [
+        'point-in-polygon service disabled'
+      ]);
+      t.equals(err, 'point-in-polygon service disabled, unable to resolve centroid');
       t.end();
     });
 
@@ -56,13 +73,81 @@ module.exports.tests.success = (test, common) => {
       'pelias-logger': logger
     })(`http://localhost:${port}`);
 
-    service({ lat: 12.121212, lon: 21.212121}, (err, results) => {
+    service({ lat: 12.121212, lon: 21.212121}, false, (err, results) => {
       t.notOk(err);
       t.deepEquals(results, { field: 'value' });
 
       t.ok(logger.isInfoMessage(`using point-in-polygon service at http://localhost:${port}`));
       t.notOk(logger.hasErrorMessages());
-      
+
+      t.end();
+
+      server.close();
+
+    });
+
+  });
+
+  test('do_not_track=true should pass DNT header', (t) => {
+    const pipServer = require('express')();
+    pipServer.get('/:lon/:lat', (req, res, next) => {
+      t.ok(req.headers.hasOwnProperty('dnt'));
+      t.equals(req.params.lat, '12.121212');
+      t.equals(req.params.lon, '21.212121');
+
+      res.send('{ "field": "value" }');
+    });
+
+    const server = pipServer.listen();
+    const port = server.address().port;
+
+    const logger = require('pelias-mock-logger')();
+
+    const service = proxyquire('../../../service/pointinpolygon', {
+      'pelias-logger': logger
+    })(`http://localhost:${port}`);
+
+    service({ lat: 12.121212, lon: 21.212121}, true, (err, results) => {
+      t.notOk(err);
+      t.deepEquals(results, { field: 'value' });
+
+      t.ok(logger.isInfoMessage(`using point-in-polygon service at http://localhost:${port}`));
+      t.notOk(logger.hasErrorMessages());
+
+      t.end();
+
+      server.close();
+
+    });
+
+  });
+
+  test('do_not_track=false should not pass DNT header', (t) => {
+    const pipServer = require('express')();
+    pipServer.get('/:lon/:lat', (req, res, next) => {
+      t.notOk(req.headers.hasOwnProperty('dnt'));
+      t.equals(req.params.lat, '12.121212');
+      t.equals(req.params.lon, '21.212121');
+
+      res.send('{ "field": "value" }');
+    });
+
+    const server = pipServer.listen();
+    const port = server.address().port;
+
+    const logger = require('pelias-mock-logger')();
+
+    const service = proxyquire('../../../service/pointinpolygon', {
+      'pelias-logger': logger
+    })(`http://localhost:${port}`);
+
+    service({ lat: 12.121212, lon: 21.212121}, false, (err, results) => {
+      t.notOk(err);
+      t.deepEquals(results, { field: 'value' });
+
+      t.ok(logger.isInfoMessage(`using point-in-polygon service at http://localhost:${port}`));
+      t.notOk(logger.hasErrorMessages());
+
       t.end();
 
       server.close();
@@ -92,10 +177,46 @@ module.exports.tests.failure = (test, common) => {
       'pelias-logger': logger
     })(`http://localhost:${port}`);
 
-    service({ lat: 12.121212, lon: 21.212121}, (err, results) => {
-      t.equals(err, `http://localhost:${port}/21.212121/12.121212 returned status 200 but with non-JSON response: this is not JSON`);
+    const expectedErrorMsg = `http://localhost:${port}/21.212121/12.121212 returned ` +
+      `status 200 but with non-JSON response: this is not JSON`;
+
+    service({ lat: 12.121212, lon: 21.212121}, false, (err, results) => {
+      t.equals(err, expectedErrorMsg);
       t.notOk(results);
-      t.ok(logger.isErrorMessage(`http://localhost:${port}/21.212121/12.121212: could not parse response body: this is not JSON`));
+      t.ok(logger.isErrorMessage(expectedErrorMsg));
+      t.end();
+
+      server.close();
+
+    });
+
+  });
+
+  test('server returning 200 & non-JSON body should log sanitized error and return no results when do_not_track', (t) => {
+    const pipServer = require('express')();
+    pipServer.get('/:lon/:lat', (req, res, next) => {
+      t.equals(req.params.lat, '12.121212');
+      t.equals(req.params.lon, '21.212121');
+
+      res.send('this is not JSON');
+    });
+
+    const server = pipServer.listen();
+    const port = server.address().port;
+
+    const logger = require('pelias-mock-logger')();
+
+    const service = proxyquire('../../../service/pointinpolygon', {
+      'pelias-logger': logger
+    })(`http://localhost:${port}`);
+
+    const expectedErrorMsg = `http://localhost:${port}/[removed]/[removed] returned ` +
+      `status 200 but with non-JSON response: this is not JSON`;
+
+    service({ lat: 12.121212, lon: 21.212121}, true, (err, results) => {
+      t.equals(err, expectedErrorMsg);
+      t.notOk(results);
+      t.ok(logger.isErrorMessage(expectedErrorMsg));
       t.end();
 
       server.close();
@@ -117,7 +238,7 @@ module.exports.tests.failure = (test, common) => {
       'pelias-logger': logger
     })(`http://localhost:${port}`);
 
-    service({ lat: 12.121212, lon: 21.212121}, (err, results) => {
+    service({ lat: 12.121212, lon: 21.212121}, false, (err, results) => {
       t.equals(err.code, 'ECONNREFUSED');
       t.notOk(results);
       t.ok(logger.isErrorMessage(/ECONNREFUSED/), 'there should be a connection refused error message');
@@ -144,10 +265,43 @@ module.exports.tests.failure = (test, common) => {
       'pelias-logger': logger
     })(`http://localhost:${port}`);
 
-    service({ lat: 12.121212, lon: 21.212121}, (err, results) => {
-      t.equals(err, `http://localhost:${port}/21.212121/12.121212 returned status 400: a bad request was made`);
+    const expectedErrorMsg = `http://localhost:${port}/21.212121/12.121212 returned ` +
+      `status 400: a bad request was made`;
+
+    service({ lat: 12.121212, lon: 21.212121}, false, (err, results) => {
+      t.equals(err, expectedErrorMsg);
       t.notOk(results);
-      t.ok(logger.isErrorMessage(`http://localhost:${port}/21.212121/12.121212 returned status 400: a bad request was made`));
+      t.ok(logger.isErrorMessage(expectedErrorMsg));
+      t.end();
+
+      server.close();
+
+    });
+
+  });
+
+  test('non-OK status should log sanitized error and return no results when do_not_track=true', (t) => {
+    const pipServer = require('express')();
+    pipServer.get('/:lat/:lon', (req, res, next) => {
+      res.status(400).send('a bad request was made');
+    });
+
+    const server = pipServer.listen();
+    const port = server.address().port;
+
+    const logger = require('pelias-mock-logger')();
+
+    const service = proxyquire('../../../service/pointinpolygon', {
+      'pelias-logger': logger
+    })(`http://localhost:${port}`);
+
+    const expectedErrorMsg = `http://localhost:${port}/[removed]/[removed] returned ` +
+      `status 400: a bad request was made`;
+
+    service({ lat: 12.121212, lon: 21.212121}, true, (err, results) => {
+      t.equals(err, expectedErrorMsg);
+      t.notOk(results);
+      t.ok(logger.isErrorMessage(expectedErrorMsg));
       t.end();
 
       server.close();


### PR DESCRIPTION
passes `dnt` header to PIP service when requested at API by caller.  Also sanitizes identifiable parameters from error messages.  