### PR TITLE
chore(tests): Update test running script with latest info

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
 set -euo pipefail
 
-node test/unit/run.js | ./node_modules/.bin/tap-dot
+node test/unit/run.js | npx tap-dot


### PR DESCRIPTION
Use npx instead of calling binaries in node_modules, and link to relevant issue.

Connects https://github.com/pelias/pelias/issues/744