### PR TITLE
Corrrectly filter /place queries by layer

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -38,7 +38,7 @@ function setup( apiConfig, esclient ){
     const cmd = req.clean.ids.map( function(id) {
       return {
         _index: apiConfig.indexName,
-        _type: id.layers,
+        _type: id.layer,
         _id: id.id
       };
     });

--- a/test/unit/controller/place.js
+++ b/test/unit/controller/place.js
@@ -51,11 +51,11 @@ module.exports.tests.success = (test, common) => {
         ids: [
           {
             id: 'id1',
-            layers: 'layer1'
+            layer: 'layer1'
           },
           {
             id: 'id2',
-            layers: 'layer2'
+            layer: 'layer2'
           }
         ]
       },


### PR DESCRIPTION
`/place` queries have been executing in a way where only the ID, but not the layer, has been considered when returning records from Elasticsearch.

It turns out this bug was introduced almost a year and a half ago in https://github.com/pelias/api/pull/407. A little, relatively unimportant bit of code was looking for a property called `layers`:

```
    const cmd = req.clean.ids.map( function(id) {
      return {
        _index: apiConfig.indexName,
        _type: id.layers,
        _id: id.id
      };
    });
```

The correct property was `layer`, so no filtering on layer was done in the resulting [mget](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html) query.

There was never an acceptance test for these sorts of queries, but there is now one in https://github.com/pelias/acceptance-tests/pull/446. The unit tests were enforcing the incorrect behavior.

Fixes https://github.com/pelias/pelias/issues/643