### PR TITLE
Normalize paths

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -1,3 +1,4 @@
+const path = require('path');
 var Router = require('express').Router;
 var elasticsearch = require('elasticsearch');
 
@@ -123,10 +124,10 @@ function addRoutes(app, peliasConfig) {
 
   var routers = {
     index: createRouter([
-      controllers.mdToHTML(peliasConfig.api, './public/apiDoc.md')
+      controllers.mdToHTML(peliasConfig.api, path.join('..', 'public', 'apiDoc.md'))
     ]),
     attribution: createRouter([
-      controllers.mdToHTML(peliasConfig.api, './public/attribution.md')
+      controllers.mdToHTML(peliasConfig.api, path.join('..', 'public', 'attribution.md'))
     ]),
     search: createRouter([
       sanitizers.search.middleware,


### PR DESCRIPTION
When using Pelias' API with Ansible, I was getting an error where it couldn't find the `public/apiDoc.md` file. This ended up being because of some path shenanigans. By normalizing the paths, I was able to fix it. Figured I'd do it elsewhere too. Hoping that the tests end up being ok...