### PR TITLE
[DO NOT MERGE] Support Korean label format

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "morgan": "^1.8.2",
     "pelias-categories": "1.2.0",
     "pelias-config": "2.12.1",
-    "pelias-labels": "1.6.0",
+    "pelias-labels": "git://github.com/pelias/labels.git#korean-labels",
     "pelias-logger": "0.2.0",
     "pelias-microservice-wrapper": "1.2.1",
     "pelias-model": "5.1.0",


### PR DESCRIPTION
This is just to make testing the changes easier on dev.
The proper version update PR should come from greenkeeper.

(Fixes labels in Korea to match expected local standards.)