### PR TITLE
improved deduping across languages

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -54,7 +54,7 @@ function isParentHierarchyDifferent(item1, item2){
  * Compare the name properties if they exist.
  * Returns false if the objects are the same, else true.
  */
-function isNameDifferent(item1, item2){
+function isNameDifferent(item1, item2, requestLanguage){
   let names1 = _.get(item1, 'name');
   let names2 = _.get(item2, 'name');
 
@@ -72,15 +72,17 @@ function isNameDifferent(item1, item2){
   // else both have name info
 
   // iterate over all the languages in item2, comparing them to the
-  // 'default' name of item1
+  // 'default' name of item1 and also against the language requested by the user.
   for( let lang in names2 ){
     if( !isPropertyDifferent({[lang]: names1.default}, names2, lang) ){ return false; }
+    if( requestLanguage && !isPropertyDifferent({[lang]: names1[requestLanguage]}, names2, lang) ){ return false; }
   }
 
   // iterate over all the languages in item1, comparing them to the
-  // 'default' name of item2
+  // 'default' name of item2 and also against the language requested by the user.
   for( let lang in names1 ){
     if( !isPropertyDifferent({[lang]: names2.default}, names1, lang) ){ return false; }
+    if( requestLanguage && !isPropertyDifferent({[lang]: names2[requestLanguage]}, names1, lang) ){ return false; }
   }
 
   return true;
@@ -119,11 +121,12 @@ function isAddressDifferent(item1, item2){
 
 /**
  * Compare the two records and return true if they differ and false if same.
+ * Optionally provide $requestLanguage (req.clean.lang.iso6393) to improve name deduplication.
  */
-function isDifferent(item1, item2){
+function isDifferent(item1, item2, requestLanguage){
   if( isLayerDifferent( item1, item2 ) ){ return true; }
   if( isParentHierarchyDifferent( item1, item2 ) ){ return true; }
-  if( isNameDifferent( item1, item2 ) ){ return true; }
+  if( isNameDifferent( item1, item2, requestLanguage ) ){ return true; }
   if( isAddressDifferent( item1, item2 ) ){ return true; }
   return false;
 }

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -17,7 +17,7 @@ function dedupeResults(req, res, next) {
   let unique = [ res.data[0] ];
 
   // convenience function to search unique array for an existing element which matches a hit
-  let findMatch = (hit) => unique.findIndex(elem => !isDifferent(elem, hit));
+  let findMatch = (hit) => unique.findIndex(elem => !isDifferent(elem, hit, _.get(req, 'clean.lang.iso6393') ));
 
   // iterate over res.data using an old-school for loop starting at index 1
   // we can call break at any time to end the iterator

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -150,6 +150,42 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('improved matching across languages - if default different, but user language matches default, consider this a match', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'English Name',
+        'eng': 'A Name'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'A Name'
+      }
+    };
+
+    t.false(isDifferent(item1, item2, 'eng'), 'should be the same');
+    t.end();
+  });
+
+
+  test('improved matching across languages - if default different, but user language matches (fra), consider this a match', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'Name',
+        'fra': 'French Name'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'Another Name',
+        'fra': 'French Name'
+      }
+    };
+
+    t.false(isDifferent(item1, item2, 'fra'), 'should be the same');
+    t.end();
+  });
+
   test('improved matching across languages - default names differ but match another language', function(t) {
     var item1 = {
       'name': {

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -128,6 +128,50 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('improved matching across languages - if default name is the same, consider this a match', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'Bern',
+        'eng': 'Bern',
+        'deu': 'Kanton Bern',
+        'fra': 'Berne'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'Bern',
+        'eng': 'Berne',
+        'deu': 'Bundesstadt', // note: this is wrong, see: https://github.com/whosonfirst-data/whosonfirst-data/issues/1363
+        'fra': 'Berne'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should be the same');
+    t.end();
+  });
+
+  test('improved matching across languages - default names differ but match another language', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'Berne',
+        'eng': 'Bern',
+        'deu': 'Kanton Bern',
+        'fra': 'Berne'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'Bern',
+        'eng': 'Berne',
+        'deu': 'Bundesstadt',
+        'fra': 'Berne'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should be the same');
+    t.end();
+  });
+
   test('catch diff address', function(t) {
     var item1 = {
       'address_parts': {
@@ -162,6 +206,14 @@ module.exports.tests.dedupe = function(test, common) {
         'street': 'Main Street'
       }
     };
+
+    t.false(isDifferent(item1, item2), 'should be the same');
+    t.end();
+  });
+
+  test('completely empty objects', function(t) {
+    var item1 = {};
+    var item2 = {};
 
     t.false(isDifferent(item1, item2), 'should be the same');
     t.end();

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -94,6 +94,24 @@ module.exports.tests.dedupe = function(test, common) {
       t.end();
     });
   });
+
+  test('test records with no address except one has postalcode', function(t) {
+    var req = {
+      clean: {
+        size: 20
+      }
+    };
+    var res = {
+      data: onlyPostalcodeDiffersData
+    };
+    var expected = onlyPostalcodeDiffersData[1]; // record with postcode
+
+    dedupe(req, res, function () {
+      t.equal(res.data.length, 1, 'only one result displayed');
+      t.equal(res.data[0], expected, 'record with postalcode is preferred');
+      t.end();
+    });
+  });
 };
 
 


### PR DESCRIPTION
following on from https://github.com/pelias/api/pull/1222 this PR changes two behaviours:

- improved matching across languages
- matching on aliases

## improved matching across languages

The previous code would cycle through all the names in `item1` and first do a key-check on `item2`, only if the key also existed in the second item, it would then compare values, if they differed then the two items were considered different.

The issue with that approach is something like this, which is considered different:

```javascript
var item1 = {
  'name': {
    'default': 'Bern',
    'eng': 'Bern'
  }
};
var item2 = {
  'name': {
    'default': 'Bern',
    'eng': 'Berne'
  }
};
```

The new code does it differently, instead it first cycles through all the values in `item2`, comparing them to `item1.default`, then it cycles through all the values in `item1` and compares them to `item2.default`.

So it's essentially saying "If any of the language values matched the default value of the other item, consider them as a dupe"

[edit] I added another commit which now also considers the user agent language for comparison on top of the `default`.

## matching on aliases

We were only matching on the first item in an array of values, this code uses slightly more CPU but it considers all aliases in deduplication.