### PR TITLE
fix: Avoid querying PIP service for non-coarse reverse

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -138,7 +138,7 @@ function addRoutes(app, peliasConfig) {
 
   // fallback to coarse reverse when regular reverse didn't return anything
   const coarseReverseShouldExecute = all(
-    isPipServiceEnabled, not(hasRequestErrors), not(hasResponseData)
+    isPipServiceEnabled, not(hasRequestErrors), not(hasResponseData), not(isOnlyNonAdminLayers)
   );
 
   const libpostalShouldExecute = all(


### PR DESCRIPTION
Queries that specified only non-coarse layers (address or venue) and had no results returned from Elasticsearch would trigger a request to the PIP service.

The PIP service does not contain any addresses or venues so this query will never return anything, and only waste time.

@trescube @missinglink any idea how to test this?