### PR TITLE
Remove old packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
     "source-map": "^0.7.0",
     "tap-dot": "^2.0.0",
     "tape": "^4.5.1",
-    "tmp": "^0.0.33",
-    "uglify-js": "^3.0.4"
+    "tmp": "^0.0.33"
   },
   "pre-commit": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "main": "index.js",
   "bin": "./bin/start",
   "scripts": {
-    "audit": "npm shrinkwrap; node node_modules/nsp/bin/nsp check; rm npm-shrinkwrap.json;",
     "ciao": "node node_modules/ciao/bin/ciao -c test/ciao.json test/ciao",
     "coverage": "node_modules/.bin/istanbul cover test/unit/run.js",
     "docs": "./bin/generate-docs",
@@ -71,7 +70,6 @@
     "difflet": "^1.0.1",
     "istanbul": "^0.4.2",
     "jshint": "^2.5.6",
-    "nsp": "^3.0.0",
     "pelias-mock-logger": "^1.3.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",


### PR DESCRIPTION
Two NPM packages in this repo are no longer needed:
- nsp, because it is shutting down and superceeded by `npm audit`
- uglify-js, because it was only used to mitigate issues related to https://github.com/pelias/api/issues/1179 which we have likely solved through other means.