### PR TITLE
allow timeout and retries settings for placeholder microservice

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -35,7 +35,9 @@ module.exports = Joi.object().keys({
         retries: Joi.number().integer().optional().default(3).min(0),
       }).unknown(false).requiredKeys('url'),
       placeholder: Joi.object().keys({
-        url: Joi.string().uri({ scheme: /https?/ })
+        url: Joi.string().uri({ scheme: /https?/ }),
+        timeout: Joi.number().integer().optional().default(250).min(0),
+        retries: Joi.number().integer().optional().default(3).min(0),
       }).unknown(false).requiredKeys('url')
     }).unknown(false).default({}) // default api.services to an empty object
 

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -484,6 +484,29 @@ module.exports.tests.api_services_validation = (test, common) => {
 };
 
 module.exports.tests.placeholder_service_validation = (test, common) => {
+  test('timeout and retries not specified should default to 250 and 3', (t) => {
+    const config = {
+      api: {
+        version: 'version value',
+        indexName: 'index name value',
+        host: 'host value',
+        services: {
+          placeholder: {
+            url: 'http://localhost'
+          }
+        }
+      },
+      esclient: {}
+    };
+
+    const result = Joi.validate(config, schema);
+
+    t.equals(result.value.api.services.placeholder.timeout, 250);
+    t.equals(result.value.api.services.placeholder.retries, 3);
+    t.end();
+
+  });
+
   test('when api.services.placeholder is defined, url is required', (t) => {
     var config = {
       api: {


### PR DESCRIPTION
I wasn't able to specify custom `timeout` or `retries` for Placeholder without these lines.

@trescube the tests all pass, is there an existing place in the code where I can test this?