### PR TITLE
apply parser bugfix for incorrect parsing of diagonal directionals

### DIFF
--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -70,6 +70,7 @@ function setup(libpostalService, should_execute) {
     const initialTime = debugLog.beginTimer(req);
 
     libpostalService(req, (err, response) => {
+
       if (err) {
         // push err.message or err onto req.errors
         req.errors.push( _.get(err, 'message', err) );
@@ -82,6 +83,10 @@ function setup(libpostalService, should_execute) {
         return next();
 
       } else {
+
+        // apply fixes for known bugs in libpostal
+        response = patchBuggyResponses(response);
+
         req.clean.parser = 'libpostal';
         req.clean.parsed_text = response.reduce(function(o, f) {
           if (field_mapping.hasOwnProperty(f.label)) {
@@ -107,6 +112,31 @@ function setup(libpostalService, should_execute) {
   }
 
   return controller;
+}
+
+const DIAGONAL_DIRECTIONALS = ['ne','nw','se','sw'];
+
+// apply fixes for known bugs in libpostal
+function patchBuggyResponses(response){
+  if( !Array.isArray(response) || !response.length ){ return response; }
+
+  // known bug where the street name is only a directional, in this case we will merge it
+  // with the subsequent element.
+  // note: the bug only affects diagonals, not N,S,E,W
+  // https://github.com/OpenTransitTools/trimet-mod-pelias/issues/20#issuecomment-417732128
+  for( var i=0; i<response.length-1; i++ ){ // dont bother checking the last element
+    if( 'road' !== response[i].label ){ continue; }
+    if( 'string' !== typeof response[i].value ){ continue; }
+    if( 2 !== response[i].value.length ){ continue; }
+    if( DIAGONAL_DIRECTIONALS.includes( response[i].value.toLowerCase() ) ){
+       if( 'string' !== typeof response[i+1].value ){ continue; }
+      response[i].value += ' ' + response[i+1].value; // merge elements
+      response.splice(i+1, 1); // remove merged element
+      break;
+    }
+  }
+
+  return response;
 }
 
 module.exports = setup;

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -303,6 +303,62 @@ module.exports.tests.success_conditions = (test, common) => {
 
 };
 
+module.exports.tests.bug_fixes = (test, common) => {
+  test('bug fix: incorrect parsing of diagonal directionals', t => {
+    const service = (req, callback) => {
+      const response =[
+        {
+          'label': 'house_number',
+          'value': '4004'
+        },
+        {
+          'label': 'road',
+          'value': 'nw'
+        },
+        {
+          'label': 'suburb',
+          'value': 'beaverton-hillsdale'
+        },
+        {
+          'label': 'city',
+          'value': 'portland'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        text: 'original query'
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          text: 'original query',
+          parser: 'libpostal',
+          parsed_text: {
+            number: '4004',
+            street: 'nw beaverton-hillsdale',
+            city: 'portland'
+          }
+        },
+        errors: []
+      }, 'req should not have been modified');
+
+      t.end();
+
+    });
+
+  });
+
+};
+
 module.exports.all = (tape, common) => {
 
   function test(name, testFunction) {


### PR DESCRIPTION
This PR adds a new function which can be used to modify responses from `libpostal` that we know are buggy.

The bugfix I included in this PR is to fix an error where `libpostal` incorrectly thinks the directional prefix is the entire street name, such as:

```
4004 SW Beaverton-Hillsdale, Portland

      "parsed_text": {
        "number": "4004",
        "street": "sw",
        "neighbourhood": "beaverton-hillsdale",
        "city": "portland"
      }
```

Note: this bug only seems to effect diagonals, not N,S,E,W.

related: https://github.com/OpenTransitTools/trimet-mod-pelias/issues/20#issuecomment-417732128