### PR TITLE
feat(coarse_reverse): ignore empty abbr properties from PIP service

### DIFF
--- a/controller/coarse_reverse.js
+++ b/controller/coarse_reverse.js
@@ -68,7 +68,7 @@ function synthesizeDoc(results) {
 
     // assign the administrative hierarchy
     _.keys(results).forEach((layer) => {
-      doc.addParent(layer, results[layer][0].name, results[layer][0].id.toString(), results[layer][0].abbr);
+      doc.addParent(layer, results[layer][0].name, results[layer][0].id.toString(), results[layer][0].abbr || undefined);
     });
 
     // set centroid if available

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -911,6 +911,66 @@ module.exports.tests.failure_conditions = (test, common) => {
     t.end();
 
   });
+
+  test('service returns 0 length abbr', (t) => {
+    t.plan(4);
+
+    const service = (req, callback) => {
+      t.deepEquals(req, { clean: { layers: ['neighbourhood'] } } );
+
+      const results = {
+        neighbourhood: [
+          { id: 20, name: 'Example', abbr: '' }
+        ]
+      };
+
+      callback(undefined, results);
+    };
+
+    const logger = require('pelias-mock-logger')();
+
+    const controller = proxyquire('../../../controller/coarse_reverse', {
+      'pelias-logger': logger
+    })(service, _.constant(true));
+
+    const req = {
+      clean: {
+        layers: ['neighbourhood']
+      }
+    };
+
+    const res = { };
+
+    // verify that next was called
+    const next = () => {
+      t.pass('next() was called');
+    };
+
+    controller(req, res, next);
+
+    const expected = {
+      meta: {},
+      data: [{
+        name: { default: 'Example' },
+        phrase: { default: 'Example' },
+        parent: {
+          neighbourhood: [ 'Example' ],
+          neighbourhood_id: [ '20' ],
+          neighbourhood_a: [ null ]
+        },
+        source: 'whosonfirst',
+        layer: 'neighbourhood',
+        source_id: '20',
+        _id: '20',
+        _type: 'neighbourhood'
+      }]
+    };
+
+    t.deepEquals(res, expected);
+    t.notOk(logger.hasErrorMessages());
+    t.end();
+
+  });
 };
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
Following on from https://github.com/pelias/api/pull/1003 ...

In 1003 I added code to `try/catch` the document construction code (to avoid the service crashing), thanks to @gitsno I was able to see that the true culprits are responses like this:

```
"id":85632733,
"name":"Somaliland",
"abbr":""
```

This PR ignores empty `abbr` attributes (ie: `abbr=''`) and so will not cause a fatal error now unless the name itself is invalid.

As a result, the API will no longer return an empty resultset for cases where the PIP service returns results with an empty abbr property.

closes https://github.com/pelias/api/issues/1009