### PR TITLE
Setting env variable host in dockerfile to make app listen on every available network interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ LABEL maintainer="pelias@mapzen.com"
 
 EXPOSE 3100
 
+# Make sure host is set to enable exposure of app outside of docker container
+ENV HOST 0.0.0.0
+
 # Where the app is built and run inside the docker fs
 ENV WORK=/opt/pelias
 


### PR DESCRIPTION
Since this change, https://github.com/pelias/api/commit/cb8f4017e55c2b7c6647d23e655e0e59d7af8da5#diff-168726dbe96b3ce427e7fedce31bb0bc I hade a hard time running Pelias API in docker setup. Could not reach the api from outside docker anymore. This small change will fix that.

Took me some time to find this problem so hopefully getting this fixed could help others.