### PR TITLE
updated code+tests to findById name array output format

### DIFF
--- a/middleware/changeLanguage.js
+++ b/middleware/changeLanguage.js
@@ -146,7 +146,7 @@ function updateDocs( req, res, translations ){
 
         // requested language is not available
         if (_.isEmpty(_.get(translations[id].names, requestLanguage, [] ))) {
-          logger.info( '[language] [info]', 'missing translation', requestLanguage, id );
+          logger.debug( '[language] [debug]', 'missing translation', requestLanguage, id );
           continue;
         }
 

--- a/middleware/changeLanguage.js
+++ b/middleware/changeLanguage.js
@@ -1,6 +1,7 @@
 
 var logger = require( 'pelias-logger' ).get( 'api' );
 var service = require('../service/language');
+const _ = require('lodash');
 
 /**
 example response from language web service:
@@ -28,7 +29,6 @@ example response from language web service:
 **/
 
 function setup() {
-
   var transport = service.findById();
   var middleware = function(req, res, next) {
 
@@ -145,18 +145,18 @@ function updateDocs( req, res, translations ){
         if( !translations[id].hasOwnProperty( 'names' ) ){ continue; }
 
         // requested language is not available
-        if( !translations[id].names.hasOwnProperty( requestLanguage ) ){
+        if (_.isEmpty(_.get(translations[id].names, requestLanguage, [] ))) {
           logger.info( '[language] [info]', 'missing translation', requestLanguage, id );
           continue;
         }
 
         // translate 'parent.*' property
-        adminValues[i] = translations[id].names[ requestLanguage ];
+        adminValues[i] = translations[id].names[ requestLanguage ][0];
 
         // if the record is an admin record we also translate
         // the 'name.default' property.
         if( adminKey === doc.layer ){
-          doc.name.default = translations[id].names[ requestLanguage ];
+          doc.name.default = translations[id].names[ requestLanguage ][0];
         }
       }
     }


### PR DESCRIPTION
Placeholder `findById` endpoint returns names as an object keyed on ISO3 code with values in an array:

```json
{
  "101750367": {
    "id": 101750367,
    "name": "London",
    "placetype": "locality",
    "names": {
      "abk": [
        "Лондан"
      ],
      "ace": [
        "London"
      ]
    }
  }
}
```

The code and tests were written to parse the names from an object keyed on ISO3->string name:

```json
{
  "101750367": {
    "id": 101750367,
    "name": "London",
    "placetype": "locality",
    "names": {
      "abk": "Лондан",
      "ace": "London"
    }
  }
}
```

This PR modifies the code and tests to read the response as returned by current placeholder `findById` (with arrays of names).  Source has been added to check for an empty array before attempting to take the first value (with tests).   

Test code also introduces proxyquire for dependency mocking. 

Also fixes typo in test (`locaity ` -> `locality`).  