### PR TITLE
Adding address unit as query input if parsed from user input

### DIFF
--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -116,6 +116,11 @@ function generateQuery( clean, res ){
   if( ! _.isEmpty(clean.parsed_text.number) ){
     vs.var( 'input:housenumber', clean.parsed_text.number );
   }
+  
+  if( ! _.isEmpty(clean.parsed_text.unit) ){
+    vs.var( 'input:unit', clean.parsed_text.unit );
+  }
+
   vs.var( 'input:street', clean.parsed_text.street );
 
   // find the first granularity band for which there are results


### PR DESCRIPTION
Kind of a bug, when I added ability to search by address property unit it was never used in address search using ids.

This fixs adds parsed unit property, if present, from user input to input:unit as AddressesUsingIdsQuery expects in pelias query https://github.com/pelias/query/blob/master/layout/AddressesUsingIdsQuery.js#L44