### PR TITLE
Utilize cutoff_frequency parameter in all queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^5.5.2",
-    "pelias-query": "^9.7.0",
+    "pelias-query": "^9.9.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "retry": "^0.12.0",

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -20,11 +20,13 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:analyzer': 'peliasQueryPartialToken',
   'ngram:field': 'name.default',
   'ngram:boost': 100,
+  'ngram:cutoff_frequency': 0.01,
 
   'phrase:analyzer': 'peliasQueryFullToken',
   'phrase:field': 'name.default',
   'phrase:boost': 1,
   'phrase:slop': 3,
+  'phrase:cutoff_frequency': 0.01,
 
   'focus:function': 'exp',
   'focus:offset': '0km',
@@ -38,50 +40,62 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:housenumber:analyzer': 'peliasHousenumber',
   'address:housenumber:field': 'address_parts.number',
   'address:housenumber:boost': 2,
+  'address:housenumber:cutoff_frequency': 0.01,
 
   'address:street:analyzer': 'peliasStreet',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 5,
+  'address:street:cutoff_frequency': 0.01,
 
   'address:postcode:analyzer': 'peliasZip',
   'address:postcode:field': 'address_parts.zip',
   'address:postcode:boost': 2000,
+  'address:postcode:cutoff_frequency': 0.01,
 
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a',
   'admin:country_a:boost': 1000,
+  'admin:country_a:cutoff_frequency': 0.01,
 
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country',
   'admin:country:boost': 800,
+  'admin:country:cutoff_frequency': 0.01,
 
   'admin:region:analyzer': 'peliasAdmin',
   'admin:region:field': 'parent.region',
   'admin:region:boost': 600,
+  'admin:region:cutoff_frequency': 0.01,
 
   'admin:region_a:analyzer': 'peliasAdmin',
   'admin:region_a:field': 'parent.region_a',
   'admin:region_a:boost': 600,
+  'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:county:analyzer': 'peliasAdmin',
   'admin:county:field': 'parent.county',
   'admin:county:boost': 400,
+  'admin:county:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin',
   'admin:localadmin:boost': 200,
+  'admin:localadmin:cutoff_frequency': 0.01,
 
   'admin:locality:analyzer': 'peliasAdmin',
   'admin:locality:field': 'parent.locality',
   'admin:locality:boost': 200,
+  'admin:locality:cutoff_frequency': 0.01,
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
   'admin:neighbourhood:field': 'parent.neighbourhood',
   'admin:neighbourhood:boost': 200,
+  'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'admin:borough:analyzer': 'peliasAdmin',
   'admin:borough:field': 'parent.borough',
   'admin:borough:boost': 600,
+  'admin:borough:cutoff_frequency': 0.01,
 
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -20,11 +20,13 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:analyzer': 'peliasQueryFullToken',
   'ngram:field': 'name.default',
   'ngram:boost': 1,
+  'ngram:cutoff_frequency': 0.01,
 
   'phrase:analyzer': 'peliasPhrase',
   'phrase:field': 'phrase.default',
   'phrase:boost': 1,
   'phrase:slop': 2,
+  'phrase:cutoff_frequency': 0.01,
 
   'focus:function': 'exp',
   'focus:offset': '0km',
@@ -38,50 +40,62 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:housenumber:analyzer': 'peliasHousenumber',
   'address:housenumber:field': 'address_parts.number',
   'address:housenumber:boost': 2,
+  'address:housenumber:cutoff_frequency': 0.01,
 
   'address:street:analyzer': 'peliasStreet',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 5,
+  'address:street:cutoff_frequency': 0.01,
 
   'address:postcode:analyzer': 'peliasZip',
   'address:postcode:field': 'address_parts.zip',
   'address:postcode:boost': 20,
+  'address:postcode:cutoff_frequency': 0.01,
 
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a',
   'admin:country_a:boost': 1,
+  'admin:country_a:cutoff_frequency': 0.01,
 
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country',
   'admin:country:boost': 1,
+  'admin:country:cutoff_frequency': 0.01,
 
   'admin:region:analyzer': 'peliasAdmin',
   'admin:region:field': 'parent.region',
   'admin:region:boost': 1,
+  'admin:region:cutoff_frequency': 0.01,
 
   'admin:region_a:analyzer': 'peliasAdmin',
   'admin:region_a:field': 'parent.region_a',
   'admin:region_a:boost': 1,
+  'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:county:analyzer': 'peliasAdmin',
   'admin:county:field': 'parent.county',
   'admin:county:boost': 1,
+  'admin:county:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin',
   'admin:localadmin:boost': 1,
+  'admin:localadmin:cutoff_frequency': 0.01,
 
   'admin:locality:analyzer': 'peliasAdmin',
   'admin:locality:field': 'parent.locality',
   'admin:locality:boost': 1,
+  'admin:locality:cutoff_frequency': 0.01,
 
   'admin:borough:analyzer': 'peliasAdmin',
   'admin:borough:field': 'parent.borough',
   'admin:borough:boost': 1,
+  'admin:borough:cutoff_frequency': 0.01,
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
   'admin:neighbourhood:field': 'parent.neighbourhood',
   'admin:neighbourhood:boost': 1,
+  'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -9,6 +9,7 @@ module.exports = {
                 'analyzer': 'peliasQueryPartialToken',
                 'boost': 100,
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'operator': 'and',
                 'slop': 3

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -9,6 +9,7 @@ module.exports = {
                 'analyzer': 'peliasQueryPartialToken',
                 'boost': 100,
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'operator': 'and',
                 'slop': 3

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -8,6 +8,7 @@
             "match": {
               "name.default": {
                 "analyzer": "peliasQueryFullToken",
+                "cutoff_frequency": 0.01,
                 "type": "phrase",
                 "boost": 1,
                 "slop": 3,
@@ -21,6 +22,7 @@
             "match": {
               "phrase.default": {
                 "analyzer": "peliasPhrase",
+                "cutoff_frequency": 0.01,
                 "type": "phrase",
                 "boost": 1,
                 "slop": 3,

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -9,6 +9,7 @@ module.exports = {
                 'analyzer': 'peliasQueryPartialToken',
                 'boost': 100,
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'operator': 'and',
                 'slop': 3

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'slop': 3,
             'query': 'one',
@@ -16,6 +17,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'analyzer': 'peliasPhrase',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'slop': 3,
             'query': 'one',

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -7,6 +7,7 @@ module.exports = {
             'match': {
               'name.default': {
                 'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',
@@ -23,6 +24,7 @@ module.exports = {
             'match': {
               'name.default': {
                 'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -7,6 +7,7 @@ module.exports = {
             'match': {
               'name.default': {
                 'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',
@@ -23,6 +24,7 @@ module.exports = {
             'match': {
               'name.default': {
                 'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -8,6 +8,7 @@ module.exports = {
             'type': 'phrase',
             'boost': 1,
             'slop': 3,
+            'cutoff_frequency': 0.01,
             'query': 'one two'
           }
         }
@@ -22,6 +23,7 @@ module.exports = {
                 'query': 'three',
                 'type': 'phrase',
                 'operator': 'and',
+                'cutoff_frequency': 0.01,
                 'slop': 3
               }
             }
@@ -36,6 +38,7 @@ module.exports = {
               'type' : 'phrase',
               'boost' : 1,
               'slop' : 3,
+              'cutoff_frequency': 0.01,
               'query' : 'one two'
             }
           }

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -9,6 +9,7 @@ module.exports = {
                 'analyzer': 'peliasQueryPartialToken',
                 'boost': 100,
                 'query': 't',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'operator': 'and',
                 'slop': 3

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -11,6 +11,7 @@ module.exports = {
                 'query': 'test',
                 'type': 'phrase',
                 'operator': 'and',
+                'cutoff_frequency': 0.01,
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -9,6 +9,7 @@ module.exports = {
                 'analyzer': 'peliasQueryPartialToken',
                 'boost': 100,
                 'query': 'tes',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'operator': 'and',
                 'slop': 3

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -9,6 +9,7 @@ module.exports = {
                 'analyzer': 'peliasQueryPartialToken',
                 'boost': 100,
                 'query': 'te',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'operator': 'and',
                 'slop': 3

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -9,6 +9,7 @@ module.exports = {
               'type': 'phrase',
               'boost': 1,
               'slop': 3,
+              'cutoff_frequency': 0.01,
               'query': 'one two'
             }
           }
@@ -20,6 +21,7 @@ module.exports = {
             'parent.country': {
               'analyzer': 'peliasAdmin',
               'boost': 800,
+              'cutoff_frequency': 0.01,
               'query': 'three'
             }
           }
@@ -28,6 +30,7 @@ module.exports = {
           'match': {
             'parent.region': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 600,
               'query': 'three'
             }
@@ -37,6 +40,7 @@ module.exports = {
           'match': {
             'parent.region_a': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 600,
               'query': 'three'
             }
@@ -46,6 +50,7 @@ module.exports = {
           'match': {
             'parent.county': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 400,
               'query': 'three'
             }
@@ -55,6 +60,7 @@ module.exports = {
           'match': {
             'parent.borough': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 600,
               'query': 'three'
             }
@@ -64,6 +70,7 @@ module.exports = {
           'match': {
             'parent.localadmin': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 200,
               'query': 'three'
             }
@@ -73,6 +80,7 @@ module.exports = {
           'match': {
             'parent.locality': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 200,
               'query': 'three'
             }
@@ -82,6 +90,7 @@ module.exports = {
           'match': {
             'parent.neighbourhood': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 200,
               'query': 'three'
             }
@@ -91,6 +100,7 @@ module.exports = {
           'match': {
             'phrase.default': {
               'analyzer' : 'peliasPhrase',
+              'cutoff_frequency': 0.01,
               'type' : 'phrase',
               'boost' : 1,
               'slop' : 3,

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
+            'cutoff_frequency': 0.01,
             'type': 'phrase',
             'boost': 1,
             'slop': 3,
@@ -17,6 +18,7 @@ module.exports = {
           'match': {
             'address_parts.street': {
               'query': 'k road',
+              'cutoff_frequency': 0.01,
               'boost': 5,
               'analyzer': 'peliasStreet'
             }
@@ -25,6 +27,7 @@ module.exports = {
           'match': {
             'parent.country': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 800,
               'analyzer': 'peliasAdmin'
             }
@@ -33,6 +36,7 @@ module.exports = {
           'match': {
             'parent.region': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 600,
               'analyzer': 'peliasAdmin'
             }
@@ -41,6 +45,7 @@ module.exports = {
           'match': {
             'parent.region_a': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 600,
               'analyzer': 'peliasAdmin'
             }
@@ -49,6 +54,7 @@ module.exports = {
           'match': {
             'parent.county': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 400,
               'analyzer': 'peliasAdmin'
             }
@@ -57,6 +63,7 @@ module.exports = {
           'match': {
             'parent.borough': {
               'analyzer': 'peliasAdmin',
+              'cutoff_frequency': 0.01,
               'boost': 600,
               'query': 'laird'
             }
@@ -65,6 +72,7 @@ module.exports = {
           'match': {
             'parent.localadmin': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 200,
               'analyzer': 'peliasAdmin'
             }
@@ -73,6 +81,7 @@ module.exports = {
           'match': {
             'parent.locality': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 200,
               'analyzer': 'peliasAdmin'
             }
@@ -81,6 +90,7 @@ module.exports = {
           'match': {
             'parent.neighbourhood': {
               'query': 'laird',
+              'cutoff_frequency': 0.01,
               'boost': 200,
               'analyzer': 'peliasAdmin'
             }
@@ -93,6 +103,7 @@ module.exports = {
               'type' : 'phrase',
               'boost' : 1,
               'slop' : 3,
+              'cutoff_frequency': 0.01,
               'query' : 'k road'
             }
           }

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -7,6 +7,7 @@ module.exports = {
             'match': {
               'name.default': {
                 'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -7,6 +7,7 @@ module.exports = {
             'match': {
               'name.default': {
                 'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',

--- a/test/unit/fixture/search_boundary_country_original.js
+++ b/test/unit/fixture/search_boundary_country_original.js
@@ -6,6 +6,7 @@ module.exports = {
           'match': {
             'name.default': {
               'query': 'test',
+              'cutoff_frequency': 0.01,
               'boost': 1,
               'analyzer': 'peliasQueryFullToken'
             }
@@ -16,6 +17,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -28,6 +30,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -53,6 +56,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_boundary_gid_original.js
+++ b/test/unit/fixture/search_boundary_gid_original.js
@@ -7,7 +7,8 @@ module.exports = {
             'name.default': {
               'query': 'test',
               'boost': 1,
-              'analyzer': 'peliasQueryFullToken'
+              'analyzer': 'peliasQueryFullToken',
+              'cutoff_frequency': 0.01
             }
           }
         }
@@ -17,6 +18,7 @@ module.exports = {
           'phrase.default': {
             'query': 'test',
             'analyzer': 'peliasPhrase',
+            'cutoff_frequency': 0.01,
             'type': 'phrase',
             'boost': 1,
             'slop': 2
@@ -29,6 +31,7 @@ module.exports = {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'slop': 2,
                 'boost': 1
@@ -54,6 +57,7 @@ module.exports = {
               'phrase.default': {
                 'query': 'test',
                 'analyzer': 'peliasPhrase',
+                'cutoff_frequency': 0.01,
                 'type': 'phrase',
                 'slop': 2,
                 'boost': 1

--- a/test/unit/fixture/search_full_address_original.js
+++ b/test/unit/fixture/search_full_address_original.js
@@ -7,6 +7,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': '123 main st',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasQueryFullToken',
             'boost': 1
           }
@@ -16,6 +17,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': '123 main st',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'slop': 2,
@@ -29,6 +31,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': '123 main st',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -54,6 +57,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': '123 main st',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -77,6 +81,7 @@ module.exports = {
         'match': {
           'address_parts.number': {
             'query': '123',
+            'cutoff_frequency': 0.01,
             'boost': vs['address:housenumber:boost'],
             'analyzer': vs['address:housenumber:analyzer']
           }
@@ -85,6 +90,7 @@ module.exports = {
         'match': {
           'address_parts.street': {
             'query': 'main st',
+            'cutoff_frequency': 0.01,
             'boost': vs['address:street:boost'],
             'analyzer': vs['address:street:analyzer']
           }
@@ -93,6 +99,7 @@ module.exports = {
         'match': {
           'address_parts.zip': {
             'query': '10010',
+            'cutoff_frequency': 0.01,
             'boost': vs['address:postcode:boost'],
             'analyzer': vs['address:postcode:analyzer']
           }
@@ -101,6 +108,7 @@ module.exports = {
         'match': {
           'parent.country_a': {
             'query': 'USA',
+            'cutoff_frequency': 0.01,
             'boost': vs['admin:country_a:boost'],
             'analyzer': vs['admin:country_a:analyzer']
           }
@@ -109,6 +117,7 @@ module.exports = {
         'match': {
           'parent.region_a': {
             'query': 'NY',
+            'cutoff_frequency': 0.01,
             'boost': vs['admin:region_a:boost'],
             'analyzer': vs['admin:region_a:analyzer']
           }

--- a/test/unit/fixture/search_linguistic_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_bbox_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -26,6 +28,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -51,6 +54,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_linguistic_focus_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -29,6 +31,7 @@ module.exports = {
                 'type': 'phrase',
                 'boost': 1,
                 'slop': 2,
+                'cutoff_frequency': 0.01,
                 'query': 'test'
               }
             }
@@ -56,6 +59,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -81,6 +85,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_linguistic_focus_null_island_original.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -29,6 +31,7 @@ module.exports = {
                 'type': 'phrase',
                 'boost': 1,
                 'slop': 2,
+                'cutoff_frequency': 0.01,
                 'query': 'test'
               }
             }
@@ -56,6 +59,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -81,6 +85,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_linguistic_focus_original.js
+++ b/test/unit/fixture/search_linguistic_focus_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -29,6 +31,7 @@ module.exports = {
                 'type': 'phrase',
                 'boost': 1,
                 'slop': 2,
+                'cutoff_frequency': 0.01,
                 'query': 'test'
               }
             }
@@ -56,6 +59,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -81,6 +85,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_linguistic_only_original.js
+++ b/test/unit/fixture/search_linguistic_only_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -26,6 +28,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -51,6 +54,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_partial_address_original.js
+++ b/test/unit/fixture/search_partial_address_original.js
@@ -7,6 +7,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'soho grand',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasQueryFullToken',
             'boost': 1
           }
@@ -16,6 +17,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'soho grand',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'slop': 2,
@@ -28,6 +30,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'soho grand',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -53,6 +56,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'soho grand',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -77,6 +81,7 @@ module.exports = {
           'parent.region_a': {
             'analyzer': 'peliasAdmin',
             'boost': 1,
+            'cutoff_frequency': 0.01,
             'query': 'NY'
           }
         }

--- a/test/unit/fixture/search_regions_address_original.js
+++ b/test/unit/fixture/search_regions_address_original.js
@@ -7,6 +7,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': '1 water st',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasQueryFullToken',
             'boost': 1
           }
@@ -16,6 +17,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': '1 water st',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'slop': 2,
@@ -28,6 +30,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': '1 water st',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -53,6 +56,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': '1 water st',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -76,6 +80,7 @@ module.exports = {
         'match': {
           'address_parts.number': {
             'query': '1',
+            'cutoff_frequency': 0.01,
             'boost': vs['address:housenumber:boost'],
             'analyzer': vs['address:housenumber:analyzer']
           }
@@ -84,6 +89,7 @@ module.exports = {
         'match': {
           'address_parts.street': {
             'query': 'water st',
+            'cutoff_frequency': 0.01,
             'boost': vs['address:street:boost'],
             'analyzer': vs['address:street:analyzer']
           }
@@ -92,6 +98,7 @@ module.exports = {
         'match': {
           'parent.region_a': {
             'query': 'NY',
+            'cutoff_frequency': 0.01,
             'boost': vs['admin:region_a:boost'],
             'analyzer': vs['admin:region_a:analyzer']
           }

--- a/test/unit/fixture/search_with_category_filtering_original.js
+++ b/test/unit/fixture/search_with_category_filtering_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -26,6 +28,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -51,6 +54,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -8,6 +8,7 @@
             "name.default": {
               "query": "test",
               "boost": 1,
+              "cutoff_frequency": 0.01,
               "analyzer": "peliasQueryFullToken"
             }
           }
@@ -16,6 +17,7 @@
           "match": {
             "phrase.default": {
               "query": "test",
+              "cutoff_frequency": 0.01,
               "analyzer": "peliasPhrase",
               "type": "phrase",
               "boost": 1,
@@ -28,6 +30,7 @@
               "match": {
                 "phrase.default": {
                   "query": "test",
+                  "cutoff_frequency": 0.01,
                   "analyzer": "peliasPhrase",
                   "type": "phrase",
                   "slop": 2,
@@ -54,6 +57,7 @@
                 "phrase.default": {
                   "query": "test",
                   "analyzer": "peliasPhrase",
+                  "cutoff_frequency": 0.01,
                   "type": "phrase",
                   "slop": 2,
                   "boost": 1

--- a/test/unit/fixture/search_with_source_filtering_original.js
+++ b/test/unit/fixture/search_with_source_filtering_original.js
@@ -5,6 +5,7 @@ module.exports = {
         'match': {
           'name.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'boost': 1,
             'analyzer': 'peliasQueryFullToken'
           }
@@ -14,6 +15,7 @@ module.exports = {
         'match': {
           'phrase.default': {
             'query': 'test',
+            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
             'type': 'phrase',
             'boost': 1,
@@ -26,6 +28,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,
@@ -51,6 +54,7 @@ module.exports = {
             'match': {
               'phrase.default': {
                 'query': 'test',
+                'cutoff_frequency': 0.01,
                 'analyzer': 'peliasPhrase',
                 'type': 'phrase',
                 'slop': 2,


### PR DESCRIPTION
This PR adds use of the Elasticsearch [cutoff_frequency](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-match-query.html#query-dsl-match-query-cutoff) feature across nearly all of our query clauses.

This feature helps with performance for queries that could potentially match _lots_ of documents by only looking at documents that match uncommon terms first.

It does this in a way that has no effect on the end result, but massively reduces the number of documents that are scored.

My understanding of the meaning of the parameter is as follows: what fraction of the documents in a shard must contain this term before it is treated as a filtering term, rather than a scoring term? The value most commonly seen in documentation is 0.01, meaning any term that is in more than 1% of documents will be used as a filter. It's worth testing different values to see which one gives the best performance, but my guess is there aren't huge wins to be had from extensive tuning of this variable (I'd love to be proven wrong).

Essentially, `cutoff_frequency` performs the "pseudo-stopword" handling that I suggested in https://github.com/pelias/schema/pull/310#issuecomment-429473365, except it does it automatically, without any work on our part such as crafting extra query clauses or coming up with a list of common tokens.

In my testing of the difficult `Washington University in St Louis` query from https://github.com/pelias/schema/pull/310, these changes have the following effect:

  | master | cutoff_frequency | change
-- | -- | -- | --
Document Hits | 67603219 | 4336420 | -93.59%
Lowest Latency Seen | 294 | 82 | -72.11%
Highest Latency Seen | 420 | 136 | -67.62%

This was using a full planet build for testing with 560 million documents. Before this change, a full 12% of the documents in the index were being searched.

Additionally, running a full set of acceptance tests showed exactly zero differences using this branch compared to master.

In addition to immediate performance improvements, this PR will allow us to make changes in the future to tokenize on whitespace, hyphens, or whatever we want, without fearing that extremely common terms (like Street, avenue, etc) will cause unacceptable query performance. Thus, it's basically a pre-requisite for merging https://github.com/pelias/schema/pull/310.

Early feedback on this PR as well as https://github.com/pelias/query/pull/88 appreciated

## References

https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-match-query.html#query-dsl-match-query-cutoff
https://www.elastic.co/guide/en/elasticsearch/guide/current/common-terms.html#common-terms
http://kempe.net/blog/2015/02/25/elasticsearch-query-full-text-search.html