### PR TITLE
Output "category" field in all responses

### DIFF
--- a/helper/geojsonify_place_details.js
+++ b/helper/geojsonify_place_details.js
@@ -57,7 +57,7 @@ const DETAILS_PROPS = [
   { name: 'marinearea_a',      type: 'string' },
   { name: 'bounding_box',      type: 'default' },
   { name: 'label',             type: 'string' },
-  { name: 'category',          type: 'array',     condition: checkCategoryParam }
+  { name: 'category',          type: 'array' }
 ];
 
 // returns true IFF source a country_gid property

--- a/test/unit/helper/geojsonify_place_details.js
+++ b/test/unit/helper/geojsonify_place_details.js
@@ -498,11 +498,12 @@ module.exports.tests.geojsonify_place_details = (test, common) => {
 
   });
 
-  test('category property should not be output when params does not contain \'category\' property', t => {
+  test('category property should be output even when params does not contain \'category\' property', t => {
     const source = {
       category: [ 1, 2 ]
     };
     const expected = {
+      category: [ 1, 2 ]
     };
 
     const clean = {};
@@ -514,11 +515,12 @@ module.exports.tests.geojsonify_place_details = (test, common) => {
 
   });
 
-  test('category property should not be output when params is not an object', t => {
+  test('category property should be output when params is not an object', t => {
     const source = {
       category: [ 1, 2 ]
     };
     const expected = {
+      category: [ 1, 2 ]
     };
 
     const clean = 'this is not an object';


### PR DESCRIPTION
`category` field is currently output only when a valid `categories` list is passed in request params.

This PR suggests to always include this field if it's defined.
Is there any drawback to returning categories in all responses ?