### PR TITLE
Disable semantic-release success actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "test"
   ],
   "release": {
-    "branch": "production"
+    "branch": "production",
+    "success": []
   }
 }


### PR DESCRIPTION
The default is to comment on every issue which made it into the release. Possibly convenient, definitely spammy.

See https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/plugins.md#success-plugin
and https://github.com/semantic-release/github