### PR TITLE
[Fix] Always apply geometric filter for placeholder

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -267,7 +267,6 @@ function addRoutes(app, peliasConfig) {
 
   // helpers to replace vague booleans
   const geometricFiltersApply = true;
-  const geometricFiltersDontApply = false;
 
   var base = '/v1/';
 
@@ -286,7 +285,7 @@ function addRoutes(app, peliasConfig) {
       middleware.calcSize(),
       controllers.libpostal(libpostalService, libpostalShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderGeodisambiguationShouldExecute),
-      controllers.placeholder(placeholderService, geometricFiltersDontApply, placeholderIdsLookupShouldExecute),
+      controllers.placeholder(placeholderService, geometricFiltersApply, placeholderIdsLookupShouldExecute),
       controllers.search_with_ids(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
       // 3rd parameter is which query module to use, use fallback first, then
       //  use original search strategy if first query didn't return anything


### PR DESCRIPTION
Sometime we use the `boundary.country` query parameter  to search in the selected country. This does not work every time because we can receive results from other countries.

## Expected Behavior

When I use `boundary.country`, I would like to receive results that are in the chosen country.
`/v1/search?text=57,ROUTE DE POITIERS 79300 SAINT SAUVEUR&size=1&boundary.country=FR`
Should return this in first position:
```json
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [
      6.393945,
      47.769581
    ]
  },
  "properties": {
    "id": "102070103",
    "gid": "whosonfirst:county:102070103",
    "layer": "county",
    "source": "whosonfirst",
    "source_id": "102070103",
    "name": "Saint-Sauveur",
    "confidence": 0.4,
    "match_type": "fallback",
    "accuracy": "centroid",
    "country": "France",
    "country_gid": "whosonfirst:country:85633147",
    "country_a": "FRA",
    "macroregion": "Bourgogne-Franche-Comté",
    "macroregion_gid": "whosonfirst:macroregion:1108826395",
    "region": "Haute-Saône",
    "region_gid": "whosonfirst:region:85683559",
    "macrocounty": "Lure",
    "macrocounty_gid": "whosonfirst:macrocounty:404227739",
    "county": "Saint-Sauveur",
    "county_gid": "whosonfirst:county:102070103",
    "continent": "Europe",
    "continent_gid": "whosonfirst:continent:102191581",
    "label": "Saint-Sauveur, France"
  },
  "bbox": [
    6.27062117136,
    47.7093925992,
    6.52850809236,
    47.867186846
  ]
}
```

## Current Behavior

Returns results from Canada.
```json
{
  "type": "Feature",
  "geometry": {
    "type": "Point",
    "coordinates": [
      -74.189771,
      45.873928
    ]
  },
  "properties": {
    "id": "101737237",
    "gid": "whosonfirst:locality:101737237",
    "layer": "locality",
    "source": "whosonfirst",
    "source_id": "101737237",
    "name": "Saint-Sauveur",
    "confidence": 0.6,
    "match_type": "fallback",
    "accuracy": "centroid",
    "country": "Canada",
    "country_gid": "whosonfirst:country:85633041",
    "country_a": "CAN",
    "region": "Québec",
    "region_gid": "whosonfirst:region:136251273",
    "region_a": "QC",
    "locality": "Saint-Sauveur",
    "locality_gid": "whosonfirst:locality:101737237",
    "continent": "Amérique du Nord",
    "continent_gid": "whosonfirst:continent:102191575",
    "label": "Saint-Sauveur, QC, Canada"
  },
  "bbox": [
    -74.263311557,
    45.834846642,
    -74.133753532,
    45.921554775
  ]
}
```


## Possible Implementation

This PR is a small possible solution.
- Why the geometry filter is not enabled for street searches? 
  - Should we definitely remove `do_geometric_filters_apply` option from [`placeholder controller`](https://github.com/pelias/api/blob/6bff132e695130a3c6998ca8a501575e1d23ae97/controller/placeholder.js#L224) ?
  - Should we add a new [postProc](https://github.com/pelias/api/blob/6bff132e695130a3c6998ca8a501575e1d23ae97/routes/v1.js#L297) for result filter ?

Placeholder was introduced in #912

## Steps to Reproduce

Here is the [live example](https://api.jawg.io/places/v1/search?text=57,ROUTE%20DE%20POITIERS%2079300%20SAINT%20SAUVEUR&size=1&boundary.country=FR&access-token=2Bq0fbAh82d5XPHMP8M9eevAM9gcMb5hhIReD5m7h35iLzfp204I0Gi6C6fvGZJJ)
