### PR TITLE
Update Dockerfile for libpostal service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM pelias/libpostal_baseimage
+FROM pelias/baseimage
 
 # maintainer information
 LABEL maintainer="pelias@mapzen.com"


### PR DESCRIPTION
The Dockerfile no longer needs to be build on the libpostal_baseimage
(which will probably go away soon)

Note: this is merging into the microservicify-libpostal branch.