### PR TITLE
feat(docker): Run API processes using pelias user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # base image
 FROM pelias/baseimage
-RUN useradd -ms /bin/bash pelias
 USER pelias
-
-# maintainer information
-LABEL maintainer="pelias.team@gmail.com"
 
 # Where the app is built and run inside the docker fs
 ENV WORK=/home/pelias


### PR DESCRIPTION
This is enabled by the work in https://github.com/pelias/baseimage/pull/2 and lets us ensure the API is run as a non-root user.

Additionally, the maintainer label is now set in the baseimage as of (https://github.com/pelias/baseimage/pull/8), so it can be removed here.