### PR TITLE
[DO NOT MERGE] Disable dfs_query_then_fetch

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -49,7 +49,6 @@ function setup( apiConfig, esclient, query, should_execute ){
     // elasticsearch command
     const cmd = {
       index: apiConfig.indexName,
-      searchType: 'dfs_query_then_fetch',
       body: renderedQuery.body
     };
 

--- a/test/unit/controller/search.js
+++ b/test/unit/controller/search.js
@@ -34,7 +34,6 @@ module.exports.tests.success = function(test, common) {
         t.equal(esclient, 'this is the esclient');
         t.deepEqual(cmd, {
           index: 'indexName value',
-          searchType: 'dfs_query_then_fetch',
           body: 'this is the query body'
         });
 
@@ -96,7 +95,6 @@ module.exports.tests.success = function(test, common) {
         t.equal(esclient, 'this is the esclient');
         t.deepEqual(cmd, {
           index: 'indexName value',
-          searchType: 'dfs_query_then_fetch',
           body: 'this is the query body'
         });
 
@@ -157,7 +155,6 @@ module.exports.tests.success = function(test, common) {
         t.equal(esclient, 'this is the esclient');
         t.deepEqual(cmd, {
           index: 'indexName value',
-          searchType: 'dfs_query_then_fetch',
           body: 'this is the query body'
         });
 
@@ -231,7 +228,6 @@ module.exports.tests.success = function(test, common) {
         t.equal(esclient, 'this is the esclient');
         t.deepEqual(cmd, {
           index: 'indexName value',
-          searchType: 'dfs_query_then_fetch',
           body: 'this is the query body'
         });
 
@@ -312,7 +308,6 @@ module.exports.tests.timeout = function(test, common) {
         t.equal(esclient, 'this is the esclient');
         t.deepEqual(cmd, {
           index: 'indexName value',
-          searchType: 'dfs_query_then_fetch',
           body: 'this is the query body'
         });
 


### PR DESCRIPTION
This query type dramatically slows down queries by requiring extra round-trip and computation on each Elasticsearch shard. It was enabled a [long time ago](https://github.com/pelias/api/pull/67/commits/ff9e9973fcdbd40b5b1cbec7d54be4e4d8422300) and is generally not recommended to be run on large indices.

From some cursory testing, it appears that one of our structured endpoint acceptance-tests returns different results with this setting changed, but the results are not obviously wrong. Structured queries also currently use a fairly complex query that was written before we had the [Placeholder](https://github.com/pelias/placeholder) service to make querying for records contained within a given administrative area much easier.