### PR TITLE
Add default route redirecting to /v1

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,3 @@
-
 var app = require('express')();
 
 var peliasConfig = require( 'pelias-config' ).generate(require('./schema'));
@@ -15,6 +14,10 @@ app.use( require('./middleware/options') );
 app.use( require('./middleware/jsonp') );
 
 /** ----------------------- routes ----------------------- **/
+
+
+var defaultRoutes = require('./routes/default');
+defaultRoutes.addRoutes(app);
 
 var v1 = require('./routes/v1');
 v1.addRoutes(app, peliasConfig);

--- a/routes/default.js
+++ b/routes/default.js
@@ -1,0 +1,12 @@
+// set up routes that are outside any particular API version
+function addRoutes(app) {
+  function redirectToV1(req, res, next) {
+    res.redirect(301, '/v1');
+  }
+
+  // default root URL traffic to V1 root
+  // which has a link to the readme and other helpful info
+  app.get('/', redirectToV1);
+}
+
+module.exports.addRoutes = addRoutes;


### PR DESCRIPTION
This makes the root URL of the API a bit more friendly

Fixes https://github.com/pelias/api/issues/961