### PR TITLE
Fix link to documentation

### DIFF
--- a/public/apiDoc.md
+++ b/public/apiDoc.md
@@ -1,1 +1,1 @@
-## [View our documentation on GitHub](https://github.com/pelias/pelias-doc/blob/master/index.md)
+## [View our documentation on GitHub](https://github.com/pelias/documentation/)


### PR DESCRIPTION
I think this was broken by https://github.com/pelias/documentation/pull/219 and the rename of pelias/pelias-doc to pelias/documentation