### PR TITLE
libpostal aus unit numbers

### DIFF
--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -17,7 +17,8 @@ var field_mapping = {
   state_district: 'county',
   state:          'state',
   postcode:       'postalcode',
-  country:        'country'
+  country:        'country',
+  unit:           'unit',
 };
 
 // This controller calls the hosted libpostal service and converts the response

--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -166,8 +166,8 @@ function patchBuggyResponses(response){
   if( _.isPlainObject(house_number) && !_.isPlainObject(unit) && _.isString(house_number.value) ){
     let split = _.trim(_.trim(house_number.value),'/').split('/');
     if( split.length === 2 ){
-      response[house_number._pos].value = split[1]; // second part (house number)
-      response.push({ label: 'unit', value: split[0] }); // first part (unit number)
+      response[house_number._pos].value = _.trim(split[1]); // second part (house number)
+      response.push({ label: 'unit', value: _.trim(split[0]) }); // first part (unit number)
     }
   }
 

--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -157,6 +157,19 @@ function patchBuggyResponses(response){
     }
   }
 
+  // known bug where Australian unit numbers are incorrectly included in the house_number label
+  // note: in the case where a 'unit' label already exists, do nothing.
+  // https://github.com/pelias/pelias/issues/753
+  let unit = _.get(idx, 'unit');
+  let house_number = _.get(idx, 'house_number');
+  if( _.isPlainObject(house_number) && !_.isPlainObject(unit) && _.isString(house_number.value) ){
+    let split = _.trim(_.trim(house_number.value),'/').split('/');
+    if( split.length === 2 ){
+      response[house_number._pos].value = split[1]; // second part (house number)
+      response.push({ label: 'unit', value: split[0] }); // first part (unit number)
+    }
+  }
+
   return response;
 }
 

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -456,6 +456,126 @@ module.exports.tests.bug_fixes = (test, common) => {
 
   });
 
+  test('bug fix: correctly parse australian-style unit numbers - with plus', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          'label': 'house_number',
+          'value': '2+3/32'
+        },
+        {
+          'label': 'road',
+          'value': 'dixon street'
+        },
+        {
+          'label': 'suburb',
+          'value': 'strathpine'
+        },
+        {
+          'label': 'postcode',
+          'value': '4500'
+        },
+        {
+          'label': 'state',
+          'value': 'qld'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        text: 'original query'
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          text: 'original query',
+          parser: 'libpostal',
+          parsed_text: {
+            unit: '2+3',
+            number: '32',
+            street: 'dixon street',
+            neighbourhood: 'strathpine',
+            postalcode: '4500',
+            state: 'qld'
+          }
+        },
+        errors: []
+      }, 'req should not have been modified');
+
+      t.end();
+
+    });
+
+  });
+
+  test('bug fix: correctly parse australian-style unit numbers - with unit spelled out', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          'label': 'house_number',
+          'value': 'unit 3 /30'
+        },
+        {
+          'label': 'road',
+          'value': 'dan rees street'
+        },
+        {
+          'label': 'suburb',
+          'value': 'wallsend'
+        },
+        {
+          'label': 'postcode',
+          'value': '2287'
+        },
+        {
+          'label': 'state',
+          'value': 'nsw'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        text: 'original query'
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          text: 'original query',
+          parser: 'libpostal',
+          parsed_text: {
+            unit: 'unit 3',
+            number: '30',
+            street: 'dan rees street',
+            neighbourhood: 'wallsend',
+            postalcode: '2287',
+            state: 'nsw'
+          }
+        },
+        errors: []
+      }, 'req should not have been modified');
+
+      t.end();
+
+    });
+
+  });
+
   test('bug fix: correctly parse australian-style unit numbers - no-op if "unit" already assigned', t => {
     const service = (req, callback) => {
       const response = [

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -359,7 +359,7 @@ module.exports.tests.bug_fixes = (test, common) => {
 
   test('bug fix: recast label for "zoo" from borough/city_district to house', t => {
     const service = (req, callback) => {
-      const response =[
+      const response = [
         {
           'label': 'city_district',
           'value': 'zoo'
@@ -385,6 +385,130 @@ module.exports.tests.bug_fixes = (test, common) => {
           parser: 'libpostal',
           parsed_text: {
             query: 'zoo'
+          }
+        },
+        errors: []
+      }, 'req should not have been modified');
+
+      t.end();
+
+    });
+
+  });
+
+  test('bug fix: correctly parse australian-style unit numbers', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          'label': 'house_number',
+          'value': '11/1015'
+        },
+        {
+          'label': 'road',
+          'value': 'nudgee road'
+        },
+        {
+          'label': 'suburb',
+          'value': 'banyo'
+        },
+        {
+          'label': 'postcode',
+          'value': '4014'
+        },
+        {
+          'label': 'state',
+          'value': 'qld'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        text: 'original query'
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          text: 'original query',
+          parser: 'libpostal',
+          parsed_text: {
+            // unit: '11',
+            number: '1015',
+            street: 'nudgee road',
+            neighbourhood: 'banyo',
+            postalcode: '4014',
+            state: 'qld'
+          }
+        },
+        errors: []
+      }, 'req should not have been modified');
+
+      t.end();
+
+    });
+
+  });
+
+  test('bug fix: correctly parse australian-style unit numbers - no-op if "unit" already assigned', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          'label': 'unit',
+          'value': '99'
+        },
+        {
+          'label': 'house_number',
+          'value': '11/1015'
+        },
+        {
+          'label': 'road',
+          'value': 'nudgee road'
+        },
+        {
+          'label': 'suburb',
+          'value': 'banyo'
+        },
+        {
+          'label': 'postcode',
+          'value': '4014'
+        },
+        {
+          'label': 'state',
+          'value': 'qld'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        text: 'original query'
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          text: 'original query',
+          parser: 'libpostal',
+          parsed_text: {
+            // unit: '999',
+            number: '11/1015',
+            street: 'nudgee road',
+            neighbourhood: 'banyo',
+            postalcode: '4014',
+            state: 'qld'
           }
         },
         errors: []

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -439,7 +439,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           text: 'original query',
           parser: 'libpostal',
           parsed_text: {
-            // unit: '11',
+            unit: '11',
             number: '1015',
             street: 'nudgee road',
             neighbourhood: 'banyo',
@@ -503,7 +503,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           text: 'original query',
           parser: 'libpostal',
           parsed_text: {
-            // unit: '999',
+            unit: '99',
             number: '11/1015',
             street: 'nudgee road',
             neighbourhood: 'banyo',


### PR DESCRIPTION
This PR fixes a bug in libpostal when parsing AUS unit numbers, as per https://github.com/pelias/pelias/issues/753

The PR assumes that the order of forward-slash delimited address numerals is in the order `{unit}/{house number}`. I did some checking online and consulted https://en.wikipedia.org/wiki/Address_(geography) and it seems to be a fairly safe bet.

You can do a `ctrl+f` on that wiki page and search for `slash`, the only other countries listed as possibly having a slash are `Czech Republic` and `Slovakia`.

In both of those cases, the slash represents an addressing scheme which we don't currently support, so I think that the change will be hugely positive for Australia while having no real negative impact elsewhere.

The PR is in 4 parts:

- refactor to use an index: as more 'bugfixes' are added, we need to avoid iterating the array multiple times, so this introduces an index and also refactors an existing bugfix to take advantage of it.
- parse the Aussie unit numbers
- enable field mapping for 'unit', for some reason we were not mapping 'unit' from libpostal to our schema, I can't see any reason why, so I've enabled it since we are working towards better unit number support.
- additional test cases to cover variants provided by OP

resolves: https://github.com/pelias/pelias/issues/753