### PR TITLE
Remove gid properties from any interpolated results

### DIFF
--- a/helper/geojsonify_meta_data.js
+++ b/helper/geojsonify_meta_data.js
@@ -8,7 +8,14 @@ var Document = require('pelias-model').Document;
  */
 function addMetaData(src, dst) {
   dst.id = src._id;
-  dst.gid = makeGid(src);
+
+  // at this time the gid's of interpolated addresses are not usable in the place endpoint
+  // to avoid confusion they will be removed altogether for now and replaced in the future when we have determined
+  // the right format for these types of results
+  if (src.source !== 'mixed') {
+    dst.gid = makeGid(src);
+  }
+
   dst.layer = lookupLayer(src);
   dst.source = lookupSource(src);
   dst.source_id = lookupSourceId(src);

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -459,6 +459,53 @@ module.exports.tests.categories = function (test, common) {
   });
 };
 
+
+module.exports.tests.interpolated_gids = function (test, common) {
+  test('do not set the gid for interpolated results', function (t) {
+    var input = [
+      {
+        '_id': 'polyline:10439991',
+        'source': 'mixed',
+        'layer': 'address',
+        'center_point': {
+          'lon': -73.953698,
+          'lat': 40.757667
+        },
+        'name': {
+          'default': '123 Main Street'
+        },
+        'source_id': 'polyline:10439991'
+      }
+    ];
+
+    var expected = {
+      'type': 'FeatureCollection',
+      'bbox': [-73.953698, 40.757667, -73.953698, 40.757667],
+      'features': [
+        {
+          'type': 'Feature',
+          'properties': {
+            'id': 'polyline:10439991',
+            'layer': 'address',
+            'source': 'mixed',
+            'source_id': 'polyline:10439991',
+            'name': '123 Main Street'
+          },
+          'geometry': {
+            'type': 'Point',
+            'coordinates': [ -73.953698, 40.757667 ]
+          }
+        }
+      ]
+    };
+
+    var json = geojsonify( {}, input );
+
+    t.deepEqual(json, expected, 'gid is not defined');
+    t.end();
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {


### PR DESCRIPTION
Connected to pelias/pelias#537

This is the first step towards resolving the interpolated gid issue. Currently the gid values are misleading because they can not be used in the `/place` endpoint, which technically is their only purpose for existing. We need to hide them until we can implement a solution that allows the reconstruction of these records via the `/place` endpoint.

@msmollin: heads up on the gid properties going away for some but not all results. let us know if this has any negative implications on mobile. ☎️ 

@louh: once this is in staging we should test the demo app and make sure it doesn't break anything.