### PR TITLE
Use exponential scoring and consistent scale values for `focus.point`

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -26,7 +26,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:boost': 1,
   'phrase:slop': 3,
 
-  'focus:function': 'linear',
+  'focus:function': 'exp',
   'focus:offset': '0km',
   'focus:scale': '250km',
   'focus:decay': 0.5,

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -28,7 +28,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'focus:function': 'exp',
   'focus:offset': '0km',
-  'focus:scale': '250km',
+  'focus:scale': '50km',
   'focus:decay': 0.5,
   'focus:weight': 15,
 

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -26,7 +26,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:boost': 1,
   'phrase:slop': 2,
 
-  'focus:function': 'linear',
+  'focus:function': 'exp',
   'focus:offset': '0km',
   'focus:scale': '50km',
   'focus:decay': 0.5,

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -32,7 +32,7 @@ module.exports = {
             }
           },
           'functions': [{
-            'linear': {
+            'exp': {
               'center_point': {
                 'origin': {
                   'lat': 29.49136,

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -39,7 +39,7 @@ module.exports = {
                   'lon': -82.50622
                 },
                 'offset': '0km',
-                'scale': '250km',
+                'scale': '50km',
                 'decay': 0.5
               }
             },

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -32,7 +32,7 @@ module.exports = {
             }
           },
           'functions': [{
-            'linear': {
+            'exp': {
               'center_point': {
                 'origin': {
                   'lat': 0,

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -39,7 +39,7 @@ module.exports = {
                   'lon': 0
                 },
                 'offset': '0km',
-                'scale': '250km',
+                'scale': '50km',
                 'decay': 0.5
               }
             },

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -44,7 +44,7 @@ module.exports = {
       'functions': [
         {
           'weight': 2,
-          'linear': {
+          'exp': {
             'center_point': {
               'origin': {
                 'lat': 29.49136,

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -55,7 +55,7 @@ module.exports = {
       'functions': [
         {
           'weight': 2,
-          'linear': {
+          'exp': {
             'center_point': {
               'origin': {
                 'lat': 29.49136,

--- a/test/unit/fixture/search_linguistic_focus_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox_original.js
@@ -34,7 +34,7 @@ module.exports = {
             }
           },
           'functions': [{
-            'linear': {
+            'exp': {
               'center_point': {
                 'origin': {
                   'lat': 29.49136,

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -44,7 +44,7 @@ module.exports = {
       'functions': [
         {
           'weight': 2,
-          'linear': {
+          'exp': {
             'center_point': {
               'origin': {
                 'lat': 0,

--- a/test/unit/fixture/search_linguistic_focus_null_island_original.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island_original.js
@@ -34,7 +34,7 @@ module.exports = {
             }
           },
           'functions': [{
-            'linear': {
+            'exp': {
               'center_point': {
                 'origin': {
                   'lat': 0,

--- a/test/unit/fixture/search_linguistic_focus_original.js
+++ b/test/unit/fixture/search_linguistic_focus_original.js
@@ -34,7 +34,7 @@ module.exports = {
             }
           },
           'functions': [{
-            'linear': {
+            'exp': {
               'center_point': {
                 'origin': {
                   'lat': 29.49136,

--- a/test/unit/query/search_original.js
+++ b/test/unit/query/search_original.js
@@ -35,7 +35,7 @@ module.exports.tests.query = function(test, common) {
     var expected = require('../fixture/search_linguistic_focus_bbox_original');
 
     t.deepEqual(compiled.type, 'search_original', 'query type set');
-    t.deepEqual(compiled.body, expected, 'search_linguistic_focus_bbox');
+    t.deepEqual(compiled.body, expected, 'search_linguistic_focus_bbox_original');
     t.end();
   });
 


### PR DESCRIPTION
Our `scale` values for the `center_point` query used by Elasticsearch to score our `focus.point` queries was inconsistent between search and autocomplete. (50km for search, 250km for autocomplete).

This PR changes autocomplete to 50km, to be consistent with search. It's tough to judge which is the better value, but here's my reasoning:
- a smaller `scale` means scores drop off faster. So a smaller value means that only _very_ close records would have a high enough distance score to outweigh a far away record with high importance or population.
- We have tested the search endpoint much more in general, so this 50km value might be more well tested

Additionally, this PR changes the decay function from `linear` to exponential. I don't recall why we settled on linear, as it was very long ago, but I suspect it _might_ have been an attempt to prevent very far away records from being scored at all. In that case, our understanding of Elasticsearch at the time was incorrect.

By using exponential scoring, records of any distance will receive a non-zero score for the distance query. This means we can differentiate between otherwise identically-scoring records that are very far away from the focus point. This is a huge help when searching for administrative areas like localities, as well as postal codes.

Looking at the acceptance tests, I could not find any cases where these changes cause a failure. However, some [newly added](https://github.com/pelias/acceptance-tests/pull/484) acceptance tests now _pass_.

connects https://github.com/pelias/api/issues/1206