### PR TITLE
Only call language service when language not defaulted

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -226,6 +226,10 @@ function addRoutes(app, peliasConfig) {
     isAddressItParse
   );
 
+  const languageWasSpecified = function(req, res) {
+    return !req.clean.lang.defaulted;
+  };
+
   // get language adjustments if:
   // - there's a response
   // - theres's a lang parameter in req.clean
@@ -233,6 +237,7 @@ function addRoutes(app, peliasConfig) {
     hasResponseData,
     not(hasRequestErrors),
     isChangeLanguageEnabled,
+    languageWasSpecified,
     hasRequestParameter('lang')
   );
 


### PR DESCRIPTION
The default language is ~English~, which is also what is stored in Elasticsearch. Thus, if the user did not specify a language via headers or query parameter, there is no reason to call Placeholder.

Some Placeholder responses for language translation can be 30KB, and all that JSON takes considerable time to parse

This was originally part of #1095 

Edit: the default language is not English in WOF/Placeholder.