### PR TITLE
fix(package): update pelias-query to version 8.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pelias-logger": "0.2.0",
     "pelias-microservice-wrapper": "1.1.2",
     "pelias-model": "4.9.0",
-    "pelias-query": "8.15.0",
+    "pelias-query": "8.16.1",
     "pelias-sorting": "1.0.1",
     "pelias-text-analyzer": "1.8.3",
     "predicates": "^1.0.1",

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -2,837 +2,829 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.venue',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'query value',
-                          'type': 'phrase',
-                          'fields': [
-                            'phrase.default'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'neighbourhood value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.neighbourhood',
-                            'parent.neighbourhood_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'borough value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.borough',
-                            'parent.borough_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a',
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'venue'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.venue',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'query value',
+                      'type': 'phrase',
+                      'fields': [
+                        'phrase.default'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'neighbourhood value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.neighbourhood',
+                        'parent.neighbourhood_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'borough value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.borough',
+                        'parent.borough_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
                     }
                   }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.address',
-                    'boost': 10,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.number': 'number value'
-                        }
-                      },
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'neighbourhood value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.neighbourhood',
-                            'parent.neighbourhood_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'borough value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.borough',
-                            'parent.borough_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a',
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'should': [
-                      {
-                        'match_phrase': {
-                          'address_parts.zip': 'postalcode value'
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'address'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.postalcode',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'postalcode value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.postalcode'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a',
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'postalcode'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'neighbourhood value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.neighbourhood',
-                            'parent.neighbourhood_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'borough value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.borough',
-                            'parent.borough_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a',
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'should': [
-                      {
-                        'match_phrase': {
-                          'address_parts.zip': 'postalcode value'
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.neighbourhood',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'neighbourhood value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.neighbourhood',
-                            'parent.neighbourhood_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'borough value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.borough',
-                            'parent.borough_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a',
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'neighbourhood'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.borough',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'borough value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.borough',
-                            'parent.borough_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a',
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'borough'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.locality',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.locality',
-                            'parent.locality_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'locality'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.localadmin',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'city value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.localadmin',
-                            'parent.localadmin_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a',
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'localadmin'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.county',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.county',
-                            'parent.county_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'county'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.macrocounty',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'county value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.macrocounty',
-                            'parent.macrocounty_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a',
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'macrocounty'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.region',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.region',
-                            'parent.region_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'region'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.macroregion',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'state value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.macroregion',
-                            'parent.macroregion_a'
-                          ]
-                        }
-                      },
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a',
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'macroregion'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.dependency',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.dependency',
-                            'parent.dependency_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'dependency'
-                      }
-                    }
-                  }
-                },
-                {
-                  'bool': {
-                    '_name': 'fallback.country',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'country value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.country',
-                            'parent.country_a'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'country'
-                      }
-                    }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'venue'
                   }
                 }
-              ]
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.address',
+                'boost': 10,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.number': 'number value'
+                    }
+                  },
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'neighbourhood value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.neighbourhood',
+                        'parent.neighbourhood_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'borough value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.borough',
+                        'parent.borough_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'should': [
+                  {
+                    'match_phrase': {
+                      'address_parts.zip': 'postalcode value'
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'address'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.postalcode',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'postalcode value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.postalcode'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'postalcode'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'neighbourhood value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.neighbourhood',
+                        'parent.neighbourhood_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'borough value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.borough',
+                        'parent.borough_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'should': [
+                  {
+                    'match_phrase': {
+                      'address_parts.zip': 'postalcode value'
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.neighbourhood',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'neighbourhood value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.neighbourhood',
+                        'parent.neighbourhood_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'borough value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.borough',
+                        'parent.borough_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'neighbourhood'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.borough',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'borough value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.borough',
+                        'parent.borough_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'borough'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.locality',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'locality'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.localadmin',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a',
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'localadmin'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.county',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.county',
+                        'parent.county_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'county'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.macrocounty',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'county value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.macrocounty',
+                        'parent.macrocounty_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'macrocounty'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.region',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'region'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.macroregion',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'macroregion'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.dependency',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'dependency'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.country',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'country'
+                  }
+                }
+              }
             }
-          },
-          'filter': {
-            'bool': {
-              'must': []
-            }
-          }
+          ]
         }
       },
       'max_boost': 20,

--- a/test/unit/fixture/search_fallback_postalcode_only.js
+++ b/test/unit/fixture/search_fallback_postalcode_only.js
@@ -2,39 +2,31 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.postalcode',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': '90210',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.postalcode'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'postalcode'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.postalcode',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': '90210',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.postalcode'
+                      ]
                     }
                   }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'postalcode'
+                  }
                 }
-              ]
+              }
             }
-          },
-          'filter': {
-            'bool': {
-              'must': []
-            }
-          }
+          ]
         }
       },
       'max_boost': 20,

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_linguistic_viewport.js
+++ b/test/unit/fixture/search_linguistic_viewport.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
+++ b/test/unit/fixture/search_linguistic_viewport_min_diagonal.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_with_category_filtering.js
+++ b/test/unit/fixture/search_with_category_filtering.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/search_with_source_filtering.js
+++ b/test/unit/fixture/search_with_source_filtering.js
@@ -2,32 +2,29 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.street',
-                    'boost': 5,
-                    'must': [
-                      {
-                        'match_phrase': {
-                          'address_parts.street': 'street value'
-                        }
-                      }
-                    ],
-                    'should': [],
-                    'filter': {
-                      'term': {
-                        'layer': 'street'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
                     }
                   }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
                 }
-              ]
+              }
             }
-          },
+          ],
           'filter': {
             'bool': {
               'must': [

--- a/test/unit/fixture/structured_geocoding/boundary_country.json
+++ b/test/unit/fixture/structured_geocoding/boundary_country.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/fallback.json
+++ b/test/unit/fixture/structured_geocoding/fallback.json
@@ -2,838 +2,830 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": [
-                {
-                  "bool": {
-                    "_name": "fallback.venue",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "query value",
-                          "type": "phrase",
-                          "fields": [
-                            "phrase.default",
-                            "category"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "venue"
-                      }
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.venue",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "query value",
+                      "type": "phrase",
+                      "fields": [
+                        "phrase.default",
+                        "category"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
                     }
                   }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.address",
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.number": "number value"
-                        }
-                      },
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [
-                      {
-                        "match_phrase": {
-                          "address_parts.zip": "postalcode value"
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "address"
-                      }
-                    },
-                    "boost": 10
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.street",
-                    "must": [
-                      {
-                        "match_phrase": {
-                          "address_parts.street": "street value"
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "should": [
-                      {
-                        "match_phrase": {
-                          "address_parts.zip": "postalcode value"
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "street"
-                      }
-                    },
-                    "boost": 5
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.postalcode",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "postalcode value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.postalcode"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "postalcode"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.neighbourhood",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "neighbourhood value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.neighbourhood",
-                            "parent.neighbourhood_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "neighbourhood"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.borough",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "borough value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.borough",
-                            "parent.borough_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a",
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "borough"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.locality",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.locality",
-                            "parent.locality_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "locality"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.localadmin",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "city value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.localadmin",
-                            "parent.localadmin_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a",
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "localadmin"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.county",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.county",
-                            "parent.county_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "county"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macrocounty",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "county value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macrocounty",
-                            "parent.macrocounty_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a",
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macrocounty"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.region",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.region",
-                            "parent.region_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "region"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.macroregion",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "state value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.macroregion",
-                            "parent.macroregion_a"
-                          ]
-                        }
-                      },
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a",
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "macroregion"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.dependency",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.dependency",
-                            "parent.dependency_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "dependency"
-                      }
-                    }
-                  }
-                },
-                {
-                  "bool": {
-                    "_name": "fallback.country",
-                    "must": [
-                      {
-                        "multi_match": {
-                          "query": "country value",
-                          "type": "phrase",
-                          "fields": [
-                            "parent.country",
-                            "parent.country_a"
-                          ]
-                        }
-                      }
-                    ],
-                    "filter": {
-                      "term": {
-                        "layer": "country"
-                      }
-                    }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "venue"
                   }
                 }
-              ]
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.address",
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.number": "number value"
+                    }
+                  },
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "address_parts.zip": "postalcode value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "address"
+                  }
+                },
+                "boost": 10
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.street",
+                "must": [
+                  {
+                    "match_phrase": {
+                      "address_parts.street": "street value"
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "should": [
+                  {
+                    "match_phrase": {
+                      "address_parts.zip": "postalcode value"
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "street"
+                  }
+                },
+                "boost": 5
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.postalcode",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "postalcode value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.postalcode"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "postalcode"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.neighbourhood",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "neighbourhood value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.neighbourhood",
+                        "parent.neighbourhood_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "neighbourhood"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.borough",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "borough value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.borough",
+                        "parent.borough_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "borough"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a",
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.county",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.county",
+                        "parent.county_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "county"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macrocounty",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "county value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macrocounty",
+                        "parent.macrocounty_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macrocounty"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.dependency",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "dependency"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.country",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "country"
+                  }
+                }
+              }
             }
-          },
-          "filter": {
-            "bool": {
-              "must": []
-            }
-          }
+          ]
         }
       },
       "max_boost": 20,

--- a/test/unit/fixture/structured_geocoding/linguistic_bbox.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_bbox.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/linguistic_focus.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_focus.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/linguistic_focus_bbox.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_focus_bbox.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/linguistic_focus_null_island.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_focus_null_island.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/linguistic_only.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_only.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/linguistic_viewport.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_viewport.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/linguistic_viewport_min_diagonal.json
+++ b/test/unit/fixture/structured_geocoding/linguistic_viewport_min_diagonal.json
@@ -2,12 +2,9 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [],
           "filter": {
             "bool": {
               "must": [

--- a/test/unit/fixture/structured_geocoding/postalcode_only.js
+++ b/test/unit/fixture/structured_geocoding/postalcode_only.js
@@ -2,39 +2,31 @@ module.exports = {
   'query': {
     'function_score': {
       'query': {
-        'filtered': {
-          'query': {
-            'bool': {
-              'should': [
-                {
-                  'bool': {
-                    '_name': 'fallback.postalcode',
-                    'must': [
-                      {
-                        'multi_match': {
-                          'query': 'postalcode value',
-                          'type': 'phrase',
-                          'fields': [
-                            'parent.postalcode'
-                          ]
-                        }
-                      }
-                    ],
-                    'filter': {
-                      'term': {
-                        'layer': 'postalcode'
-                      }
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.postalcode',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'postalcode value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.postalcode'
+                      ]
                     }
                   }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'postalcode'
+                  }
                 }
-              ]
+              }
             }
-          },
-          'filter': {
-            'bool': {
-              'must': []
-            }
-          }
+          ]
         }
       },
       'max_boost': 20,

--- a/test/unit/fixture/structured_geocoding/with_source_filtering.json
+++ b/test/unit/fixture/structured_geocoding/with_source_filtering.json
@@ -2,12 +2,10 @@
   "query": {
     "function_score": {
       "query": {
-        "filtered": {
-          "query": {
-            "bool": {
-              "should": []
-            }
-          },
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [
+          ],
           "filter": {
             "bool": {
               "must": [


### PR DESCRIPTION
pelias-query 8.16.1 includes working Elasticsearch 5 queries, and my additional commit updates our test fixtures to use them.

Fixes https://github.com/pelias/api/issues/762
Fixes #844
Connects https://github.com/pelias/pelias/issues/461