### PR TITLE
Fix extremely verbose, repeated error output

### DIFF
--- a/middleware/sendJSON.js
+++ b/middleware/sendJSON.js
@@ -59,8 +59,8 @@ function sendJSONResponse(req, res, next) {
             statusCode = Math.max( statusCode, 500 );
             break; // break on first match
           }
-          logger.warn( 'unknown geocoding error string:', err );
         }
+        logger.warn( 'unknown geocoding error string:', err );
       } else {
         logger.warn( 'unknown geocoding error type:', typeof err, err );
       }


### PR DESCRIPTION
In some error cases, a warning is repeated many many times. It turns out there is code checking against elasticsearch error codes, and warning _each_ time it fails to match aganst one of them.

Many times, the error that is being compared is not from elasticsearch, and in any case, the [elasticsearch-exceptions](https://www.npmjs.com/package/elasticsearch-exceptions) module is 3 years old. We should rewrite most of this code and stop using that module.

For now, this at least reduces log noise.