### PR TITLE
Update CI and Node.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build and push image to Docker Hub
-          command: apk --no-cache add curl && curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | sh -
+          command: apk --no-cache add curl bash && curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | bash -

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 6
   - 8
   - 10
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-      if: branch = master
+      if: (branch = master) AND ( type = push )

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ jobs:
     - stage: release
       node_js: 10
       script: curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
-      if: branch = production
+      if: branch = master

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Full documentation for the Pelias API lives in the [pelias/documentation](https:
 
 ## Install Dependencies
 
-Note: Pelias requires Node.js v6 or newer
+The Pelias API has no dependencies beyond Node.js
+
+See [Pelias Software requirements](https://github.com/pelias/documentation/blob/master/requirements.md) for the supported and recommended versions.
 
 ```bash
 npm install

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/pelias/api/issues"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "@mapbox/geojson-extent": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test"
   ],
   "release": {
-    "branch": "production",
+    "branch": "master",
     "success": []
   }
 }


### PR DESCRIPTION
Several changes regarding CI and Node.js versions
- The Docker build script now requires `bash`
- Support for Node.js 6 has been dropped (https://github.com/pelias/pelias/issues/752)
- Semantic-release was running (doing nothing but taking up build time) on all pull requests for no reason
- Readme is updated to point to a central version requirement document rather than listing the supported Node.js version
- Releases now run off the master branch (https://github.com/pelias/pelias/issues/749)