### PR TITLE
Fix confidence score detection

### DIFF
--- a/controller/placeholder.js
+++ b/controller/placeholder.js
@@ -250,7 +250,7 @@ function setup(placeholderService, do_geometric_filters_apply, should_execute) {
         // boundary.country filter must happen after synthesis since multiple
         //  lineages may produce different country docs
         res.meta = {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         };
 
         res.data = results

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -29,7 +29,7 @@ function computeScores(req, res, next) {
   // do nothing if no result data set or if query is not of the original variety
   if (check.undefined(req.clean) || check.undefined(res) ||
       check.undefined(res.data) || check.undefined(res.meta) ||
-      res.meta.query_type !== 'original') {
+      res.meta.query_type !== 'search_original') {
     return next();
   }
 

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -21,8 +21,11 @@ function computeScores(req, res, next) {
   // do nothing if no result data set or if the query is not of the fallback variety
   // later add disambiguation to this list
   if (check.undefined(req.clean) || check.undefined(res) ||
-      check.undefined(res.data) || check.undefined(res.meta) ||
-      res.meta.query_type !== 'search_fallback') {
+      check.undefined(res.data) || check.undefined(res.meta)) {
+    return next();
+  }
+
+  if (['search_fallback', 'address_search_with_ids', 'structured'].includes(res.meta.queryType)) {
     return next();
   }
 

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -22,7 +22,7 @@ function computeScores(req, res, next) {
   // later add disambiguation to this list
   if (check.undefined(req.clean) || check.undefined(res) ||
       check.undefined(res.data) || check.undefined(res.meta) ||
-      res.meta.query_type !== 'fallback') {
+      res.meta.query_type !== 'search_fallback') {
     return next();
   }
 

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -212,7 +212,7 @@ module.exports.tests.success = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -330,7 +330,7 @@ module.exports.tests.success = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -393,7 +393,7 @@ module.exports.tests.success = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -453,7 +453,7 @@ module.exports.tests.success = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -518,7 +518,7 @@ module.exports.tests.success = (test, common) => {
       controller(req, res, () => {
         const expected_res = {
           meta: {
-            query_type: 'fallback'
+            query_type: 'search_fallback'
           },
           data: [
             {
@@ -583,7 +583,7 @@ module.exports.tests.success = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -756,7 +756,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -874,7 +874,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1075,7 +1075,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1191,7 +1191,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1345,7 +1345,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1480,7 +1480,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1629,7 +1629,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1779,7 +1779,7 @@ module.exports.tests.result_filtering = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1906,7 +1906,7 @@ module.exports.tests.lineage_errors = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -1980,7 +1980,7 @@ module.exports.tests.lineage_errors = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -2053,7 +2053,7 @@ module.exports.tests.lineage_errors = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -2113,7 +2113,7 @@ module.exports.tests.geometry_errors = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -2172,7 +2172,7 @@ module.exports.tests.centroid_errors = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -2232,7 +2232,7 @@ module.exports.tests.centroid_errors = (test, common) => {
     controller(req, res, () => {
       const expected_res = {
         meta: {
-          query_type: 'fallback'
+          query_type: 'search_fallback'
         },
         data: [
           {
@@ -2302,7 +2302,7 @@ module.exports.tests.boundingbox_errors = (test, common) => {
       controller(req, res, () => {
         const expected_res = {
           meta: {
-            query_type: 'fallback'
+            query_type: 'search_fallback'
           },
           data: [
             {

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -47,7 +47,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'original'
+        query_type: 'search_original'
       }
     };
 
@@ -89,7 +89,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'original'
+        query_type: 'search_original'
       }
     };
 
@@ -125,7 +125,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'original'
+        query_type: 'search_original'
       }
     };
 
@@ -134,7 +134,7 @@ module.exports.tests.confidenceScore = function(test, common) {
     t.end();
   });
 
-  test('should only work for original query_type', function(t) {
+  test('should only work for search_original query_type', function(t) {
     var req = {
       clean: {
         text: '123 Main St, City, NM',
@@ -161,7 +161,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -191,7 +191,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'original'
+        query_type: 'search_original'
       }
     };
 
@@ -223,7 +223,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'original'
+        query_type: 'search_original'
       }
     };
 

--- a/test/unit/middleware/confidenceScoreFallback.js
+++ b/test/unit/middleware/confidenceScoreFallback.js
@@ -137,6 +137,82 @@ module.exports.tests.confidenceScore = function(test, common) {
     t.end();
   });
 
+  test('placeholder style search queries should get confidence score', function(t) {
+    var req = {
+      clean: {
+        text: '123 Main St, City, NM',
+        parsed_text: {
+          number: 123,
+          street: 'Main St',
+          city: 'City',
+          state: 'NM'
+        }
+      }
+    };
+    var res = {
+      data: [{
+        _score: 10,
+        found: true,
+        value: 1,
+        layer: 'address',
+        center_point: { lat: 100.1, lon: -50.5 },
+        name: { default: 'test name1' },
+        parent: {
+          country: ['country1'],
+          region: ['region1'],
+          county: ['city1']
+        }
+      }],
+      meta: {
+        scores: [10],
+        query_type: 'address_search_with_ids'
+      }
+    };
+
+    confidenceScore(req, res, function() {});
+    t.equal(res.data[0].confidence, 1.0, 'max score was set');
+    t.equal(res.data[0].match_type, 'exact', 'exact match indicated');
+    t.end();
+  });
+
+  test('structured search queries should get confidence score', function(t) {
+    var req = {
+      clean: {
+        text: '123 Main St, City, NM',
+        parsed_text: {
+          number: 123,
+          street: 'Main St',
+          city: 'City',
+          state: 'NM'
+        }
+      }
+    };
+    var res = {
+      data: [{
+        _score: 10,
+        found: true,
+        value: 1,
+        layer: 'address',
+        center_point: { lat: 100.1, lon: -50.5 },
+        name: { default: 'test name1' },
+        parent: {
+          country: ['country1'],
+          region: ['region1'],
+          county: ['city1']
+        }
+      }],
+      meta: {
+        scores: [10],
+        query_type: 'structured'
+      }
+    };
+
+    confidenceScore(req, res, function() {});
+    t.equal(res.data[0].confidence, 1.0, 'max score was set');
+    t.equal(res.data[0].match_type, 'exact', 'exact match indicated');
+    t.end();
+  });
+
   test('no fallback street query should have max score', function(t) {
     var req = {
       clean: {

--- a/test/unit/middleware/confidenceScoreFallback.js
+++ b/test/unit/middleware/confidenceScoreFallback.js
@@ -47,7 +47,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'original'
+        query_type: 'search_fallback'
       }
     };
 
@@ -89,7 +89,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -127,7 +127,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -163,7 +163,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -197,7 +197,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -230,7 +230,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -265,7 +265,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -300,7 +300,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -336,7 +336,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -360,7 +360,7 @@ module.exports.tests.confidenceScore = function(test, common) {
         layer: 'locality'
       }],
       meta: {
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -384,7 +384,7 @@ module.exports.tests.confidenceScore = function(test, common) {
         layer: 'localadmin'
       }],
       meta: {
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -408,7 +408,7 @@ module.exports.tests.confidenceScore = function(test, common) {
         layer: 'region'
       }],
       meta: {
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -433,7 +433,7 @@ module.exports.tests.confidenceScore = function(test, common) {
         layer: 'country'
       }],
       meta: {
-        query_type: 'fallback'
+        query_type: 'search_fallback'
       }
     };
 
@@ -461,7 +461,7 @@ module.exports.tests.confidenceScore = function(test, common) {
                 layer: 'postalcode'
             }],
             meta: {
-                query_type: 'fallback'
+                query_type: 'search_fallback'
             }
         };
         confidenceScore(req, res, function() {});
@@ -485,7 +485,7 @@ module.exports.tests.confidenceScore = function(test, common) {
                 layer: 'postalcode'
             }],
             meta: {
-                query_type: 'fallback'
+                query_type: 'search_fallback'
             }
         };
         confidenceScore(req, res, function() {});


### PR DESCRIPTION
4adf4b3 renamed some queries to be quite a bit more informative, however it
wasn't obvious that these query names were used elsewhere in the code.

With those changes, no confidence score middleware was running, which
this should help fix.