### PR TITLE
feat(coarse_reverse): add try/catch block around synthesizeDoc code

### DIFF
--- a/controller/coarse_reverse.js
+++ b/controller/coarse_reverse.js
@@ -102,7 +102,7 @@ function synthesizeDoc(results) {
     // an error occurred when generating a new Document
     logger.info(`[controller:coarse_reverse][error]`);
     logger.error(e);
-    logger.error(results);
+    logger.info(results);
 
     return null;
   }

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -861,7 +861,7 @@ module.exports.tests.failure_conditions = (test, common) => {
   });
 
   test('service returns 0 length name', (t) => {
-    t.plan(5);
+    t.plan(6);
 
     const service = (req, callback) => {
       t.deepEquals(req, { clean: { layers: ['neighbourhood'] } } );
@@ -902,15 +902,12 @@ module.exports.tests.failure_conditions = (test, common) => {
     };
 
     t.deepEquals(res, expected);
-    t.deepEquals(logger.getMessages('info'), [
-      '[controller:coarse_reverse][queryType:pip][result_count:1]',
-      '[controller:coarse_reverse][error]'
-    ]);
-    t.deepEquals(logger.getMessages('error'), [
-      '{ [PeliasModelError: invalid document type, expecting: truthy, ' +
-      'got: ]\n  name: \'PeliasModelError\',\n  message: \'invalid document type, expecting: truthy, got: \' }',
-      '{ neighbourhood: [ { id: 20, name: \'\' } ] }'
-    ]);
+
+    // logger messages
+    t.true(logger.hasMessages('info'), '[controller:coarse_reverse][error]');
+    t.true(logger.hasMessages('error'), 'invalid document type, expecting: truthy, got: ');
+    t.true(logger.hasMessages('info'), '{ neighbourhood: [ { id: 20, name: \'\' } ] }');
+
     t.end();
 
   });

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -860,6 +860,60 @@ module.exports.tests.failure_conditions = (test, common) => {
 
   });
 
+  test('service returns 0 length name', (t) => {
+    t.plan(5);
+
+    const service = (req, callback) => {
+      t.deepEquals(req, { clean: { layers: ['neighbourhood'] } } );
+
+      const results = {
+        neighbourhood: [
+          { id: 20, name: '' }
+        ]
+      };
+
+      callback(undefined, results);
+    };
+
+    const logger = require('pelias-mock-logger')();
+
+    const controller = proxyquire('../../../controller/coarse_reverse', {
+      'pelias-logger': logger
+    })(service, _.constant(true));
+
+    const req = {
+      clean: {
+        layers: ['neighbourhood']
+      }
+    };
+
+    const res = { };
+
+    // verify that next was called
+    const next = () => {
+      t.pass('next() was called');
+    };
+
+    controller(req, res, next);
+
+    const expected = {
+      meta: {},
+      data: []
+    };
+
+    t.deepEquals(res, expected);
+    t.deepEquals(logger.getMessages('info'), [
+      '[controller:coarse_reverse][queryType:pip][result_count:1]',
+      '[controller:coarse_reverse][error]'
+    ]);
+    t.deepEquals(logger.getMessages('error'), [
+      '{ [PeliasModelError: invalid document type, expecting: truthy, ' +
+      'got: ]\n  name: \'PeliasModelError\',\n  message: \'invalid document type, expecting: truthy, got: \' }',
+      '{ neighbourhood: [ { id: 20, name: \'\' } ] }'
+    ]);
+    t.end();
+
+  });
 };
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
fix for the pagerduty alert reported this morning:

```
2017-09-25_08:03:40.45896 /srv/www/api/releases/20170919173917/node_modules/pelias-model/util/valid.js:29
2017-09-25_08:03:40.45896     throw new PeliasModelError( 'invalid document type, expecting: truthy, got: ' + val );
2017-09-25_08:03:40.45896     ^
2017-09-25_08:03:40.45934 PeliasModelError: invalid document type, expecting: truthy, got: 
2017-09-25_08:03:40.45934     at Object.module.exports.truthy (/srv/www/api/releases/20170919173917/node_modules/pelias-model/util/valid.js:29:11)
2017-09-25_08:03:40.45934     at Document.<anonymous> (/srv/www/api/releases/20170919173917/node_modules/pelias-model/Document.js:255:14)
2017-09-25_08:03:40.45935     at Document.addParent (/srv/www/api/releases/20170919173917/node_modules/pelias-model/Document.js:291:5)
2017-09-25_08:03:40.45935     at /srv/www/api/releases/20170919173917/controller/coarse_reverse.js:70:9
2017-09-25_08:03:40.45935     at Array.forEach (native)
2017-09-25_08:03:40.45935     at synthesizeDoc (/srv/www/api/releases/20170919173917/controller/coarse_reverse.js:69:19)
2017-09-25_08:03:40.45936     at /srv/www/api/releases/20170919173917/controller/coarse_reverse.js:144:23
2017-09-25_08:03:40.45936     at /srv/www/api/releases/20170919173917/node_modules/pelias-microservice-wrapper/service.js:110:18
2017-09-25_08:03:40.45936     at Request.callback (/srv/www/api/releases/20170919173917/node_modules/superagent/lib/node/index.js:679:14)
2017-09-25_08:03:40.45936     at /srv/www/api/releases/20170919173917/node_modules/superagent/lib/node/index.js:868:18
2017-09-25_08:03:41.04725 loading libpostal data, this may take a few seconds...
```