### PR TITLE
improved boosting for exact matches where the last token is in fact complete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -40,7 +40,8 @@ query.score( peliasQuery.view.admin('locality') );
 query.score( peliasQuery.view.admin('neighbourhood') );
 
 // scoring boost
-query.score( views.boost_exact_matches );
+query.score( views.boost_exact_matches(false) );
+query.score( views.boost_exact_matches(true) );
 query.score( peliasQuery.view.focus( views.ngrams_strict ) );
 query.score( peliasQuery.view.popularity( views.pop_subquery ) );
 query.score( peliasQuery.view.population( views.pop_subquery ) );

--- a/query/view/boost_exact_matches.js
+++ b/query/view/boost_exact_matches.js
@@ -14,26 +14,58 @@ var peliasQuery = require('pelias-query'),
   the view uses some of the values from the 'search_defaults.js' file to add an
   additional 'SHOULD' condition which scores exact matches slighly higher
   than partial matches.
+
+  the 'includePartialTokens' variable was introduced in order to allow the view
+  to be reused as an additional boost for tokens which are in fact complete,
+  despite us not knowing for sure whether they are complete or not.
+
+  an example is 'Stop 2', without partial tokens the boost will only apply to
+  documents matching 'stop', with an additional view we can further boost
+  documents matching 'stop 2'.
+
+  note: it is most likely insufficent to include a version of this view in your
+  query which has includePartialTokens=true without also having a copy with
+  includePartialTokens=false. One view will boost the tokens that are known to
+  be complete and the other will additionally boost tokens which may or may not be
+  complete, as per the example above.
+
+  note: a clause has been included in the code which disables the view for
+  includePartialTokens=true if it would generate the exact same view as for
+  includePartialTokens=false.
 **/
 
-module.exports = function( vs ){
+module.exports = function( includePartialTokens ){
+  return function( vs ){
 
-  // make a copy of the variables so we don't interfere with the values
-  // passed to other views.
-  var vsCopy = new peliasQuery.Vars( vs.export() );
+    // make a copy of the variables so we don't interfere with the values
+    // passed to other views.
+    var vsCopy = new peliasQuery.Vars( vs.export() );
 
-  // copy phrase:* values from search defaults
-  vsCopy.var('phrase:analyzer').set(searchDefaults['phrase:analyzer']);
-  vsCopy.var('phrase:field').set(searchDefaults['phrase:field']);
+    // copy phrase:* values from search defaults
+    vsCopy.var('phrase:analyzer').set(searchDefaults['phrase:analyzer']);
+    vsCopy.var('phrase:field').set(searchDefaults['phrase:field']);
 
-  // get a copy of the *complete* tokens produced from the input:name
-  var tokens = vs.var('input:name:tokens_complete').get();
+    // get a copy of only the *complete* tokens produced from the input:name
+    var tokens = vs.var('input:name:tokens_complete').get();
 
-  // no valid tokens to use, fail now, don't render this view.
-  if( !tokens || tokens.length < 1 ){ return null; }
+    if( includePartialTokens ){
+      // get a copy of *all* tokens produced from the input:name (including partial tokens)
+      var allTokens = vs.var('input:name:tokens').get();
 
-  // set 'input:name' to be only the fully completed characters
-  vsCopy.var('input:name').set( tokens.join(' ') );
+      // a duplicate view would be generated, fail now, don't render this view.
+      // see file comments for more info
+      if( allTokens.join(' ') === tokens.join(' ') ){ return null; }
 
-  return peliasQuery.view.phrase( vsCopy );
+      // use *all* the tokens for this view instead of only the complete tokens.
+      tokens = allTokens;
+    }
+
+    // no valid tokens to use, fail now, don't render this view.
+    if( !tokens || tokens.length < 1 ){ return null; }
+
+    // set 'input:name' to be only the fully completed characters
+    vsCopy.var('input:name').set( tokens.join(' ') );
+
+    return peliasQuery.view.phrase( vsCopy );
+  };
 };

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -25,6 +25,16 @@ module.exports = {
         }
       }],
       'should':[{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test',
+            'type': 'phrase'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -18,6 +18,16 @@ module.exports = {
         }
       }],
       'should':[{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'type': 'phrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -23,6 +23,16 @@ module.exports = {
           }
         }
       },{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'one t',
+            'type': 'phrase'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -18,6 +18,16 @@ module.exports = {
         }
       }],
       'should': [{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test',
+            'type': 'phrase'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match': {

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -18,6 +18,16 @@ module.exports = {
         }
       }],
       'should': [{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test',
+            'type': 'phrase'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match': {

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -41,6 +41,17 @@ module.exports = {
           }
         },
         {
+          'match': {
+            'phrase.default': {
+              'analyzer' : 'peliasPhrase',
+              'type' : 'phrase',
+              'boost' : 1,
+              'slop' : 3,
+              'query' : 'one two three'
+            }
+          }
+        },
+        {
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -18,6 +18,16 @@ module.exports = {
         }
       }],
       'should':[{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'type': 'phrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -18,6 +18,16 @@ module.exports = {
         }
       }],
       'should':[{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test',
+            'type': 'phrase'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -18,6 +18,16 @@ module.exports = {
         }
       }],
       'should':[{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasPhrase',
+            'boost': 1,
+            'slop': 3,
+            'query': 'test',
+            'type': 'phrase'
+          }
+        }
+      },{
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -206,7 +206,7 @@ module.exports.tests.query = function(test, common) {
     var expected = require('../fixture/autocomplete_linguistic_bbox_san_francisco');
 
     t.deepEqual(compiled.type, 'autocomplete', 'query type set');
-    t.deepEqual(compiled.body, expected, 'autocomplete_linguistic_focus_null_island');
+    t.deepEqual(compiled.body, expected, 'autocomplete_linguistic_bbox_san_francisco');
     t.end();
   });
 };


### PR DESCRIPTION
Today I was looking into the scoring of queries for autocomplete transit stops and managed to fix some incorrect scoring in some cases:

before:
```
/v1/autocomplete?text=stop 2

 1)	SW 2nd & Alder (TriMet Stop ID 7095), Portland, OR, USA
 2)	W Burnside & SW 2nd (TriMet Stop ID 9526), Portland, OR, USA
 3)	SW 2nd & Taylor (TriMet Stop ID 7098), Portland, OR, USA
...

/v1/autocomplete?text=2905

 1)	2905 SW 1st Ave, Portland, OR, USA
 2)	2905 SW 4th Ave, Portland, OR, USA
 3)	2905 SE 17th Ave, Portland, OR, USA
```

after:
```
/v1/autocomplete?text=stop 2

 1)	A Ave & Chandler (TriMet Stop ID 2), Lake Oswego, OR, USA
 2)	W Burnside & SW 2nd (TriMet Stop ID 9526), Portland, OR, USA
 3)	NW Everett & 2nd (TriMet Stop ID 1612), Portland, OR, USA

/v1/autocomplete?text=2905

 1)	SE Hwy 212 & 122nd (TriMet Stop ID 2905), Clackamas County, OR, USA
 2)	2905 SW 1st Ave, Portland, OR, USA
 3)	2905 SW 4th Ave, Portland, OR, USA
```

So.. explaining this one is a bit complex but I'll give it a shot!

For autocomplete we split the input text in to 'tokens', and then we mark those tokens as complete or incomplete, the gist of this is that every token except the last one is 'complete', the last one we don't know if the user has finished typing that word or not.

An example query:
```
input: "stop 2"
tokens: [ "stop", "2" ]
complete: [ "top" ]
incomplete: [ "2" ]
```

So before this PR we would already boost documents matching `stop` in the phrase index, this is important because it boosted exact matching phrases higher and didn't use the ngram index.

So this prevented "Clayton Avenue" and "Clay Ave" from scoring the same despite sharing common ngrams.

This works great when the first token is complete and the last one isn't.

This PR now covers the additonal case **where the last token is in fact also complete** (something we cannot tell from just looking at the text) 

So in the example above we will generate one more subquery which also tries to match `stop 2`, and in this case it would find an exact match, giving that document an additional boost.