### PR TITLE
Move lots of logging from info to debug

### DIFF
--- a/controller/placeholder.js
+++ b/controller/placeholder.js
@@ -265,7 +265,7 @@ function setup(placeholderService, do_geometric_filters_apply, should_execute) {
           `[result_count:${_.defaultTo(res.data, []).length}]`
         ];
 
-        logger.info(messageParts.join(' '));
+        logger.debug(messageParts.join(' '));
         debugLog.push(req, messageParts[1].slice(1,-1));
         debugLog.push(req, res.data);
       }

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -36,7 +36,7 @@ function dedupeResults(req, res, next) {
       // since the order in which Elasticsearch returns identical text matches is arbitrary
       // of course, if the new one is preferred we should replace previous with new
       else if (isPreferred(uniqueResults[dupeIndex], hit)) {
-        logger.info('[dupe][replacing]', {
+        logger.debug('[dupe][replacing]', {
           query: req.clean.text,
           previous: uniqueResults[dupeIndex].source,
           hit: field.getStringValue(hit.name.default) + ' ' + hit.source + ':' + hit._id
@@ -46,7 +46,7 @@ function dedupeResults(req, res, next) {
       }
       // if not preferred over existing, just log and move on
       else {
-        logger.info('[dupe][skipping]', {
+        logger.debug('[dupe][skipping]', {
           query: req.clean.text,
           previous: uniqueResults[dupeIndex].source,
           hit: field.getStringValue(hit.name.default) + ' ' + hit.source + ':' + hit._id

--- a/middleware/requestLanguage.js
+++ b/middleware/requestLanguage.js
@@ -101,8 +101,7 @@ module.exports = function middleware( req, res, next ){
     defaulted: req.language.defaulted
   };
 
-  // logging
-  logger.info( '[lang] \'%s\' via \'%s\'', lang.iso6391, via );
+  logger.debug( '[lang] \'%s\' via \'%s\'', lang.iso6391, via );
 
   next();
 };

--- a/query/search.js
+++ b/query/search.js
@@ -120,10 +120,10 @@ function generateQuery( clean ){
   //console.log(JSON.stringify(q, null, 2));
 
   if (q !== undefined) {
-    logger.info(logStr);
+    logger.debug(logStr);
   }
   else {
-    logger.info('[parser:libpostal] query type not supported');
+    logger.debug('[parser:libpostal] query type not supported');
   }
 
   return q;

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -291,7 +291,7 @@ module.exports.tests.success = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:2]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:2]'));
       t.end();
     });
 
@@ -355,7 +355,7 @@ module.exports.tests.success = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:1]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:1]'));
       t.end();
     });
 
@@ -415,7 +415,7 @@ module.exports.tests.success = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:1]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:1]'));
       t.end();
     });
 
@@ -473,7 +473,7 @@ module.exports.tests.success = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:1]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:1]'));
       t.end();
     });
 
@@ -538,7 +538,7 @@ module.exports.tests.success = (test, common) => {
         };
 
         t.deepEquals(res, expected_res);
-        t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:1]'));
+        t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:1]'));
       });
 
     });
@@ -607,7 +607,7 @@ module.exports.tests.success = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:1]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:1]'));
       t.end();
     });
 
@@ -1403,7 +1403,7 @@ module.exports.tests.result_filtering = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:3]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:3]'));
       t.end();
     });
 
@@ -1538,7 +1538,7 @@ module.exports.tests.result_filtering = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:3]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:3]'));
       t.end();
     });
 
@@ -1680,7 +1680,7 @@ module.exports.tests.result_filtering = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:2]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:2]'));
       t.end();
     });
 
@@ -1852,7 +1852,7 @@ module.exports.tests.result_filtering = (test, common) => {
       };
 
       t.deepEquals(res, expected_res);
-      t.ok(logger.isInfoMessage('[controller:placeholder] [result_count:3]'));
+      t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:3]'));
       t.end();
     });
 
@@ -2356,7 +2356,7 @@ module.exports.tests.error_conditions = (test, common) => {
     controller(req, res, () => {
       t.deepEquals(res, {}, 'res should not have been modified');
       t.deepEquals(req.errors, ['placeholder service error']);
-      t.notOk(logger.isInfoMessage(/\\[controller:placeholder\\] \\[result_count:\\d+\\]/));
+      t.notOk(logger.isDebugMessage(/\\[controller:placeholder\\] \\[result_count:\\d+\\]/));
       t.end();
     });
 
@@ -2385,7 +2385,7 @@ module.exports.tests.error_conditions = (test, common) => {
     controller(req, res, () => {
       t.deepEquals(res, {}, 'res should not have been modified');
       t.deepEquals(req.errors, ['placeholder service error']);
-      t.notOk(logger.isInfoMessage(/\\[controller:placeholder\\] \\[result_count:\\d+\\]/));
+      t.notOk(logger.isDebugMessage(/\\[controller:placeholder\\] \\[result_count:\\d+\\]/));
       t.end();
     });
 
@@ -2410,7 +2410,7 @@ module.exports.tests.error_conditions = (test, common) => {
     controller(req, res, () => {
       t.deepEquals(res, {}, 'res should not have been modified');
       t.deepEquals(req.errors, [{ error_key: 'error_value' }]);
-      t.notOk(logger.isInfoMessage(/\\[controller:placeholder\\] \\[result_count:\\d+\\]/));
+      t.notOk(logger.isDebugMessage(/\\[controller:placeholder\\] \\[result_count:\\d+\\]/));
       t.end();
     });
 


### PR DESCRIPTION
These are log lines that are not really useful in a production context, and just create a lot of noise.