### PR TITLE
fix(boundary.country): use boundary.country query as filter

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -21,7 +21,6 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 // mandatory matches
 query.score( views.phrase_first_tokens_only, 'must' );
 query.score( views.ngrams_last_token_only, 'must' );
-query.score( peliasQuery.view.boundary_country, 'must' );
 
 // address components
 query.score( peliasQuery.view.address('housenumber') );
@@ -49,6 +48,7 @@ query.score( peliasQuery.view.population( views.pop_subquery ) );
 query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.boundary_rect );
+query.filter( peliasQuery.view.boundary_country );
 
 // --------------------------------
 

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -10,7 +10,7 @@ const logger = require('pelias-logger').get('api');
 var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
-query.score( peliasQuery.view.boundary_country, 'must' );
+// (none)
 
 // scoring boost
 query.sort( peliasQuery.view.sort_distance );
@@ -20,6 +20,7 @@ query.filter( peliasQuery.view.boundary_circle );
 query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.categories );
+query.filter( peliasQuery.view.boundary_country );
 
 // --------------------------------
 

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -18,7 +18,6 @@ var adminFields = placeTypes.concat(['region_a']);
 var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
-query.score( peliasQuery.view.boundary_country, 'must' );
 query.score( peliasQuery.view.ngrams, 'must' );
 
 // scoring boost
@@ -46,6 +45,7 @@ query.filter( peliasQuery.view.boundary_rect );
 query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.categories );
+query.filter( peliasQuery.view.boundary_country );
 
 // --------------------------------
 

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -16,13 +16,6 @@ module.exports = {
             }
           }
         }
-      }, {
-        'match': {
-          'parent.country_a': {
-            'analyzer': 'standard',
-            'query': 'ABC'
-          }
-        }
       }],
       'should':[{
         'function_score': {
@@ -57,6 +50,14 @@ module.exports = {
             },
             'weight': 3
           }]
+        }
+      }],
+      'filter': [{
+        'match': {
+          'parent.country_a': {
+            'analyzer': 'standard',
+            'query': 'ABC'
+          }
         }
       }]
     }

--- a/test/unit/fixture/search_boundary_country_original.js
+++ b/test/unit/fixture/search_boundary_country_original.js
@@ -4,14 +4,6 @@ module.exports = {
       'must': [
         {
           'match': {
-            'parent.country_a': {
-              'analyzer': 'standard',
-              'query': 'ABC'
-            }
-          }
-        },
-        {
-          'match': {
             'name.default': {
               'query': 'test',
               'boost': 1,
@@ -87,6 +79,14 @@ module.exports = {
             'layer': [
               'test'
             ]
+          }
+        },
+        {
+          'match': {
+            'parent.country_a': {
+              'analyzer': 'standard',
+              'query': 'ABC'
+            }
           }
         }
       ]

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -56,14 +56,14 @@ module.exports.tests.query = (test, common) => {
     t.notOk(query.body.vs.isset('input:categories'));
 
     t.deepEquals(query.body.score_functions, [
-      'boundary_country view'
     ]);
 
     t.deepEquals(query.body.filter_functions, [
       'boundary_circle view',
       'sources view',
       'layers view',
-      'categories view'
+      'categories view',
+      'boundary_country view'
     ]);
 
     t.deepEquals(query.body.sort_functions, [


### PR DESCRIPTION
By definition, all boundary.country query matches will either be identical, or not a match. Thus, it does not make sense to put the query clause for boundary.country in the `must` section of the query, since there's no point in scoring based on the result of `boundary.country`.

In theory, because our queries would generally combine this `must` clause with others, there shouldn't be any performance improvement (or regression) from this change.

However, semantically, this clause fits better as a `filter`, and in the case of a bug causing a degenerate query with the `boundary.country` query clause as the only one under the `must` section, this could have a big impact.