### PR TITLE
Skip CI Docker Image builds on Greenkeeper branches

### DIFF
--- a/.circleci/docker.sh
+++ b/.circleci/docker.sh
@@ -6,6 +6,11 @@ DATE=`date +%Y-%m-%d`
 DOCKER_REPOSITORY="pelias"
 DOCKER_PROJECT="${DOCKER_REPOSITORY}/${CIRCLE_PROJECT_REPONAME}"
 
+# skip builds on greenkeeper branches
+if [ "${CIRCLE_BRANCH##greenkeeper}" ]; then
+	exit 0
+fi
+
 # the name of the image that represents the "branch", that is an image that will be updated over time with the git branch
 # the production branch is changed to "latest", otherwise the git branch becomes the name of the version
 if [[ "${CIRCLE_BRANCH}" == "production" ]]; then


### PR DESCRIPTION
We most likely will not want these Docker images and they can fail due
to characters in branch names that are not valid in Docker image tags.

Fixes https://github.com/pelias/api/issues/975
Connects https://github.com/pelias/dockerfiles/issues/21