### PR TITLE
Run semantic-relase on the production branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "validate",
     "test",
     "check-dependencies"
-  ]
+  ],
+  "release": {
+    "branch": "production"
+  }
 }


### PR DESCRIPTION
This change will make semantic-release run only on the `production`
branch. This means only merges to production will create new NPM
packages, GitHub releases, git tags, and `:latest` Docker images on
Docker hub.

Connects https://github.com/pelias/pelias/issues/721