### PR TITLE
add postcode to variable store if we have it

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^5.5.2",
-    "pelias-query": "^9.1.1",
+    "pelias-query": "^9.7.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "retry": "^0.12.0",

--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -112,6 +112,9 @@ function generateQuery( clean, res ){
   if( ! _.isEmpty(clean.parsed_text.number) ){
     vs.var( 'input:housenumber', clean.parsed_text.number );
   }
+  if( ! _.isEmpty(clean.parsed_text.postalcode) ){
+    vs.var( 'input:postcode', clean.parsed_text.postalcode );
+  }
   vs.var( 'input:street', clean.parsed_text.street );
 
   // find the first granularity band for which there are results

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -29,6 +29,7 @@ module.exports.tests.base_query = (test, common) => {
     const clean = {
       parsed_text: {
         number: 'housenumber value',
+        postalcode: 'postcode value',
         street: 'street value'
       }
     };
@@ -52,6 +53,7 @@ module.exports.tests.base_query = (test, common) => {
     t.equals(generatedQuery.type, 'address_search_using_ids');
 
     t.equals(generatedQuery.body.vs.var('input:housenumber').toString(), 'housenumber value');
+    t.equals(generatedQuery.body.vs.var('input:postcode').toString(), 'postcode value');
     t.equals(generatedQuery.body.vs.var('input:street').toString(), 'street value');
     t.notOk(generatedQuery.body.vs.isset('sources'));
     t.equals(generatedQuery.body.vs.var('size').toString(), 20);


### PR DESCRIPTION
This PR enabled https://github.com/pelias/query/pull/91 to function for `address_search_using_ids` queries

It's a simple change, we just add `postcode` data to the query variable store if we have it.

Note: although not strictly interdependent, it would be ideal to merge the query PR first and then merge this one after so it pulls in the update dependency.