### PR TITLE
Drop Node.js 4 support, add Node.js 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,13 @@ node_js:
   - 8
 matrix:
   fast_finish: true
-env:
-  global:
-    - BUILD_LEADER_ID=2
 script: npm run travis
 before_install:
-  - npm i -g npm@^3.0.0
+  - npm i -g npm
 before_script:
   - npm prune
 after_success:
-  - npm install -g npx
-  - npx -p node@8 npm run semantic-release
+  - npm run semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 4
   - 6
+  - 8
 matrix:
   fast_finish: true
 env:

--- a/controller/markdownToHtml.js
+++ b/controller/markdownToHtml.js
@@ -1,4 +1,3 @@
-
 var markdown = require('markdown').markdown;
 var fs = require('fs');
 

--- a/controller/place.js
+++ b/controller/place.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const retry = require('retry');
 

--- a/controller/search.js
+++ b/controller/search.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 
 const searchService = require('../service/search');

--- a/helper/debug.js
+++ b/helper/debug.js
@@ -1,4 +1,3 @@
-'use strict';
 const _ = require('lodash');
 
 class Debug {

--- a/helper/fieldValue.js
+++ b/helper/fieldValue.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 
 function getStringValue(property) {

--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -1,4 +1,3 @@
-
 const GeoJSON = require('geojson');
 const extent = require('@mapbox/geojson-extent');
 const logger = require('pelias-logger').get('geojsonify');

--- a/helper/geojsonify_place_details.js
+++ b/helper/geojsonify_place_details.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 const field = require('./fieldValue');
 

--- a/helper/stackTraceLine.js
+++ b/helper/stackTraceLine.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = () => {
   const stack = new Error().stack.split('\n');
   let targetLine;

--- a/middleware/404.js
+++ b/middleware/404.js
@@ -1,4 +1,3 @@
-
 // handle not found errors
 function middleware(req, res) {
   res.header('Cache-Control','public');

--- a/middleware/access_log.js
+++ b/middleware/access_log.js
@@ -2,8 +2,6 @@
  * Create a middleware that prints access logs via pelias-logger.
  */
 
-'use strict';
-
 var url = require( 'url' );
 
 var _ = require( 'lodash' );

--- a/middleware/changeLanguage.js
+++ b/middleware/changeLanguage.js
@@ -1,4 +1,3 @@
-
 var logger = require( 'pelias-logger' ).get( 'api' );
 const _ = require('lodash');
 

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  *
  * Basic confidence score should be computed and returned for each item in the results.

--- a/middleware/cors.js
+++ b/middleware/cors.js
@@ -1,4 +1,3 @@
-
 function middleware(req, res, next){
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET, OPTIONS');

--- a/middleware/jsonp.js
+++ b/middleware/jsonp.js
@@ -1,4 +1,3 @@
-
 function middleware(req, res, next){
 
   // store old json function

--- a/middleware/normalizeParentIds.js
+++ b/middleware/normalizeParentIds.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const logger = require('pelias-logger').get('api');
 const Document = require('pelias-model').Document;
 const placeTypes = require('../helper/placeTypes');

--- a/middleware/options.js
+++ b/middleware/options.js
@@ -1,4 +1,3 @@
-
 /**
   this functionality is required by CORS as the browser will send an
   HTTP OPTIONS request before performing the CORS request.

--- a/middleware/renamePlacenames.js
+++ b/middleware/renamePlacenames.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const _ = require('lodash');
 
 const PARENT_PROPS = require('../helper/placeTypes');

--- a/middleware/requestLanguage.js
+++ b/middleware/requestLanguage.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const logger = require( 'pelias-logger' ).get( 'api' );
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/pelias/api/issues"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "dependencies": {
     "addressit": "1.5.0",

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const peliasQuery = require('pelias-query');
 const defaults = require('./autocomplete_defaults');
 const textParser = require('./text_parser_addressit');

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query');
 var _ = require('lodash');
 

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const peliasQuery = require('pelias-query');
 const defaults = require('./reverse_defaults');
 const check = require('check-types');

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query');
 var _ = require('lodash');
 

--- a/query/search.js
+++ b/query/search.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');

--- a/query/search.js
+++ b/query/search.js
@@ -1,4 +1,3 @@
-
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
 const textParser = require('./text_parser');

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query');
 var _ = require('lodash');
 

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -1,4 +1,3 @@
-
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
 const textParser = require('./text_parser_addressit');

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');

--- a/query/text_parser_addressit.js
+++ b/query/text_parser_addressit.js
@@ -1,4 +1,3 @@
-
 var logger = require('pelias-logger').get('api');
 var placeTypes = require('../helper/placeTypes');
 

--- a/query/view/boost_exact_matches.js
+++ b/query/view/boost_exact_matches.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query'),
     searchDefaults = require('../search_defaults');
 

--- a/query/view/focus_selected_layers.js
+++ b/query/view/focus_selected_layers.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query');
 
 /**

--- a/query/view/ngrams_last_token_only.js
+++ b/query/view/ngrams_last_token_only.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query'),
     ngrams_strict = require('./ngrams_strict');
 

--- a/query/view/ngrams_strict.js
+++ b/query/view/ngrams_strict.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query');
 
 /**

--- a/query/view/phrase_first_tokens_only.js
+++ b/query/view/phrase_first_tokens_only.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query');
 
 /**

--- a/query/view/pop_subquery.js
+++ b/query/view/pop_subquery.js
@@ -1,4 +1,3 @@
-
 var peliasQuery = require('pelias-query'),
     check = require('check-types');
 

--- a/sanitizer/_single_scalar_parameters.js
+++ b/sanitizer/_single_scalar_parameters.js
@@ -1,4 +1,3 @@
-
 var _ = require('lodash'),
     check = require('check-types');
 

--- a/sanitizer/_tokenizer.js
+++ b/sanitizer/_tokenizer.js
@@ -1,4 +1,3 @@
-
 var check = require('check-types');
 
 /**

--- a/sanitizer/place.js
+++ b/sanitizer/place.js
@@ -1,4 +1,3 @@
-
 var sanitizeAll = require('../sanitizer/sanitizeAll'),
     sanitizers = {
       singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),

--- a/sanitizer/reverse.js
+++ b/sanitizer/reverse.js
@@ -1,4 +1,3 @@
-
 var type_mapping = require('../helper/type_mapping');
 var sanitizeAll = require('../sanitizer/sanitizeAll'),
     sanitizers = {

--- a/sanitizer/sanitizeAll.js
+++ b/sanitizer/sanitizeAll.js
@@ -1,4 +1,3 @@
-'use strict';
 function sanitize( req, sanitizers ){
   // init an object to store clean (sanitized) input parameters if not initialized
   req.clean = req.clean || {};

--- a/sanitizer/wrap.js
+++ b/sanitizer/wrap.js
@@ -1,4 +1,3 @@
-
 /**
   normalize co-ordinates that lie outside of the normal ranges.
 

--- a/schema.js
+++ b/schema.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Joi = require('joi');
 

--- a/service/configurations/Interpolation.js
+++ b/service/configurations/Interpolation.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const url = require('url');
 

--- a/service/configurations/Interpolation.js
+++ b/service/configurations/Interpolation.js
@@ -1,4 +1,3 @@
-
 const url = require('url');
 
 const _ = require('lodash');

--- a/service/configurations/Language.js
+++ b/service/configurations/Language.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const url = require('url');
 

--- a/service/configurations/Language.js
+++ b/service/configurations/Language.js
@@ -1,4 +1,3 @@
-
 const url = require('url');
 
 const _ = require('lodash');

--- a/service/configurations/Libpostal.js
+++ b/service/configurations/Libpostal.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const url = require('url');
 

--- a/service/configurations/Libpostal.js
+++ b/service/configurations/Libpostal.js
@@ -1,4 +1,3 @@
-
 const url = require('url');
 
 const ServiceConfiguration = require('pelias-microservice-wrapper').ServiceConfiguration;

--- a/service/configurations/PlaceHolder.js
+++ b/service/configurations/PlaceHolder.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const url = require('url');
 

--- a/service/configurations/PlaceHolder.js
+++ b/service/configurations/PlaceHolder.js
@@ -1,4 +1,3 @@
-
 const url = require('url');
 
 const _ = require('lodash');

--- a/service/configurations/PointInPolygon.js
+++ b/service/configurations/PointInPolygon.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const url = require('url');
 

--- a/service/configurations/PointInPolygon.js
+++ b/service/configurations/PointInPolygon.js
@@ -1,4 +1,3 @@
-
 const url = require('url');
 
 const _ = require('lodash');

--- a/service/mget.js
+++ b/service/mget.js
@@ -1,4 +1,3 @@
-
 /**
 
   query must be an array of hashes, structured like so:

--- a/service/search.js
+++ b/service/search.js
@@ -1,4 +1,3 @@
-
 /**
 
   cmd can be any valid ES query command

--- a/test/ciao_test_data.js
+++ b/test/ciao_test_data.js
@@ -1,4 +1,3 @@
-
 /**
   Test data required by the ciao test suite.
 

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1,4 +1,3 @@
-
 const proxyquire = require('proxyquire').noCallThru();
 
 module.exports.tests = {};

--- a/test/unit/app.js
+++ b/test/unit/app.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const proxyquire = require('proxyquire').noCallThru();
 

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -1,4 +1,3 @@
-
 const setup = require('../../../controller/coarse_reverse');
 const proxyquire =  require('proxyquire').noCallThru();
 const _  = require('lodash');

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const setup = require('../../../controller/coarse_reverse');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/controller/index.js
+++ b/test/unit/controller/index.js
@@ -1,4 +1,3 @@
-
 var setup = require('../../../controller/markdownToHtml');
 
 module.exports.tests = {};

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const proxyquire =  require('proxyquire').noCallThru();
 const libpostal = require('../../../controller/libpostal');

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -1,4 +1,3 @@
-
 const proxyquire =  require('proxyquire').noCallThru();
 const libpostal = require('../../../controller/libpostal');
 const _ = require('lodash');

--- a/test/unit/controller/place.js
+++ b/test/unit/controller/place.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const setup = require('../../../controller/place');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/controller/place.js
+++ b/test/unit/controller/place.js
@@ -1,4 +1,3 @@
-
 const setup = require('../../../controller/place');
 const proxyquire =  require('proxyquire').noCallThru();
 

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -1,4 +1,3 @@
-
 const placeholder = require('../../../controller/placeholder');
 const proxyquire =  require('proxyquire').noCallThru();
 const mock_logger = require('pelias-mock-logger');

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const placeholder = require('../../../controller/placeholder');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/controller/predicates/has_parsed_text_properties.js
+++ b/test/unit/controller/predicates/has_parsed_text_properties.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const has_parsed_text_properties = require('../../../../controller/predicates/has_parsed_text_properties');

--- a/test/unit/controller/predicates/has_parsed_text_properties.js
+++ b/test/unit/controller/predicates/has_parsed_text_properties.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const has_parsed_text_properties = require('../../../../controller/predicates/has_parsed_text_properties');
 

--- a/test/unit/controller/predicates/has_request_errors.js
+++ b/test/unit/controller/predicates/has_request_errors.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const has_request_errors = require('../../../../controller/predicates/has_request_errors');

--- a/test/unit/controller/predicates/has_request_errors.js
+++ b/test/unit/controller/predicates/has_request_errors.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const has_request_errors = require('../../../../controller/predicates/has_request_errors');
 

--- a/test/unit/controller/predicates/has_request_parameter.js
+++ b/test/unit/controller/predicates/has_request_parameter.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const has_request_parameter = require('../../../../controller/predicates/has_request_parameter');
 

--- a/test/unit/controller/predicates/has_request_parameter.js
+++ b/test/unit/controller/predicates/has_request_parameter.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const has_request_parameter = require('../../../../controller/predicates/has_request_parameter');

--- a/test/unit/controller/predicates/has_response_data.js
+++ b/test/unit/controller/predicates/has_response_data.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const has_response_data = require('../../../../controller/predicates/has_response_data');
 

--- a/test/unit/controller/predicates/has_response_data.js
+++ b/test/unit/controller/predicates/has_response_data.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const has_response_data = require('../../../../controller/predicates/has_response_data');

--- a/test/unit/controller/predicates/has_results_at_layers.js
+++ b/test/unit/controller/predicates/has_results_at_layers.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const has_results_at_layers = require('../../../../controller/predicates/has_results_at_layers');
 

--- a/test/unit/controller/predicates/has_results_at_layers.js
+++ b/test/unit/controller/predicates/has_results_at_layers.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const has_results_at_layers = require('../../../../controller/predicates/has_results_at_layers');

--- a/test/unit/controller/predicates/is_addressit_parse.js
+++ b/test/unit/controller/predicates/is_addressit_parse.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const is_addressit_parse = require('../../../../controller/predicates/is_addressit_parse');

--- a/test/unit/controller/predicates/is_addressit_parse.js
+++ b/test/unit/controller/predicates/is_addressit_parse.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const is_addressit_parse = require('../../../../controller/predicates/is_addressit_parse');
 

--- a/test/unit/controller/predicates/is_admin_only_analysis.js
+++ b/test/unit/controller/predicates/is_admin_only_analysis.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const is_admin_only_analysis = require('../../../../controller/predicates/is_admin_only_analysis');
 

--- a/test/unit/controller/predicates/is_admin_only_analysis.js
+++ b/test/unit/controller/predicates/is_admin_only_analysis.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const is_admin_only_analysis = require('../../../../controller/predicates/is_admin_only_analysis');

--- a/test/unit/controller/predicates/is_coarse_reverse.js
+++ b/test/unit/controller/predicates/is_coarse_reverse.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const is_coarse_reverse = require('../../../../controller/predicates/is_coarse_reverse');

--- a/test/unit/controller/predicates/is_coarse_reverse.js
+++ b/test/unit/controller/predicates/is_coarse_reverse.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const is_coarse_reverse = require('../../../../controller/predicates/is_coarse_reverse');
 

--- a/test/unit/controller/predicates/is_only_non_admin_layers.js
+++ b/test/unit/controller/predicates/is_only_non_admin_layers.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const is_only_non_admin_layers = require('../../../../controller/predicates/is_only_non_admin_layers');
 

--- a/test/unit/controller/predicates/is_only_non_admin_layers.js
+++ b/test/unit/controller/predicates/is_only_non_admin_layers.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const is_only_non_admin_layers = require('../../../../controller/predicates/is_only_non_admin_layers');

--- a/test/unit/controller/predicates/is_request_sources_only_whosonfirst.js
+++ b/test/unit/controller/predicates/is_request_sources_only_whosonfirst.js
@@ -1,4 +1,3 @@
-
 const _ = require('lodash');
 const is_request_sources_only_whosonfirst = require('../../../../controller/predicates/is_request_sources_only_whosonfirst');
 

--- a/test/unit/controller/predicates/is_request_sources_only_whosonfirst.js
+++ b/test/unit/controller/predicates/is_request_sources_only_whosonfirst.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const _ = require('lodash');
 const is_request_sources_only_whosonfirst = require('../../../../controller/predicates/is_request_sources_only_whosonfirst');

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const setup = require('../../../controller/search');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -1,4 +1,3 @@
-
 const setup = require('../../../controller/search');
 const proxyquire =  require('proxyquire').noCallThru();
 

--- a/test/unit/controller/search_with_ids.js
+++ b/test/unit/controller/search_with_ids.js
@@ -1,4 +1,3 @@
-
 const setup = require('../../../controller/search_with_ids');
 const proxyquire =  require('proxyquire').noCallThru();
 const mocklogger = require('pelias-mock-logger');

--- a/test/unit/controller/search_with_ids.js
+++ b/test/unit/controller/search_with_ids.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const setup = require('../../../controller/search_with_ids');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/controller/structured_libpostal.js
+++ b/test/unit/controller/structured_libpostal.js
@@ -1,4 +1,3 @@
-
 const proxyquire =  require('proxyquire').noCallThru();
 const libpostal = require('../../../controller/structured_libpostal');
 const _ = require('lodash');

--- a/test/unit/controller/structured_libpostal.js
+++ b/test/unit/controller/structured_libpostal.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const proxyquire =  require('proxyquire').noCallThru();
 const libpostal = require('../../../controller/structured_libpostal');

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_boundary_country_original.js
+++ b/test/unit/fixture/search_boundary_country_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_linguistic_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_bbox_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_linguistic_focus_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_linguistic_focus_null_island_original.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_linguistic_focus_original.js
+++ b/test/unit/fixture/search_linguistic_focus_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_linguistic_only_original.js
+++ b/test/unit/fixture/search_linguistic_only_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/fixture/search_partial_address_original.js
+++ b/test/unit/fixture/search_partial_address_original.js
@@ -1,4 +1,3 @@
-
 var vs = require('../../../query/search_defaults');
 
 module.exports = {

--- a/test/unit/fixture/search_regions_address_original.js
+++ b/test/unit/fixture/search_regions_address_original.js
@@ -1,4 +1,3 @@
-
 var vs = require('../../../query/search_defaults');
 
 module.exports = {

--- a/test/unit/fixture/search_with_source_filtering_original.js
+++ b/test/unit/fixture/search_with_source_filtering_original.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   'query': {
     'bool': {

--- a/test/unit/middleware/changeLanguage.js
+++ b/test/unit/middleware/changeLanguage.js
@@ -1,4 +1,3 @@
-
 const setup = require('../../../middleware/changeLanguage');
 const proxyquire =  require('proxyquire').noCallThru();
 const _  = require('lodash');

--- a/test/unit/middleware/changeLanguage.js
+++ b/test/unit/middleware/changeLanguage.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const setup = require('../../../middleware/changeLanguage');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/middleware/interpolate.js
+++ b/test/unit/middleware/interpolate.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const setup = require('../../../middleware/interpolate');
 const proxyquire =  require('proxyquire').noCallThru();

--- a/test/unit/middleware/interpolate.js
+++ b/test/unit/middleware/interpolate.js
@@ -1,4 +1,3 @@
-
 const setup = require('../../../middleware/interpolate');
 const proxyquire =  require('proxyquire').noCallThru();
 const _  = require('lodash');

--- a/test/unit/middleware/localNamingConventions.js
+++ b/test/unit/middleware/localNamingConventions.js
@@ -1,4 +1,3 @@
-
 const proxyquire = require('proxyquire');
 
 var customConfig = {

--- a/test/unit/middleware/requestLanguage.js
+++ b/test/unit/middleware/requestLanguage.js
@@ -1,4 +1,3 @@
-
 var middleware = require('../../../middleware/requestLanguage');
 module.exports.tests = {};
 

--- a/test/unit/query/MockQuery.js
+++ b/test/unit/query/MockQuery.js
@@ -1,4 +1,3 @@
-'use strict';
 
 module.exports = class MockQuery {
   constructor() {

--- a/test/unit/query/MockQuery.js
+++ b/test/unit/query/MockQuery.js
@@ -1,4 +1,3 @@
-
 module.exports = class MockQuery {
   constructor() {
     this._score_functions = [];

--- a/test/unit/query/autocomplete_defaults.js
+++ b/test/unit/query/autocomplete_defaults.js
@@ -1,4 +1,3 @@
-
 var defaults = require('../../../query/autocomplete_defaults');
 
 module.exports.tests = {};

--- a/test/unit/query/reverse_defaults.js
+++ b/test/unit/query/reverse_defaults.js
@@ -1,4 +1,3 @@
-
 var defaults = require('../../../query/reverse_defaults');
 
 module.exports.tests = {};

--- a/test/unit/query/search_defaults.js
+++ b/test/unit/query/search_defaults.js
@@ -1,4 +1,3 @@
-
 var defaults = require('../../../query/search_defaults');
 
 module.exports.tests = {};

--- a/test/unit/sanitizer/_geo_reverse.js
+++ b/test/unit/sanitizer/_geo_reverse.js
@@ -1,4 +1,3 @@
-
 const sanitizer = require('../../../sanitizer/_geo_reverse')();
 const defaults = require('../../../query/reverse_defaults');
 

--- a/test/unit/sanitizer/_geo_reverse.js
+++ b/test/unit/sanitizer/_geo_reverse.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const sanitizer = require('../../../sanitizer/_geo_reverse')();
 const defaults = require('../../../query/reverse_defaults');

--- a/test/unit/sanitizer/wrap.js
+++ b/test/unit/sanitizer/wrap.js
@@ -1,4 +1,3 @@
-
 var wrap = require('../../../sanitizer/wrap');
 
 module.exports.tests = {};

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -1,4 +1,3 @@
-'use strict';
 
 const Joi = require('joi');
 const schema = require('../../schema');

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -1,4 +1,3 @@
-
 const Joi = require('joi');
 const schema = require('../../schema');
 const _ = require('lodash');


### PR DESCRIPTION
A nice thing about this change is it speeds up our Travis tests considerably. Now that we are on Node.js 8 we get faster NPM installs (from a newer NPM version), and don't have to use NPX to install Node.js 8 just to run semantic-release. Compare:

## Before
![image](https://user-images.githubusercontent.com/111716/37925607-011879c2-3103-11e8-9241-15bca97f1173.png)

## After
![image](https://user-images.githubusercontent.com/111716/37925713-52d835cc-3103-11e8-8e60-9d8d421436ee.png)


Connects https://github.com/pelias/pelias/issues/693
Connects https://github.com/pelias/pelias/issues/612