### PR TITLE
Rewrite Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # base image
 FROM pelias/baseimage
+RUN useradd -ms /bin/bash pelias
+USER pelias
 
 # maintainer information
 LABEL maintainer="pelias.team@gmail.com"
@@ -7,23 +9,17 @@ LABEL maintainer="pelias.team@gmail.com"
 EXPOSE 3100
 
 # Where the app is built and run inside the docker fs
-ENV WORK=/opt/pelias
-
-# Used indirectly for saving npm logs etc.
-ENV HOME=/opt/pelias
-
+ENV WORK=/home/pelias
 WORKDIR ${WORK}
+
+# copy package.json first to prevent npm install being rerun when only code changes
+COPY ./package.json ${WORK}
+RUN npm install
+
 COPY . ${WORK}
 
-# Build and set permissions for arbitrary non-root user
-RUN npm install && \
-  npm test && \
-  chmod -R a+rwX .
-
-# Don't run as root, because there's no reason to (https://docs.docker.com/engine/articles/dockerfile_best-practices/#user).
-# This also reveals permission problems on local Docker.
-RUN chown -R 9999:9999 ${WORK}
-USER 9999
+# only allow containers to succeed if tests pass
+RUN npm test
 
 # start service
 CMD [ "npm", "start" ]


### PR DESCRIPTION
There were a couple problems with the current Dockerfile:

* It set the userid of the processes running in the container to 9999,
without creating a user with that ID. This leads to confusion and an
annoying message when you run an interactive bash session (the shell PS1
would display something like `I have no name!@1438586f786e:~$`)
* It tried to run `chown` on _all_ code files after running NPM install.
This takes a really long time
* It did not copy `package.json` and run `npm install` before copying
other files. This means even a one line code change causes the image
rebuild process to re-run `npm install`, which takes 30 seconds or so
* It used `npm start` which unfortunately does not handle signals properly, making the container slower to shut down (see https://github.com/npm/npm/issues/4603)

Now the image creates and uses a pelias user, sets permissions correctly
from the start to avoid `chown`, and only runs `npm install` when it
absolutely has to.