### PR TITLE
fix attribution link

### DIFF
--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -47,7 +47,11 @@ function convertToGeocodeJSON(req, res, next, opts) {
   // OPTIONAL. Default: null. The attribution of the data. In case of multiple sources,
   // and then multiple attributions, can be an object with one key by source.
   // Can be a URI on the server, which outlines attribution details.
-  res.body.geocoding.attribution = url.resolve(opts.config.host, opts.basePath + 'attribution');
+  res.body.geocoding.attribution = url.format({
+    protocol: req.protocol,
+    host: req.get('host'),
+    pathname: opts.basePath + 'attribution'
+  });
 
   // OPTIONAL. Default: null. The query that has been issued to trigger the
   // search.


### PR DESCRIPTION
I noticed on localhost that the attribution property is set as:
```
"attribution": "localhost:/v1/attribution"
```

This PR fixes the URL by adding the scheme & port:

```
"attribution": "http://localhost:3100/v1/attribution"
```