### PR TITLE
Check for missing parent object in confidence score computation

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -94,7 +94,8 @@ function checkForDealBreakers(req, hit) {
     return false;
   }
 
-  if (check.assigned(req.clean.parsed_text.state) && hit.parent.region_a && req.clean.parsed_text.state !== hit.parent.region_a[0]) {
+  if (check.assigned(req.clean.parsed_text.state) && check.assigned(hit.parent) &&
+      hit.parent.region_a && req.clean.parsed_text.state !== hit.parent.region_a[0]) {
     logger.debug('[confidence][deal-breaker]: state !== region_a');
     return true;
   }
@@ -220,8 +221,8 @@ function checkAddress(text, hit) {
     res += propMatch(text.number, (hit.address_parts ? hit.address_parts.number : null), false);
     res += propMatch(text.street, (hit.address_parts ? hit.address_parts.street : null), false);
     res += propMatch(text.postalcode, (hit.address_parts ? hit.address_parts.zip: null), true);
-    res += propMatch(text.state, (hit.parent.region_a ? hit.parent.region_a[0] : null), true);
-    res += propMatch(text.country, (hit.parent.country_a ? hit.parent.country_a[0] :null), true);
+    res += propMatch(text.state, ((hit.parent && hit.parent.region_a) ? hit.parent.region_a[0] : null), true);
+    res += propMatch(text.country, ((hit.parent && hit.parent.country_a) ? hit.parent.country_a[0] :null), true);
 
     res /= checkCount;
   }

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -169,6 +169,38 @@ module.exports.tests.confidenceScore = function(test, common) {
     t.false(res.data[0].hasOwnProperty('confidence'), 'score was not set');
     t.end();
   });
+
+  test('missing parent object should not throw an exception', function(t) {
+    var req = {
+      clean: {
+        text: '123 Main St, City, NM',
+        parsed_text: {
+          number: 123,
+          street: 'Main St',
+          state: 'NM'
+        }
+      }
+    };
+    var res = {
+      data: [{
+        _score: 10,
+        found: true,
+        value: 1,
+        center_point: { lat: 100.1, lon: -50.5 },
+        name: { default: 'test name1' },
+      }],
+      meta: {
+        scores: [10],
+        query_type: 'original'
+      }
+    };
+
+    t.doesNotThrow(() => {
+      confidenceScore(req, res, () => {});
+    });
+    t.equal(res.data[0].confidence, 0.28, 'score was set');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
We have been experiences a significant number of these errors recently. 

`500 Cannot read property 'region_a' of undefined`

![screen shot 2017-09-25 at 12 49 17 pm](https://user-images.githubusercontent.com/5446511/30820468-ff3f64fa-a1ef-11e7-8191-7e2ca2f0aec7.png)

For example: [/v1/search?debug=true&layers=neighbourhood&text=cuba, new me](http://pelias.github.io/compare/#/v1/search%3Fdebug=true&layers=neighbourhood&text=cuba,%20new%20me)

![screen shot 2017-09-25 at 12 47 22 pm](https://user-images.githubusercontent.com/5446511/30820361-b43b4c44-a1ef-11e7-8ea2-409d35d138bb.png)
