### PR TITLE
Update to current Pelias contact email address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM pelias/baseimage
 
 # maintainer information
-LABEL maintainer="pelias@mapzen.com"
+LABEL maintainer="pelias.team@gmail.com"
 
 EXPOSE 3100
 

--- a/sanitizer/_deprecate_quattroshapes.js
+++ b/sanitizer/_deprecate_quattroshapes.js
@@ -26,7 +26,7 @@ function _sanitize( raw, clean, opts ) {
        'replaced by Who\'s on First, an actively maintained data project based on Quattroshapes' +
        'Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will ' +
        'be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as ' +
-       '`sources=whosonfirst`. If you have any questions, please email search@mapzen.com.');
+       '`sources=whosonfirst`. If you have any questions, please email pelias.team@gmail.com.');
 
        // user requested 'quattroshapes', we will give them 'whosonfirst' instead.
        sources = _.without(sources, 'quattroshapes', 'qs');

--- a/test/ciao/reverse/sources_deprecation_warning.coffee
+++ b/test/ciao/reverse/sources_deprecation_warning.coffee
@@ -27,7 +27,7 @@ should.not.exist json.geocoding.errors
 
 #? expected warnings
 should.exist json.geocoding.warnings
-json.geocoding.warnings.should.eql ['You are using Quattroshapes as a data source in this query. Quattroshapes has been disabled as a data source for Mapzen Search, and has beenreplaced by Who\'s on First, an actively maintained data project based on QuattroshapesYour existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as `sources=whosonfirst`. If you have any questions, please email search@mapzen.com.' ]
+json.geocoding.warnings.should.eql ['You are using Quattroshapes as a data source in this query. Quattroshapes has been disabled as a data source for Mapzen Search, and has beenreplaced by Who\'s on First, an actively maintained data project based on QuattroshapesYour existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as `sources=whosonfirst`. If you have any questions, please email pelias.team@gmail.com.' ]
 
 #? inputs
 json.geocoding.query['size'].should.eql 10

--- a/test/ciao/search/sources_deprecation_warning.coffee
+++ b/test/ciao/search/sources_deprecation_warning.coffee
@@ -27,7 +27,7 @@ should.not.exist json.geocoding.errors
 
 #? expected warnings
 should.exist json.geocoding.warnings
-json.geocoding.warnings.should.eql ['You are using Quattroshapes as a data source in this query. Quattroshapes has been disabled as a data source for Mapzen Search, and has beenreplaced by Who\'s on First, an actively maintained data project based on QuattroshapesYour existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as `sources=whosonfirst`. If you have any questions, please email search@mapzen.com.' ]
+json.geocoding.warnings.should.eql ['You are using Quattroshapes as a data source in this query. Quattroshapes has been disabled as a data source for Mapzen Search, and has beenreplaced by Who\'s on First, an actively maintained data project based on QuattroshapesYour existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as `sources=whosonfirst`. If you have any questions, please email pelias.team@gmail.com.' ]
 
 #? inputs
 json.geocoding.query['size'].should.eql 10

--- a/test/unit/sanitizer/_deprecate_quattroshapes.js
+++ b/test/unit/sanitizer/_deprecate_quattroshapes.js
@@ -15,7 +15,7 @@ module.exports.tests.warning_message_1 = function(test, common) {
        'replaced by Who\'s on First, an actively maintained data project based on Quattroshapes' +
        'Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will ' +
        'be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as ' +
-       '`sources=whosonfirst`. If you have any questions, please email search@mapzen.com.']
+       '`sources=whosonfirst`. If you have any questions, please email pelias.team@gmail.com.']
     }, 'warning emitted');
 
     t.end();
@@ -35,7 +35,7 @@ module.exports.tests.warning_message_2 = function(test, common) {
        'replaced by Who\'s on First, an actively maintained data project based on Quattroshapes' +
        'Your existing queries WILL CONTINUE TO WORK for the foreseeable future, but results will ' +
        'be coming from Who\'s on First and `sources=quattroshapes` will be interpreted as ' +
-       '`sources=whosonfirst`. If you have any questions, please email search@mapzen.com.']
+       '`sources=whosonfirst`. If you have any questions, please email pelias.team@gmail.com.']
     }, 'warning emitted');
 
     t.end();


### PR DESCRIPTION
Per https://github.com/pelias/pelias/tree/master/announcements/2018-01-02-pelias-update replace all @mapzen.com email addresses with the current Pelias contact email address.

With the objective of making small granular changes in standalone commits, the `Dockerfile` change was separated out.

grep used to confirm no '@mapzen.com' remain.

---
#### Here's the reason for this change :rocket:

Works towards one of the tasks in https://github.com/pelias/pelias/issues/703 ("sweep through all code for mapzen links and other 404s")

---
#### Here's what actually got changed :clap:

- [x] `Dockerfile`
- [x] `sanitizer/_deprecate_quattroshapes.js` and associated unit tests.

---
#### Here's how others can test the changes :eyes:
Existing continuous integration outcome should remain unchanged, particularly after the change to `sanitizer/_deprecate_quattroshapes.js` and associated unit tests.
