### PR TITLE
Prefer openaddresses results with zip code

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -65,6 +65,14 @@ function dedupeResults(req, res, next) {
 function isPreferred(existing, candidateReplacement) {
   // NOTE: we are assuming here that the layer for both records is the same
 
+  var isOA = _.flow(_.property('source'), _.eq.bind(null, 'openaddresses'));
+  var hasZip = _.bind(_.has, null, _.bind.placeholder, 'address_parts.zip');
+
+  // https://github.com/pelias/api/issues/872
+  if (isOA(existing) && isOA(candidateReplacement)) {
+    return hasZip(candidateReplacement) && !hasZip(existing);
+  }
+
   //bind the trumps function to the data items to keep the rest of the function clean
   var trumpsFunc = trumps.bind(null, existing, candidateReplacement);
 

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -186,6 +186,42 @@ module.exports.tests.trump = function(test, common) {
       t.end();
     });
   });
+
+  test('openaddresses with zip trumps openaddresses without zip', function (t) {
+    var req = {
+      clean: {
+        text: '100 Main St',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': '100 Main St' },
+          'source': 'openaddresses',
+          'source_id': '123456',
+          'layer': 'address',
+          'address_parts': {}
+        },
+        {
+          'name': { 'default': '100 Main St' },
+          'source': 'openaddresses',
+          'source_id': '654321',
+          'layer': 'address',
+          'address_parts': {
+            'zip': '54321'
+          }
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].source_id, '654321', 'openaddresses result with zip won');
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Resolves #872 

If duplicate results exist and both are from `openaddresses`, prefer the one with a `zip` when applicable.

---

Note: It's not entirely clear to me if I only need to worry about `address_parts.zip` or if I should also be looking for `address_parts.postalcode`.

`helper/diffPlaces.js` seems to only care about `zip` – but presumably non-US data wouldn't have that property. I'm just not 100% clear on what that data can/will look like.

