### PR TITLE
Fix table formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ The API recognizes the following properties under the top-level `api` key in you
 |`indexName`|*no*|*pelias*|name of the Elasticsearch index to be used when building queries|
 |`legacyUrl`|*no*||the url to redirect to in case the user does not specify a version such as `v1`
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
-|`accessLog`|*no*||name of the format to use for access logs; may be any one of the
-  [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to
-  `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
+|`accessLog`|*no*||name of the format to use for access logs; may be any one of the [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`pipService`|*yes*||full url to the pip service to be used for coarse reverse queries. if missing, which is not recommended, the service will default to using nearby lookups instead of point-in-polygon.|
 
 Example configuration file would look something like this:


### PR DESCRIPTION
It looks like markdown tables don't allow for newlines, so the changes
in https://github.com/pelias/api/pull/883 break the table.