### PR TITLE
[on hold] add hard distance filter to short focus.point queries

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -54,6 +54,7 @@ query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.boundary_rect );
 query.filter( peliasQuery.view.boundary_country );
+query.filter( peliasQuery.view.boundary_circle );
 
 // --------------------------------
 
@@ -112,6 +113,18 @@ function generateQuery( clean ){
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
     });
+
+    // search only near the focus.point for short inputs
+    // this reduces the numer of documents hit and keeps latency low
+    const hardLimitTextLength = config.get('api.autocomplete.focusHardLimitTextLength') || 0;
+    const distanceMultplier   = config.get('api.autocomplete.focusHardLimitMultiplier') || 50;
+    if (clean.text.length < hardLimitTextLength) {
+      vs.set({
+        'boundary:circle:lat': clean['focus.point.lat'],
+        'boundary:circle:lon': clean['focus.point.lon'],
+        'boundary:circle:radius': `${50 * clean.text.length}km`
+      });
+    }
   }
 
   // boundary rect


### PR DESCRIPTION
## Background

Short autocomplete inputs are very difficult to serve in a performant and low-latency way. With shorter inputs, many more documents match for just about any input string.

In our testing, one to three character input texts generally match up to 100 million documents out of a 560 million document full planet build.

There's really no way to make scoring 100 million documents fast, so in order to achieve acceptable performance (ideally, <100ms P99 latency), it's worth looking at ways to either avoid querying Elasticsearch or reducing the scope of autocomplete queries.

Short autocomplete queries without a focus.point parameter can be cached. There are only 47,000 possible 1-3 character alphanumerical inputs. At this time, caching is outside the scope of Pelias itself but can easily be implemented with Varnish, Nginx, Fastly, Cloudfront, and lots of other tools and services.

Queries with a `focus.point` are effectively uncachable however, since the coordinate chosen will often be unique.

## Changes

This PR is a prototype of using the `focus.point` coordinate to build a hard filter limiting the search to documents only within a certain radius of the coordinate. This can reduce the number of documents searched and improve performance, while still returning results that are useful.

As it stands, the code essentially takes two values into consideration:
- the input text length below which results will be filtered (currently 4)
- the base filter distance (in kilometers) to be used, which is multiplied by the text length to get the actual filter distance.

In other words, results are currently filtered as follows:

| text length | max distance |
| ---- | ----|
| 1 | 50km |
| 2 | 100km |
| 3 | 150km |
| 4+ | unlimited |

These parameters will eventually be configurable.

Testing, thoughts, and benchmarks appreciated.