### PR TITLE
Relocate indexname to config root

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ The API recognizes the following properties under the top-level `api` key in you
 |---|---|---|---|
 |`host`|*yes*||specifies the url under which the http service is to run|
 |`textAnalyzer`|*no*|*addressit*|can be either `libpostal` or `addressit` however will soon be **deprecated** and only `libpostal` will be supported going forward|
-|`indexName`|*no*|*pelias*|name of the Elasticsearch index to be used when building queries|
 |`legacyUrl`|*no*||the url to redirect to in case the user does not specify a version such as `v1`
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
 |`accessLog`|*no*||name of the format to use for access logs; may be any one of the
   [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to
   `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`pipService`|*yes*||full url to the pip service to be used for coarse reverse queries. if missing, which is not recommended, the service will default to using nearby lookups instead of point-in-polygon.|
+
+The top-level configuration also supports an optional key named `schema` that supports a single child name `indexName`.  The value of `schema.indexName` should contain the name of the Elasticsearch index used when building queries.  The default value for `schema.indexName` is `pelias`.  
 
 Example configuration file would look something like this:
 
@@ -66,11 +67,13 @@ Example configuration file would look something like this:
   },
   "api": {
     "host": "localhost:3100/v1/",
-    "indexName": "foobar",  
     "legacyUrl": "pelias.mapzen.com",
     "relativeScores": true,
     "textAnalyzer": "libpostal",
     "pipService": "http://mypipservice.com/3000"
+  },
+  "schema": {
+    "indexName": "foobar",  
   },
   "interpolation": {
     "client": {

--- a/app.js
+++ b/app.js
@@ -2,9 +2,16 @@
 var app = require('express')();
 
 var peliasConfig = require( 'pelias-config' ).generate(require('./schema'));
+const logger = require('pelias-logger').get('api');
 
 if( peliasConfig.api.accessLog ){
   app.use( require( './middleware/access_log' ).createAccessLogger( peliasConfig.api.accessLog ) );
+}
+
+// indexName config value has been moved to 'schema' root child, so warn if
+// it's in the old place
+if (peliasConfig.api.hasOwnProperty('indexName')) {
+  logger.warn('api.indexName has been deprecated, new location is schema.indexName');
 }
 
 /** ----------------------- pre-processing-middleware ----------------------- **/

--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ if( peliasConfig.api.accessLog ){
 // indexName config value has been moved to 'schema' root child, so warn if
 // it's in the old place
 if (peliasConfig.api.hasOwnProperty('indexName')) {
-  logger.warn('api.indexName has been deprecated, new location is schema.indexName');
+  logger.warn('deprecation warning: api.indexName has been relocated to schema.indexName');
 }
 
 /** ----------------------- pre-processing-middleware ----------------------- **/

--- a/controller/place.js
+++ b/controller/place.js
@@ -14,7 +14,7 @@ function isRequestTimeout(err) {
   return _.get(err, 'status') === 408;
 }
 
-function setup( apiConfig, esclient ){
+function setup( config, esclient ){
   function controller( req, res, next ){
     // do not run controller when a request validation error has occurred.
     if (requestHasErrors(req)){
@@ -25,7 +25,7 @@ function setup( apiConfig, esclient ){
     // maxRetries is from the API config with default of 3
     // factor of 1 means that each retry attempt will esclient requestTimeout
     const operationOptions = {
-      retries: _.get(apiConfig, 'requestRetries', 3),
+      retries: _.get(config.api, 'requestRetries', 3),
       factor: 1,
       minTimeout: _.get(esclient, 'transport.requestTimeout')
     };
@@ -35,7 +35,7 @@ function setup( apiConfig, esclient ){
 
     const cmd = req.clean.ids.map( function(id) {
       return {
-        _index: apiConfig.indexName,
+        _index: config.schema.indexName,
         _type: id.layers,
         _id: id.id
       };

--- a/controller/search.js
+++ b/controller/search.js
@@ -11,7 +11,7 @@ function isRequestTimeout(err) {
   return _.get(err, 'status') === 408;
 }
 
-function setup( apiConfig, esclient, query, should_execute ){
+function setup( config, esclient, query, should_execute ){
   function controller( req, res, next ){
     if (!should_execute(req, res)) {
       return next();
@@ -35,7 +35,7 @@ function setup( apiConfig, esclient, query, should_execute ){
     // maxRetries is from the API config with default of 3
     // factor of 1 means that each retry attempt will esclient requestTimeout
     const operationOptions = {
-      retries: _.get(apiConfig, 'requestRetries', 3),
+      retries: _.get(config.api, 'requestRetries', 3),
       factor: 1,
       minTimeout: _.get(esclient, 'transport.requestTimeout')
     };
@@ -45,7 +45,7 @@ function setup( apiConfig, esclient, query, should_execute ){
 
     // elasticsearch command
     const cmd = {
-      index: apiConfig.indexName,
+      index: config.schema.indexName,
       searchType: 'dfs_query_then_fetch',
       body: renderedQuery.body
     };

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -114,9 +114,9 @@ function addRoutes(app, peliasConfig) {
       middleware.calcSize(),
       // 3rd parameter is which query module to use, use fallback/geodisambiguation
       //  first, then use original search strategy if first query didn't return anything
-      controllers.search(peliasConfig.api, esclient, queries.libpostal, not(hasResponseDataOrRequestErrors)),
+      controllers.search(peliasConfig, esclient, queries.libpostal, not(hasResponseDataOrRequestErrors)),
       sanitizers.search_fallback.middleware,
-      controllers.search(peliasConfig.api, esclient, queries.fallback_to_old_prod, not(hasResponseDataOrRequestErrors)),
+      controllers.search(peliasConfig, esclient, queries.fallback_to_old_prod, not(hasResponseDataOrRequestErrors)),
       postProc.trimByGranularity(),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig.api),
@@ -137,13 +137,13 @@ function addRoutes(app, peliasConfig) {
       sanitizers.structured_geocoding.middleware,
       middleware.requestLanguage,
       middleware.calcSize(),
-      controllers.search(peliasConfig.api, esclient, queries.structured_geocoding, not(hasResponseDataOrRequestErrors)),
+      controllers.search(peliasConfig, esclient, queries.structured_geocoding, not(hasResponseDataOrRequestErrors)),
       postProc.trimByGranularityStructured(),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig.api),
       postProc.confidenceScoresFallback(),
       postProc.interpolate(),
-      postProc.dedupe(),      
+      postProc.dedupe(),
       postProc.accuracy(),
       postProc.localNamingConventions(),
       postProc.renamePlacenames(),
@@ -157,7 +157,7 @@ function addRoutes(app, peliasConfig) {
     autocomplete: createRouter([
       sanitizers.autocomplete.middleware,
       middleware.requestLanguage,
-      controllers.search(peliasConfig.api, esclient, queries.autocomplete, not(hasResponseDataOrRequestErrors)),
+      controllers.search(peliasConfig, esclient, queries.autocomplete, not(hasResponseDataOrRequestErrors)),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig.api),
       postProc.dedupe(),
@@ -176,7 +176,7 @@ function addRoutes(app, peliasConfig) {
       middleware.requestLanguage,
       middleware.calcSize(),
       controllers.coarse_reverse(pipService, coarse_reverse_should_execute),
-      controllers.search(peliasConfig.api, esclient, queries.reverse, original_reverse_should_execute),
+      controllers.search(peliasConfig, esclient, queries.reverse, original_reverse_should_execute),
       postProc.distances('point.'),
       // reverse confidence scoring depends on distance from origin
       //  so it must be calculated first
@@ -196,7 +196,7 @@ function addRoutes(app, peliasConfig) {
       sanitizers.nearby.middleware,
       middleware.requestLanguage,
       middleware.calcSize(),
-      controllers.search(peliasConfig.api, esclient, queries.reverse, not(hasResponseDataOrRequestErrors)),
+      controllers.search(peliasConfig, esclient, queries.reverse, not(hasResponseDataOrRequestErrors)),
       postProc.distances('point.'),
       // reverse confidence scoring depends on distance from origin
       //  so it must be calculated first
@@ -215,7 +215,7 @@ function addRoutes(app, peliasConfig) {
     place: createRouter([
       sanitizers.place.middleware,
       middleware.requestLanguage,
-      controllers.place(peliasConfig.api, esclient),
+      controllers.place(peliasConfig, esclient),
       postProc.accuracy(),
       postProc.localNamingConventions(),
       postProc.renamePlacenames(),

--- a/schema.js
+++ b/schema.js
@@ -5,7 +5,6 @@ const Joi = require('joi');
 // Schema Configuration
 // required:
 // * api.version (string)
-// * api.indexName (string)
 // * api.host (string)
 // * esclient (object - positive integer requestTimeout)
 //
@@ -14,6 +13,7 @@ const Joi = require('joi');
 // * api.relativeScores (boolean)
 // * api.legacyUrl (string)
 // * api.localization (flipNumberAndStreetCountries is array of 3 character strings)
+// * schema.indexName (string, defaults to 'pelias')
 module.exports = Joi.object().keys({
   api: Joi.object().keys({
     version: Joi.string(),
@@ -27,9 +27,11 @@ module.exports = Joi.object().keys({
       flipNumberAndStreetCountries: Joi.array().items(Joi.string().regex(/^[A-Z]{3}$/))
     }).unknown(false),
     pipService: Joi.string().uri({ scheme: /https?/ })
-
-  }).requiredKeys('version', 'indexName', 'host').unknown(true),
+  }).requiredKeys('version', 'host').unknown(true),
   esclient: Joi.object().keys({
     requestTimeout: Joi.number().integer().min(0)
-  }).unknown(true)
+  }).unknown(true),
+  schema: Joi.object().keys({
+    indexName: Joi.string().default('pelias')
+  }).unknown(false).default() // default() here creates an empty object when missing
 }).requiredKeys('api', 'esclient').unknown(true);

--- a/test/ciao_test_data.js
+++ b/test/ciao_test_data.js
@@ -15,7 +15,7 @@
 var client = require('elasticsearch').Client(),
     async = require('async'),
     actions = [];
-var config = require('pelias-config').generate().api;
+const indexName = require('pelias-config').generate().schema.indexName;
 
 // add one record per 'type' in order to cause the _default_ mapping
 // to be copied when the new type is created.
@@ -29,7 +29,7 @@ types.forEach( function( type, i1 ){
     layers.forEach( function( layer, i3 ){
       actions.push( function( done ){
         client.index({
-          index: config.indexName,
+          index: indexName,
           type: type,
           id: [i1,i2,i3].join(':'),
           body: {
@@ -50,7 +50,7 @@ types.forEach( function( type, i1 ){
 
 client.index(
   {
-    index: config.indexName,
+    index: indexName,
     type: 'address',
     id: 'way:265038872',
     body: {
@@ -130,7 +130,7 @@ client.index(
 
 // call refresh so the index merges the changes
 actions.push( function( done ){
-  client.indices.refresh( { index: config.indexName }, done);
+  client.indices.refresh( { index: indexName }, done);
 });
 
 // perform all actions in series

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -49,7 +49,7 @@ module.exports.tests.api_indexName_deprecation_warning = (test, common) => {
       }
     });
 
-    t.ok(logger.isWarnMessage(/^api.indexName has been deprecated, new location is schema.indexName$/));
+    t.ok(logger.isWarnMessage(/^deprecation warning: api.indexName has been relocated to schema.indexName$/));
     t.end();
 
   });

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -27,6 +27,35 @@ module.exports.tests.invalid_configuration = (test, common) => {
 
 };
 
+module.exports.tests.api_indexName_deprecation_warning = (test, common) => {
+  test('indexName found in api section of config should log deprecation warning', (t) => {
+    const logger = require('pelias-mock-logger')();
+
+    const app = proxyquire('../../app', {
+      './schema': 'this is the schema',
+      'pelias-config': {
+        generate: (schema) => {
+          return {
+            api: {
+              indexName: 'this is the indexName'
+            }
+          };
+        }
+      },
+      'pelias-logger': logger,
+      // mock out routes/v1 since it causes test to hang
+      './routes/v1': {
+        addRoutes: () => {}
+      }
+    });
+
+    t.ok(logger.isWarnMessage(/^api.indexName has been deprecated, new location is schema.indexName$/));
+    t.end();
+
+  });
+
+};
+
 module.exports.all = (tape, common) => {
 
   function test(name, testFunction) {

--- a/test/unit/controller/place.js
+++ b/test/unit/controller/place.js
@@ -16,7 +16,9 @@ module.exports.tests.interface = (test, common) => {
 module.exports.tests.success = (test, common) => {
   test('successful request to search service should set data and meta', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
 
@@ -100,7 +102,9 @@ module.exports.tests.error_conditions = (test, common) => {
 
   test('mgetService returning error should add to req.errors and ignore docs', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
 
@@ -152,7 +156,9 @@ module.exports.tests.error_conditions = (test, common) => {
 module.exports.tests.timeout = function(test, common) {
   test('default # of request timeout retries should be 3', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
 
@@ -220,8 +226,12 @@ module.exports.tests.timeout = function(test, common) {
 
   test('explicit apiConfig.requestRetries should retry that many times', (t) => {
     const config = {
-      indexName: 'indexName value',
-      requestRetries: 17
+      schema: {
+        indexName: 'indexName value'
+      },
+      api: {
+        requestRetries: 17
+      }
     };
     const esclient = 'this is the esclient';
 
@@ -268,7 +278,9 @@ module.exports.tests.timeout = function(test, common) {
 
   test('only status code 408 should be considered a retryable request', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
 
@@ -316,7 +328,9 @@ module.exports.tests.timeout = function(test, common) {
 
   test('string error should not retry and be logged as-is', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
 

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -16,7 +16,9 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.success = function(test, common) {
   test('successful request to search service should set data and meta', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -81,7 +83,9 @@ module.exports.tests.success = function(test, common) {
 
   test('undefined meta should set empty object into res', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -145,7 +149,9 @@ module.exports.tests.success = function(test, common) {
 
   test('undefined docs should log 0 results', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -209,7 +215,9 @@ module.exports.tests.success = function(test, common) {
 
   test('successful request on retry to search service should log info message', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -297,7 +305,9 @@ module.exports.tests.success = function(test, common) {
 module.exports.tests.timeout = function(test, common) {
   test('default # of request timeout retries should be 3', (t) => {
     const config = {
-      indexName: 'indexName value'
+      schema: {
+        indexName: 'indexName value'
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -368,8 +378,12 @@ module.exports.tests.timeout = function(test, common) {
 
   test('explicit apiConfig.requestRetries should retry that many times', (t) => {
     const config = {
-      indexName: 'indexName value',
-      requestRetries: 17
+      schema: {
+        indexName: 'indexName value'
+      },
+      api: {
+        requestRetries: 17
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -408,8 +422,12 @@ module.exports.tests.timeout = function(test, common) {
 
   test('only status code 408 should be considered a retryable request', (t) => {
     const config = {
-      indexName: 'indexName value',
-      requestRetries: 17
+      schema: {
+        indexName: 'indexName value'
+      },
+      api: {
+        requestRetries: 17
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {
@@ -453,8 +471,12 @@ module.exports.tests.timeout = function(test, common) {
 
   test('string error should not retry and be logged as-is', (t) => {
     const config = {
-      indexName: 'indexName value',
-      requestRetries: 17
+      schema: {
+        indexName: 'indexName value'
+      },
+      api: {
+        requestRetries: 17
+      }
     };
     const esclient = 'this is the esclient';
     const query = () => {

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -3,22 +3,13 @@
 const Joi = require('joi');
 const schema = require('../../schema');
 
-function validate(config) {
-  Joi.validate(config, schema, (err, value) => {
-    if (err) {
-      throw new Error(err.details[0].message);
-    }
-  });
-}
-
 module.exports.tests = {};
 
 module.exports.tests.completely_valid = (test, common) => {
   test('all valid configuration elements should not throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value',
         legacyUrl: 'legacyUrl value',
         accessLog: 'accessLog value',
@@ -33,16 +24,17 @@ module.exports.tests.completely_valid = (test, common) => {
       }
     };
 
-    t.doesNotThrow(validate.bind(config));
+    const result = Joi.validate(config, schema);
+
+    t.notOk(result.error);
     t.end();
 
   });
 
   test('basic valid configuration should not throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value'
       },
       esclient: {
@@ -50,7 +42,9 @@ module.exports.tests.completely_valid = (test, common) => {
       }
     };
 
-    t.doesNotThrow(validate.bind(config));
+    const result = Joi.validate(config, schema);
+
+    t.notOk(result.error);
     t.end();
 
   });
@@ -59,43 +53,49 @@ module.exports.tests.completely_valid = (test, common) => {
 
 module.exports.tests.api_validation = (test, common) => {
   test('config without api should throw error', (t) => {
-    var config = {
+    const config = {
       esclient: {}
     };
 
-    t.throws(validate.bind(null, config), /"api" is required/, 'api should exist');
+    const result = Joi.validate(config, schema);
+
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"api" is required');
     t.end();
 
   });
 
   test('config without unknown field in api should not throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value',
         unknown: 'unknown value'
       },
       esclient: {}
     };
 
-    t.doesNotThrow(validate.bind(null, config), 'unknown properties should be allowed');
+    const result = Joi.validate(config, schema);
+
+    t.notOk(result.error);
     t.end();
 
   });
 
   test('non-string api.version should throw error', (t) => {
     [null, 17, {}, [], true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: value,
-          indexName: 'index name value',
           host: 'host value'
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"version" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"version" must be a string');
 
     });
 
@@ -105,7 +105,7 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-string api.indexName should throw error', (t) => {
     [null, 17, {}, [], true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
           indexName: value,
@@ -114,7 +114,10 @@ module.exports.tests.api_validation = (test, common) => {
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"indexName" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"indexName" must be a string');
 
     });
 
@@ -124,16 +127,18 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-string api.host should throw error', (t) => {
     [null, 17, {}, [], true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"host" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"host" must be a string');
 
     });
 
@@ -143,17 +148,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-string api.legacyUrl should throw error', (t) => {
     [null, 17, {}, [], true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           legacyUrl: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"legacyUrl" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"legacyUrl" must be a string');
 
     });
 
@@ -163,17 +170,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-string api.accessLog should throw error', (t) => {
     [null, 17, {}, [], true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           accessLog: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"accessLog" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"accessLog" must be a string');
 
     });
 
@@ -183,17 +192,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-boolean api.relativeScores should throw error', (t) => {
     [null, 17, {}, [], 'string'].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           relativeScores: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"relativeScores" must be a boolean/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"relativeScores" must be a boolean');
 
     });
 
@@ -203,17 +214,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-object api.localization should throw error', (t) => {
     [null, 17, false, [], 'string'].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           localization: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"localization" must be an object/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"localization" must be an object');
 
     });
 
@@ -222,10 +235,9 @@ module.exports.tests.api_validation = (test, common) => {
   });
 
   test('unknown properties in api.localization should throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value',
         localization: {
           unknown_property: 'value'
@@ -234,18 +246,19 @@ module.exports.tests.api_validation = (test, common) => {
       esclient: {}
     };
 
-    t.throws(validate.bind(null, config), /"unknown_property" is not allowed/);
+    const result = Joi.validate(config, schema);
 
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"unknown_property" is not allowed');
     t.end();
 
   });
 
   test('non-array api.localization.flipNumberAndStreetCountries should throw error', (t) => {
     [null, 17, {}, false, 'string'].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           localization: {
             flipNumberAndStreetCountries: value
@@ -254,9 +267,10 @@ module.exports.tests.api_validation = (test, common) => {
         esclient: {}
       };
 
-      t.throws(
-        validate.bind(null, config),
-        /"flipNumberAndStreetCountries" must be an array/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"flipNumberAndStreetCountries" must be an array');
 
     });
 
@@ -266,10 +280,9 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-string api.localization.flipNumberAndStreetCountries elements should throw error', (t) => {
     [null, 17, {}, false, []].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           localization: {
             flipNumberAndStreetCountries: [value]
@@ -278,7 +291,10 @@ module.exports.tests.api_validation = (test, common) => {
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"0" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"0" must be a string');
 
     });
 
@@ -288,10 +304,9 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-3-char api.localization.flipNumberAndStreetCountries elements should throw error', (t) => {
     ['AB', 'ABCD'].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           localization: {
             flipNumberAndStreetCountries: [value]
@@ -300,7 +315,11 @@ module.exports.tests.api_validation = (test, common) => {
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /fails to match the required pattern/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.ok(result.error.details[0].message.match(/fails to match the required pattern/));
+
     });
 
     t.end();
@@ -309,19 +328,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('config with non-number api.requestRetries should throw error', (t) => {
     [null, 'string', {}, [], false].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           requestRetries: value
         },
         esclient: {}
       };
 
-      t.throws(
-        validate.bind(null, config),
-        /"requestRetries" must be a number/, 'api.requestRetries should be a number');
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"requestRetries" must be a number');
 
     });
 
@@ -330,56 +349,56 @@ module.exports.tests.api_validation = (test, common) => {
   });
 
   test('config with non-integer api.requestRetries should throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value',
         requestRetries: 17.3
       },
       esclient: {}
     };
 
-    t.throws(
-      validate.bind(null, config),
-      /"requestRetries" must be an integer/, 'api.requestRetries should be an integer');
+    const result = Joi.validate(config, schema);
 
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"requestRetries" must be an integer');
     t.end();
 
   });
 
   test('config with negative api.requestRetries should throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value',
         requestRetries: -1
       },
       esclient: {}
     };
 
-    t.throws(
-      validate.bind(null, config),
-      /"requestRetries" must be larger than or equal to 0/, 'api.requestRetries must be positive');
+    const result = Joi.validate(config, schema);
 
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"requestRetries" must be larger than or equal to 0');
     t.end();
 
   });
 
   test('non-string api.pipService should throw error', (t) => {
     [null, 17, {}, [], true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           pipService: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"pipService" must be a string/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"pipService" must be a string');
 
     });
 
@@ -389,17 +408,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-URI-formatted api.pipService should throw error', (t) => {
     ['this is not a URI'].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           pipService: value
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"pipService" must be a valid uri/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.ok(result.error.details[0].message.match(/"pipService" must be a valid uri/));
 
     });
 
@@ -409,17 +430,19 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('non-http/https api.pipService should throw error', (t) => {
     ['ftp', 'git', 'unknown'].forEach((scheme) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           pipService: `${scheme}://localhost`
         },
         esclient: {}
       };
 
-      t.throws(validate.bind(null, config), /"pipService" must be a valid uri/);
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.ok(result.error.details[0].message.match(/"pipService" must be a valid uri/));
 
     });
 
@@ -429,17 +452,18 @@ module.exports.tests.api_validation = (test, common) => {
 
   test('http/https api.pipService should not throw error', (t) => {
     ['http', 'https'].forEach((scheme) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value',
           pipService: `${scheme}://localhost`
         },
         esclient: {}
       };
 
-      t.doesNotThrow(validate.bind(null, config), `${scheme} should be allowed`);
+      const result = Joi.validate(config, schema);
+
+      t.notOk(result.error);
 
     });
 
@@ -449,37 +473,84 @@ module.exports.tests.api_validation = (test, common) => {
 
 };
 
-module.exports.tests.esclient_validation = (test, common) => {
-  test('config without esclient should throw error', (t) => {
-    var config = {
+module.exports.tests.schema_validation = (test, common) => {
+  test('non-string schema.indexName should throw error', (t) => {
+    [null, 17, {}, [], true].forEach((value) => {
+      const config = {
+        api: {
+          version: 'version value',
+          indexName: 'index name value',
+          host: 'host value'
+        },
+        esclient: {},
+        schema: {
+          indexName: value
+        }
+      };
+
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"indexName" must be a string');
+
+    });
+
+    t.end();
+
+  });
+
+  test('unspecified schema.indexName should default to \'pelias\'', (t) => {
+    const config = {
       api: {
         version: 'version value',
         indexName: 'index name value',
         host: 'host value'
+      },
+      esclient: {}
+    };
+
+    const result = Joi.validate(config, schema);
+
+    t.notOk(result.error);
+    t.equals(result.value.schema.indexName, 'pelias');
+    t.end();
+
+  });
+
+};
+
+
+module.exports.tests.esclient_validation = (test, common) => {
+  test('config without esclient should throw error', (t) => {
+    const config = {
+      api: {
+        version: 'version value',
+        host: 'host value'
       }
     };
 
-    t.throws(
-      validate.bind(null, config),
-      /"esclient" is required/, 'esclient should exist');
+    const result = Joi.validate(config, schema);
+
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"esclient" is required');
     t.end();
 
   });
 
   test('config with non-object esclient should throw error', (t) => {
     [null, 17, [], 'string', true].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value'
         },
         esclient: value
       };
 
-      t.throws(
-        validate.bind(null, config),
-        /"esclient" must be an object/, 'esclient should be an object');
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"esclient" must be an object');
 
     });
 
@@ -489,10 +560,9 @@ module.exports.tests.esclient_validation = (test, common) => {
 
   test('config with non-number esclient.requestTimeout should throw error', (t) => {
     [null, 'string', {}, [], false].forEach((value) => {
-      var config = {
+      const config = {
         api: {
           version: 'version value',
-          indexName: 'index name value',
           host: 'host value'
         },
         esclient: {
@@ -500,9 +570,10 @@ module.exports.tests.esclient_validation = (test, common) => {
         }
       };
 
-      t.throws(
-        validate.bind(null, config),
-        /"requestTimeout" must be a number/, 'esclient.requestTimeout should be a number');
+      const result = Joi.validate(config, schema);
+
+      t.equals(result.error.details.length, 1);
+      t.equals(result.error.details[0].message, '"requestTimeout" must be a number');
 
     });
 
@@ -511,10 +582,9 @@ module.exports.tests.esclient_validation = (test, common) => {
   });
 
   test('config with non-integer esclient.requestTimeout should throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value'
       },
       esclient: {
@@ -522,19 +592,18 @@ module.exports.tests.esclient_validation = (test, common) => {
       }
     };
 
-    t.throws(
-      validate.bind(null, config),
-    /"requestTimeout" must be an integer/, 'esclient.requestTimeout should be an integer');
+    const result = Joi.validate(config, schema);
 
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"requestTimeout" must be an integer');
     t.end();
 
   });
 
   test('config with negative esclient.requestTimeout should throw error', (t) => {
-    var config = {
+    const config = {
       api: {
         version: 'version value',
-        indexName: 'index name value',
         host: 'host value'
       },
       esclient: {
@@ -542,10 +611,11 @@ module.exports.tests.esclient_validation = (test, common) => {
       }
     };
 
-    t.throws(
-      validate.bind(null, config),
-      /"requestTimeout" must be larger than or equal to 0/, 'esclient.requestTimeout must be positive');
+    const result = Joi.validate(config, schema);
 
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"requestTimeout" must be larger than or equal to 0',
+      'esclient.requestTimeout must be positive');
     t.end();
 
   });
@@ -555,10 +625,10 @@ module.exports.tests.esclient_validation = (test, common) => {
 module.exports.all = (tape, common) => {
 
   function test(name, testFunction) {
-    return tape('configValidation: ' + name, testFunction);
+    return tape(`schema: ${name}`, testFunction);
   }
 
-  for( var testCase in module.exports.tests ){
+  for( const testCase in module.exports.tests ){
     module.exports.tests[testCase](test, common);
   }
 };


### PR DESCRIPTION
Currently the importers use `schema.indexName` while the API uses `api.indexName`.  This PR modifies the API to use `schema.indexName` and adds a deprecation warning about the relocation of this configuration variable.  