### PR TITLE
added empire as supported explicit and as part of coarse

### DIFF
--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -49,7 +49,7 @@ var LAYERS_BY_SOURCE = {
  openaddresses: [ 'address' ],
  geonames: [ 'country','macroregion', 'region', 'county','localadmin',
   'locality','borough', 'neighbourhood', 'venue' ],
- whosonfirst: [ 'continent', 'country', 'dependency', 'macroregion', 'region',
+ whosonfirst: [ 'continent', 'empire', 'country', 'dependency', 'macroregion', 'region',
    'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'borough',
    'neighbourhood', 'microhood', 'disputed', 'venue', 'postalcode']
 };
@@ -60,7 +60,7 @@ var LAYERS_BY_SOURCE = {
  * may have layers that mean the same thing but have a different name
  */
 var LAYER_ALIASES = {
-  'coarse': [ 'continent', 'country', 'dependency', 'macroregion', 'region',
+  'coarse': [ 'continent', 'empire', 'country', 'dependency', 'macroregion', 'region',
    'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'borough',
    'neighbourhood', 'microhood', 'disputed', 'postalcode' ]
 };

--- a/test/unit/helper/type_mapping.js
+++ b/test/unit/helper/type_mapping.js
@@ -12,7 +12,7 @@ module.exports.tests.interfaces = function(test, common) {
 
   test('alias layer mapping', function(t) {
     t.deepEquals(type_mapping.layer_mapping.coarse,
-                 [ 'continent', 'country', 'dependency', 'macroregion',
+                 [ 'continent', 'empire', 'country', 'dependency', 'macroregion',
                    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood',
                    'borough', 'neighbourhood', 'microhood', 'disputed', 'postalcode' ]);
     t.end();

--- a/test/unit/sanitizer/_layers.js
+++ b/test/unit/sanitizer/_layers.js
@@ -41,7 +41,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
 
     sanitizer.sanitize(raw, clean);
 
-    var admin_layers = [ 'continent', 'country', 'dependency',
+    var admin_layers = [ 'continent', 'empire', 'country', 'dependency',
     'macroregion', 'region', 'locality', 'localadmin', 'macrocounty', 'county',
     'macrohood', 'borough', 'neighbourhood', 'microhood', 'disputed', 'postalcode' ];
 
@@ -76,7 +76,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
 
     sanitizer.sanitize(raw, clean);
 
-    var expected_layers = [ 'continent', 'country', 'dependency',
+    var expected_layers = [ 'continent', 'empire', 'country', 'dependency',
     'macroregion', 'region', 'locality', 'localadmin', 'macrocounty', 'county',
     'macrohood', 'borough', 'neighbourhood', 'microhood', 'disputed', 'postalcode' ];
 
@@ -112,7 +112,7 @@ module.exports.tests.sanitize_layers = function(test, common) {
 
     sanitizer.sanitize(raw, clean);
 
-    var coarse_layers = [ 'continent',
+    var coarse_layers = [ 'continent', 'empire',
       'country', 'dependency', 'macroregion', 'region', 'locality', 'localadmin',
       'macrocounty', 'county', 'macrohood', 'borough', 'neighbourhood', 'microhood',
       'disputed', 'postalcode' ];


### PR DESCRIPTION
allows empire placetype records to be returned when `layers=empire` and `layers=coarse`.  