### PR TITLE
Add executable for pelias api NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/pelias/api",
   "license": "MIT",
   "main": "index.js",
-  "bin": {"pelias": "./bin/start"},
+  "bin": "./bin/start",
   "scripts": {
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nsp check; rm npm-shrinkwrap.json;",
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/pelias/api",
   "license": "MIT",
   "main": "index.js",
+  "bin": {"pelias": "./bin/start"},
   "scripts": {
     "audit": "npm shrinkwrap; node node_modules/nsp/bin/nsp check; rm npm-shrinkwrap.json;",
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",


### PR DESCRIPTION
I decided to take a look at https://github.com/pelias/api/issues/609 which has some ideas for creating a binary entry point for the Pelias API package.

That ticket suggests some ideas for reorganizing the package to support this, but based on my research it may be even simpler than that.

Based on my local testing it seems that the existing `bin/start` command in this project works fine as an executable entry point. I'm curious if anyone knows of other reasons why the approach @sheerun described is more desirable. It's possible that particular file structure is more idiomatic in Node projects or something.

It seems that the other common approach is to include a `.js` script which includes the node script shebang, and is marked executable, and use that to kick off your program.

But whether we go with a more thorough re-structuring of some of the files, or something simple like just adding this command, it seems like this should be pretty easy to do.

### Testing

My approach for testing this was to install the npm package globally (sudo may not be necessary if you're using NVM or some such):

```
sudo npm install -g .
```

After doing that you should be able to see the package installed via your global node_modules directory:

```
$ which pelias
/usr/local/bin/pelias
$ ls -la /usr/local/bin/pelias
lrwxrwxrwx 1 root root 40 Aug  1 20:34 /usr/local/bin/pelias -> ../lib/node_modules/pelias-api/bin/start
```

And be able to start the server by just running:

```
$  pelias
2018-08-02T03:41:08.892Z - warn: [pip] pip service disabled
2018-08-02T03:41:08.894Z - warn: [placeholder] placeholder service disabled
2018-08-02T03:41:08.895Z - warn: [language] language service disabled
2018-08-02T03:41:08.895Z - warn: [interpolation] interpolation service disabled
2018-08-02T03:41:08.895Z - warn: [libpostal] libpostal service disabled
2018-08-02T03:41:08.895Z - warn: [libpostal] libpostal service disabled
pelias is now running on :::3100
```

### Naming

It's also very easy to change the name of the command that gets installed, so if desired we could make it `pelias-api` or `pelias-server` or something like that. This might be useful if there are any existing `pelias` commands that this would otherwise conflict with. [More info here](https://docs.npmjs.com/files/package.json#bin)

Fixes #609 