### PR TITLE
Adding support for unit field in structured search.

### DIFF
--- a/test/unit/controller/structured_libpostal.js
+++ b/test/unit/controller/structured_libpostal.js
@@ -291,6 +291,55 @@ module.exports.tests.success_conditions = (test, common) => {
 
   });
 
+  test('service returning house_number and unit should set req.clean.parsed_text.unit', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          label: 'road',
+          value: 'the street'
+        },
+        {
+          label: 'house_number',
+          value: '22'
+        },
+        {
+          label: 'unit',
+          value: '1 th'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        parsed_text: {
+          address: 'the street 22 1 th'
+        }
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          parsed_text: {
+            street: 'the street',
+            number: '22',
+            unit: '1 th'
+          }
+        },
+        errors: []
+      }, 'req should have been modified');
+
+      t.end();
+
+    });
+
+  });
+
   // test('service returning valid response should convert and append', t => {
   //   const service = (req, callback) => {
   //     const response = [


### PR DESCRIPTION
If libpostal finds it in input use it for searching.
E.g. if address is set to: "Rådhusvej 20 1 th" 
libpostal will parse it to: 
```
[
    {
		"label": "road",
		"value": "Rådhusvej"
	},
	{
		"label": "house_number",
		"value": "20"
	},
	{
		"label": "unit",
		"value": "1 th"
	}
]
```
then, as for house_number, `unit` should be added to `parsed_text` and removed from `parsed_text.address` to result in:
```
"parsed_text": {
	"number": "20",
	"street": "Rådhusvej",
	"unit": "1 th"
} 
```

today the result is 
```
"parsed_text": {
	"number": "20",
	"street": "Rådhusvej  1 th"
} 
```

this PR resolves it and adds a test for it.