### PR TITLE
Add Node.js 10 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ notifications:
 node_js:
   - 6
   - 8
+  - 10
 matrix:
   fast_finish: true
 script: npm run travis


### PR DESCRIPTION
Node.js 10 is out! It should work well, so lets start by adding it to our TravisCI runs.

Connects https://github.com/pelias/pelias/issues/723