### PR TITLE
Remove duplicate pelias-config entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "lodash": "^4.17.4",
     "markdown": "0.5.0",
     "morgan": "^1.8.2",
-    "pelias-config": "2.11.0",
     "pelias-categories": "1.2.0",
     "pelias-config": "2.11.0",
     "pelias-labels": "1.6.0",


### PR DESCRIPTION
Somehow it made its way in twice, which doesn't seem to break anything,
but we might as well fix it.