### PR TITLE
Fix attribution URL settings

### DIFF
--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -47,7 +47,7 @@ function convertToGeocodeJSON(req, res, next, opts) {
   // OPTIONAL. Default: null. The attribution of the data. In case of multiple sources,
   // and then multiple attributions, can be an object with one key by source.
   // Can be a URI on the server, which outlines attribution details.
-  res.body.geocoding.attribution = url.format({
+  res.body.geocoding.attribution = opts.config.attributionURL || url.format({
     protocol: req.protocol,
     host: req.get('host'),
     pathname: opts.basePath + 'attribution'

--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -50,7 +50,7 @@ function convertToGeocodeJSON(req, res, next, opts) {
   res.body.geocoding.attribution = opts.config.attributionURL || url.format({
     protocol: req.protocol,
     host: req.get('host'),
-    pathname: opts.basePath + 'attribution'
+    pathname: 'attribution'
   });
 
   // OPTIONAL. Default: null. The query that has been issued to trigger the


### PR DESCRIPTION
The attribution URL returned in each API response was autodetected in a way that was not always correct. The path for the default attribution page that's part of Pelias was also not correct.

This PR fixes both of those issues by allowing the attribution URL to be set via `pelias.json`. The default path is corrected as well.