### PR TITLE
Remove EXPOSE command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ USER pelias
 # maintainer information
 LABEL maintainer="pelias.team@gmail.com"
 
-EXPOSE 3100
-
 # Where the app is built and run inside the docker fs
 ENV WORK=/home/pelias
 WORKDIR ${WORK}


### PR DESCRIPTION
Since we use the `PORT` env var to configure the port, this value will often be out of date. It leads to some confusing output in, for example `docker-compose ps` when using a port other than the default:

```
julian@manhattan ~/repos/pelias/dockerfiles $ docker-compose ps
           Name                         Command               State                        Ports
---------------------------------------------------------------------------------------------------------------------
pelias_api                   ./bin/start                      Up       3100/tcp, 0.0.0.0:4000->4000/tcp
```

Notice how the Ports section shows 3100, even though nothing is running on that port in the container, because the `PORT` env var was set to 4000.