### PR TITLE
Update to current upstream Who's On First URL

### DIFF
--- a/public/attribution.md
+++ b/public/attribution.md
@@ -4,4 +4,4 @@
    * [OpenStreetMap](http://www.openstreetmap.org/copyright) © OpenStreetMap contributors under [ODbL](http://opendatacommons.org/licenses/odbl/)
    * [OpenAddresses](http://openaddresses.io) under a [Creative Commons Zero](https://github.com/openaddresses/openaddresses/blob/master/sources/LICENSE) public domain designation
    * [GeoNames](http://www.geonames.org/) under [CC-BY-3.0](https://creativecommons.org/licenses/by/2.0/)
-   * [WhosOnFirst](http://whosonfirst.mapzen.com) under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)
+   * [WhosOnFirst](https://www.whosonfirst.org/) under [various licenses](https://github.com/whosonfirst/whosonfirst-data/blob/master/LICENSE.md)


### PR DESCRIPTION
grep used to confirm no other direct whosonfirst.mapzen.com links remain.

---
#### Here's the reason for this change :rocket:

Works towards one of the tasks in pelias/pelias#703 ("Switch all whosonfirst URLs to https://www.whosonfirst.org/")

---
#### Here's what actually got changed :clap:

- [x] `public/attribution.md`

---
#### Here's how others can test the changes :eyes:
n/a