### PR TITLE
Always query for a minimum of 20 results from Elasticsearch

### DIFF
--- a/middleware/sizeCalculator.js
+++ b/middleware/sizeCalculator.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 
 var SIZE_PADDING = 2;
 
+var MIN_QUERY_SIZE = 20;
+
 /**
  * Utility for calculating query result size
  * incorporating padding for dedupe process
@@ -24,12 +26,7 @@ function setup() {
  * @returns {number}
  */
 function calculateSize(cleanSize) {
-  switch (cleanSize || 1) {
-    case 1:
-      return 1;
-    default:
-      return cleanSize * SIZE_PADDING;
-  }
+  return Math.max(MIN_QUERY_SIZE, cleanSize * SIZE_PADDING);
 }
 
 module.exports = setup;

--- a/test/unit/helper/sizeCalculator.js
+++ b/test/unit/helper/sizeCalculator.js
@@ -25,7 +25,7 @@ module.exports.tests.valid = function(test, common) {
   test('size=0', function (t) {
     setup(0);
     calcSize(req, {}, function () {
-      t.equal(req.clean.querySize, 1);
+      t.equal(req.clean.querySize, 20);
       t.end();
     });
   });
@@ -33,7 +33,7 @@ module.exports.tests.valid = function(test, common) {
   test('size=1', function (t) {
     setup(1);
     calcSize(req, {}, function () {
-      t.equal(req.clean.querySize, 1);
+      t.equal(req.clean.querySize, 20);
       t.end();
     });
   });
@@ -42,6 +42,14 @@ module.exports.tests.valid = function(test, common) {
     setup(10);
     calcSize(req, {}, function () {
       t.equal(req.clean.querySize, 20);
+      t.end();
+    });
+  });
+
+  test('size=20', function (t) {
+    setup(20);
+    calcSize(req, {}, function () {
+      t.equal(req.clean.querySize, 40);
       t.end();
     });
   });


### PR DESCRIPTION
Fallback and interpolation queries rely on several results coming back
from Elasticsearch to ensure the best result is returned. It was
possible that queries with `size=1` would not return enough results from
Elasticsearch. This change ensures even with `size=1` a sufficient
number of results are returned.

Fixes https://github.com/pelias/pelias/issues/562