### PR TITLE
only query ES for non-coarse layers on non-coarse reverse requests

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -3,6 +3,7 @@
 const peliasQuery = require('pelias-query');
 const defaults = require('./reverse_defaults');
 const check = require('check-types');
+const _ = require('lodash');
 const logger = require('pelias-logger').get('api');
 
 //------------------------------
@@ -44,7 +45,8 @@ function generateQuery( clean ){
 
   // layers
   if( check.array(clean.layers) && clean.layers.length ) {
-    vs.var( 'layers', clean.layers);
+    // only include non-coarse layers
+    vs.var( 'layers', _.intersection(clean.layers, ['address', 'street', 'venue']));
     logStr += '[param:layers] ';
   }
 

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -6,6 +6,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'size': 1,
   'track_scores': true,
+  'layers': ['venue', 'address', 'street'],
 
   'centroid:field': 'center_point',
 

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -449,6 +449,7 @@ module.exports.tests.success_conditions = (test, common) => {
     };
 
     t.deepEquals(res, expected);
+
     t.notOk(logger.hasErrorMessages());
     t.end();
 
@@ -481,92 +482,6 @@ module.exports.tests.success_conditions = (test, common) => {
     const controller = proxyquire('../../../controller/coarse_reverse', {
       'pelias-logger': logger
     })(service, _.constant(true));
-
-    const req = {
-      clean: {
-        layers: [],
-        point: {
-          lat: 12.121212,
-          lon: 21.212121
-        }
-      }
-    };
-
-    const res = { };
-
-    // verify that next was called
-    const next = () => {
-      t.pass('next() should have been called');
-    };
-
-    controller(req, res, next);
-
-    const expected = {
-      meta: {},
-      data: [
-        {
-          _id: '10',
-          _type: 'neighbourhood',
-          layer: 'neighbourhood',
-          source: 'whosonfirst',
-          source_id: '10',
-          name: {
-            'default': 'neighbourhood name'
-          },
-          phrase: {
-            'default': 'neighbourhood name'
-          },
-          parent: {
-            neighbourhood: ['neighbourhood name'],
-            neighbourhood_id: ['10'],
-            neighbourhood_a: ['neighbourhood abbr']
-          }
-        }
-      ]
-    };
-
-    t.deepEquals(req.clean.layers, [], 'req.clean.layers should be unmodified');
-    t.deepEquals(res, expected);
-    t.notOk(logger.hasErrorMessages());
-
-    t.end();
-
-  });
-
-  test('no requested layers should use everything', (t) => {
-    // this test is used to test coarse reverse fallback for when non-coarse reverse
-    //  was requested but no non-coarse results were found
-
-    // by plan'ing the number of tests, we can verify that next() was called w/o
-    //  additional bookkeeping
-    t.plan(5);
-
-    const service = (point, do_not_track, callback) => {
-      t.equals(do_not_track, 'do_not_track value');
-      const results = {
-        neighbourhood: [
-          {
-            id: 10,
-            name: 'neighbourhood name',
-            abbr: 'neighbourhood abbr'
-          }
-        ]
-      };
-
-      callback(undefined, results);
-    };
-
-    const logger = require('pelias-mock-logger')();
-
-    const should_execute = () => { return true; };
-    const controller = proxyquire('../../../controller/coarse_reverse', {
-      'pelias-logger': logger,
-      '../helper/logging': {
-        isDNT: () => {
-          return 'do_not_track value';
-        }
-      }
-    })(service, should_execute);
 
     const req = {
       clean: {

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -533,6 +533,92 @@ module.exports.tests.success_conditions = (test, common) => {
 
   });
 
+  test('no requested layers should use everything', (t) => {
+    // this test is used to test coarse reverse fallback for when non-coarse reverse
+    //  was requested but no non-coarse results were found
+
+    // by plan'ing the number of tests, we can verify that next() was called w/o
+    //  additional bookkeeping
+    t.plan(5);
+
+    const service = (point, do_not_track, callback) => {
+      t.equals(do_not_track, 'do_not_track value');
+      const results = {
+        neighbourhood: [
+          {
+            id: 10,
+            name: 'neighbourhood name',
+            abbr: 'neighbourhood abbr'
+          }
+        ]
+      };
+
+      callback(undefined, results);
+    };
+
+    const logger = require('pelias-mock-logger')();
+
+    const should_execute = () => { return true; };
+    const controller = proxyquire('../../../controller/coarse_reverse', {
+      'pelias-logger': logger,
+      '../helper/logging': {
+        isDNT: () => {
+          return 'do_not_track value';
+        }
+      }
+    })(service, should_execute);
+
+    const req = {
+      clean: {
+        layers: [],
+        point: {
+          lat: 12.121212,
+          lon: 21.212121
+        }
+      }
+    };
+
+    const res = { };
+
+    // verify that next was called
+    const next = () => {
+      t.pass('next() should have been called');
+    };
+
+    controller(req, res, next);
+
+    const expected = {
+      meta: {},
+      data: [
+        {
+          _id: '10',
+          _type: 'neighbourhood',
+          layer: 'neighbourhood',
+          source: 'whosonfirst',
+          source_id: '10',
+          name: {
+            'default': 'neighbourhood name'
+          },
+          phrase: {
+            'default': 'neighbourhood name'
+          },
+          parent: {
+            neighbourhood: ['neighbourhood name'],
+            neighbourhood_id: ['10'],
+            neighbourhood_a: ['neighbourhood abbr']
+          }
+        }
+      ]
+    };
+
+    t.deepEquals(req.clean.layers, [], 'req.clean.layers should be unmodified');
+    t.deepEquals(res, expected);
+    t.notOk(logger.hasErrorMessages());
+
+    t.end();
+
+  });
+
   test('layers specifying only venue, address, or street should not exclude coarse results', (t) => {
     // this test is used to test coarse reverse fallback for when non-coarse reverse
     //  was requested but no non-coarse results were found

--- a/test/unit/fixture/reverse_null_island.js
+++ b/test/unit/fixture/reverse_null_island.js
@@ -13,6 +13,11 @@ module.exports = {
             'lon': 0
           }
         }
+      },
+      {
+        'terms': {
+          'layer': ['venue', 'address', 'street']
+        }
       }]
     }
   },

--- a/test/unit/fixture/reverse_with_boundary_country.js
+++ b/test/unit/fixture/reverse_with_boundary_country.js
@@ -23,6 +23,11 @@ module.exports = {
             'lon': -82.50622
           }
         }
+      },
+      {
+        'terms': {
+          'layer': ['venue', 'address', 'street']
+        }
       }]
     }
   },

--- a/test/unit/fixture/reverse_with_layer_filtering.js
+++ b/test/unit/fixture/reverse_with_layer_filtering.js
@@ -17,7 +17,7 @@ module.exports = {
         },
         {
           'terms': {
-            'layer': ['country']
+            'layer': ['venue', 'address', 'street']
           }
         }
       ]

--- a/test/unit/fixture/reverse_with_layer_filtering_non_coarse_subset.js
+++ b/test/unit/fixture/reverse_with_layer_filtering_non_coarse_subset.js
@@ -3,22 +3,24 @@ var vs = require('../../../query/reverse_defaults');
 module.exports = {
   'query': {
     'bool': {
-      'filter': [{
-        'geo_distance': {
-          'distance': '500km',
-          'distance_type': 'plane',
-          'optimize_bbox': 'indexed',
-          'center_point': {
-            'lat': 29.49136,
-            'lon': -82.50622
+      'filter': [
+        {
+          'geo_distance': {
+            'distance': '500km',
+            'distance_type': 'plane',
+            'optimize_bbox': 'indexed',
+            'center_point': {
+              'lat': 29.49136,
+              'lon': -82.50622
+            }
+          }
+        },
+        {
+          'terms': {
+            'layer': ['venue', 'street']
           }
         }
-      },
-      {
-        'terms': {
-          'layer': ['venue', 'address', 'street']
-        }
-      }]
+      ]
     }
   },
   'sort': [

--- a/test/unit/fixture/reverse_with_source_filtering.js
+++ b/test/unit/fixture/reverse_with_source_filtering.js
@@ -19,6 +19,11 @@ module.exports = {
           'terms': {
             'source': ['test']
           }
+        },
+        {
+          'terms': {
+            'layer': ['venue', 'address', 'street']
+          }
         }
       ]
     }

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -132,23 +132,46 @@ module.exports.tests.query = function(test, common) {
     t.end();
   });
 
-  test('valid layers filter', function(t) {
-    var query = generate({
+  test('valid layers filter', (t) => {
+    const query = generate({
       'point.lat': 29.49136,
       'point.lon': -82.50622,
       'boundary.circle.lat': 29.49136,
       'boundary.circle.lon': -82.50622,
       'boundary.circle.radius': 500,
-      'layers': ['country']
+      // only venue, address, and street layers should be retained
+      'layers': ['neighbourhood', 'venue', 'locality', 'address', 'region', 'street', 'country']
     });
 
-    var compiled = JSON.parse( JSON.stringify( query ) );
-    var expected = require('../fixture/reverse_with_layer_filtering');
+    const compiled = JSON.parse( JSON.stringify( query ) );
+    const expected = require('../fixture/reverse_with_layer_filtering');
 
     t.deepEqual(compiled.type, 'reverse', 'query type set');
     t.deepEqual(compiled.body, expected, 'valid reverse query with source filtering');
     t.end();
+
   });
+
+  test('valid layers filter - subset of non-coarse layers', (t) => {
+    const query = generate({
+      'point.lat': 29.49136,
+      'point.lon': -82.50622,
+      'boundary.circle.lat': 29.49136,
+      'boundary.circle.lon': -82.50622,
+      'boundary.circle.radius': 500,
+      // only venue, address, and street layers should be retained
+      'layers': ['neighbourhood', 'venue', 'street', 'locality']
+    });
+
+    const compiled = JSON.parse( JSON.stringify( query ) );
+    const expected = require('../fixture/reverse_with_layer_filtering_non_coarse_subset');
+
+    t.deepEqual(compiled.type, 'reverse', 'query type set');
+    t.deepEqual(compiled.body, expected, 'valid reverse query with source filtering');
+    t.end();
+
+  });
+
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Currently, /reverse queries ES for all explicit layers or all implied layers for non-coarse requests.  This causes an issue when coarse results can be mixed in with non-coarse results.  For example, in this request, a coarse result (geonames localadmin) is returned 1st in combination with addresses:

http://pelias.github.io/compare/#/v1/reverse%3Fpoint.lat=39.898609&point.lon=-76.607735

In this request, a WOF locality is returned 2nd along with a number of addresses:

http://pelias.github.io/compare/#/v1/reverse%3Flayers=venue,locality&point.lat=39.898609&point.lon=-76.607735

To continue moving towards querying for addresses, venues, and streets, then falling back to admin areas, this PR modifies reverse ES queries as follows:

- if no `layers` parameter is specified, ES is only queried for `address`, `street`, and `venue`
- if the `layers` parameter is specified, ES is only queried for the intersection of the `layers` array and `['venue', 'address', 'street']`

This will cause ES to only be queried for non-coarse results.  If no results are returned, the PiP service will be called.  

This also has the side benefit of removing geonames entirely from the /reverse endpoint.  

This may also eliminate the need to have two coarse calls since they would have the same effect when the non-coarse ES request is either explicitly not called or returns 0 results.  
