### PR TITLE
Remove extend dependency

### DIFF
--- a/helper/type_mapping.js
+++ b/helper/type_mapping.js
@@ -1,5 +1,4 @@
-var extend = require('extend'),
-  _ = require('lodash');
+const _ = require('lodash');
 
 function addStandardTargetsToAliases(standard, aliases) {
   var combined = _.extend({}, aliases);

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -74,7 +74,7 @@ function convertToGeocodeJSON(req, res, next, opts) {
   res.body.geocoding.timestamp = new Date().getTime();
 
   // convert docs to geojson and merge with geocoding block
-  extend(res.body, geojsonify(req.clean, res.data || []));
+  _.extend(res.body, geojsonify(req.clean, res.data || []));
 
   next();
 }

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -1,5 +1,4 @@
 var url = require('url');
-var extend = require('extend');
 var geojsonify = require('../helper/geojsonify');
 var _ = require('lodash');
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "elasticsearch": "^13.0.0",
     "elasticsearch-exceptions": "0.0.4",
     "express": "^4.8.8",
-    "extend": "^3.0.1",
     "geojson": "^0.5.0",
     "@mapbox/geojson-extent": "^0.3.1",
     "geolib": "^2.0.18",

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -1,6 +1,5 @@
 var check = require('check-types');
 var parser = require('addressit');
-var extend = require('extend');
 var _      = require('lodash');
 var logger = require('pelias-logger').get('api');
 

--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -82,8 +82,8 @@ function parse(query) {
   var addressWithAdminParts  = getAdminPartsBySplittingOnDelim(queryParts);
   var addressWithAddressParts= getAddressParts(queryParts.join(DELIM + ' '));
 
-  var parsedAddress  = extend(addressWithAdminParts,
-                              addressWithAddressParts);
+  // combine the 2 objects
+  _.extend(addressWithAdminParts, addressWithAddressParts);
 
   var address_parts  =  [ 'name',
                           'number',
@@ -99,8 +99,8 @@ function parse(query) {
   var parsed_text = {};
 
   address_parts.forEach(function(part){
-    if (parsedAddress[part]) {
-      parsed_text[part] = parsedAddress[part];
+    if (addressWithAdminParts[part]) {
+      parsed_text[part] = addressWithAdminParts[part];
     }
   });
 


### PR DESCRIPTION
Removes the [extend](https://www.npmjs.com/package/extend) dependency, opting for [Lodash extend](https://lodash.com/docs/4.17.4#assignIn).  