### PR TITLE
feat(docs): Add examples of using service `timeout` and `retry` settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ A good starting configuration file includes this section (fill in the service an
         "url": "http://libpostal:8080"
       },
       "pip": {
-        "url": "http://pip-service:4200"
+        "url": "http://pip-service:4200",
+        "timeout": 1000,
+        "retries": 2
       },
       "interpolation": {
         "url": "http://interpolation:4300"
@@ -77,6 +79,7 @@ A good starting configuration file includes this section (fill in the service an
     "level": "debug"
   }
 }
+The `timeout` and `retry` values, as showin in the `pip` service section, are optional but configurable for all services (see [pelias/microservice-wrapper](https://github.com/pelias/microservice-wrapper) for more details).
 ```
 
 


### PR DESCRIPTION
These examples have been possible from the beginning, but not explicitly
called out in documentation.

Fixes https://github.com/pelias/wof-admin-lookup/issues/192