### PR TITLE
Fix CircleCI script to skip Greenkeeper branch builds

### DIFF
--- a/.circleci/docker.sh
+++ b/.circleci/docker.sh
@@ -7,7 +7,7 @@ DOCKER_REPOSITORY="pelias"
 DOCKER_PROJECT="${DOCKER_REPOSITORY}/${CIRCLE_PROJECT_REPONAME}"
 
 # skip builds on greenkeeper branches
-if [ "${CIRCLE_BRANCH##greenkeeper}" ]; then
+if [[ -z "${CIRCLE_BRANCH##*greenkeeper*}" ]]; then
 	exit 0
 fi
 


### PR DESCRIPTION
Somehow I completely failed at copying code [from StackOverflow](https://speakerdeck.com/noelrap/the-road-to-legacy-is-paved-with-good-intentions) in https://github.com/pelias/api/pull/983.

Instead of skipping Docker image builds only for branches with greenkeeper in the name, it _always_ skipped the build!

Connects https://github.com/pelias/dockerfiles/issues/21