### PR TITLE
Use Node.js's default listen behaviour as our default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 
 const app = require('./app'),
     port = ( process.env.PORT || 3100 ),
-    host = ( process.env.HOST || 'localhost' );
+    host = ( process.env.HOST || undefined );
 
 /** run server on the default setup (single core) **/
 console.log( `pelias is now running on ${host}:${port}` );

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ const app = require('./app'),
     port = ( process.env.PORT || 3100 ),
     host = ( process.env.HOST || undefined );
 
-/** run server on the default setup (single core) **/
-console.log( `pelias is now running on ${host}:${port}` );
-app.listen( port, host );
+const server = app.listen( port, host, () => {
+  // ask server for the actual address and port its listening on
+  const listenAddress = server.address();
+  console.log( `pelias is now running on ${listenAddress.address}:${listenAddress.port}` );
+});


### PR DESCRIPTION
This restores the Node.js default listen behaviour (listening on all network interfaces), unless the `HOST` environment variable is specified.

I also use `http.Server`'s `address()` function to get the actual address and port the server listens on, in order to print a helpful and accurate message when Pelias starts.

Fixes https://github.com/pelias/api/issues/1037
Closes https://github.com/pelias/dockerfiles/pull/34 (no longer needed)