### PR TITLE
only check parent fields above the layer of the least granular match

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -39,11 +39,26 @@ function isParentHierarchyDifferent(item1, item2){
   if( !isPojo1 || !isPojo2 ){ return false; }
 
   // else both have parent info
-  // iterate over all the placetypes, comparing between items
-  return placeTypes.some( placeType => {
 
-    // skip the parent field corresponding to the item placetype
-    if( placeType === item1.layer ){ return false; }
+  // iterate over all the placetypes, comparing between items
+
+  // we only want to check parent items representing places less granular
+  // than the highest matched layer.
+  // eg. if we are comparing layer=address & layer=country then we only
+  // check for differences in layers above country, so continent, planet etc.
+  let highestLayerIndex = Math.min(
+    placeTypes.findIndex(el => el === item1.layer),
+    placeTypes.findIndex(el => el === item2.layer)
+  );
+
+  // in the case where we couldn't find either later in the $placeTypes array
+  // we will enforce that all parent fields are checked.
+  if( highestLayerIndex === -1 ){ highestLayerIndex = Infinity; }
+
+  return placeTypes.some((placeType, pos) => {
+
+    // skip layers that are less granular than the highest matched layer
+    if( pos > highestLayerIndex ){ return false; }
 
     // ensure the parent ids are the same for all placetypes
     return isPropertyDifferent( item1.parent, item2.parent, placeType + '_id' );

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -3,6 +3,21 @@ const placeTypes = require('./placeTypes');
 const canonicalLayers = require('../helper/type_mapping').getCanonicalLayers();
 const field = require('../helper/fieldValue');
 
+// only consider these layers as synonymous for deduplication purposes.
+// when performing inter-layer deduping, layers coming earlier in this list take
+// preference to those appearing later.
+const layerPreferences = [
+  'locality',
+  'country',
+  'localadmin',
+  'county',
+  'region',
+  'neighbourhood',
+  'macrocounty',
+  'macroregion',
+  'empire'
+];
+
 /**
  * Compare the layer properties if they exist.
  * Returns false if the objects are the same, else true.
@@ -57,8 +72,8 @@ function isParentHierarchyDifferent(item1, item2){
 
   return placeTypes.some((placeType, pos) => {
 
-    // skip layers that are less granular than the highest matched layer
-    if( pos > highestLayerIndex ){ return false; }
+    // skip layers that are less granular than, or equal to the highest matched layer
+    if( pos >= highestLayerIndex ){ return false; }
 
     // ensure the parent ids are the same for all placetypes
     return isPropertyDifferent( item1.parent, item2.parent, placeType + '_id' );
@@ -164,3 +179,4 @@ function normalizeString(str){
 }
 
 module.exports.isDifferent = isDifferent;
+module.exports.layerPreferences = layerPreferences;

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -1,6 +1,7 @@
 const logger = require('pelias-logger').get('api');
 const _ = require('lodash');
 const isDifferent = require('../helper/diffPlaces').isDifferent;
+const layerPreferences = require('../helper/diffPlaces').layerPreferences;
 const canonical_sources = require('../helper/type_mapping').canonical_sources;
 const field = require('../helper/fieldValue');
 

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -60,6 +60,82 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('isParentHierarchyDifferent: do not compare parentage at lower levels to the highest item placetypes', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '12345',
+        'locality_id': '54321'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '56789',
+        'locality_id': '98765'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do compare parentage at the same level as the item placetypes', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '12345'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '54321'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do compare parentage at higher levels than the highest item placetypes', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '12345',
+        'ocean_id': '54321'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '56789',
+        'ocean_id': '98765'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: consider parentage at same level as placetype for comparison', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '12345'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '54321'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
   test('catch diff name', function(t) {
     var item1 = {
       'name': {

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -80,7 +80,7 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
-  test('isParentHierarchyDifferent: do compare parentage at the same level as the item placetypes', function(t) {
+  test('isParentHierarchyDifferent: do not compare parentage at the same level as the item placetypes', function(t) {
     var item1 = {
       'layer': 'country',
       'parent': {
@@ -94,7 +94,7 @@ module.exports.tests.dedupe = function(test, common) {
       }
     };
 
-    t.true(isDifferent(item1, item2), 'should be different');
+    t.false(isDifferent(item1, item2), 'should be different');
     t.end();
   });
 
@@ -111,24 +111,6 @@ module.exports.tests.dedupe = function(test, common) {
       'parent': {
         'localadmin_id': '56789',
         'ocean_id': '98765'
-      }
-    };
-
-    t.true(isDifferent(item1, item2), 'should be different');
-    t.end();
-  });
-
-  test('isParentHierarchyDifferent: consider parentage at same level as placetype for comparison', function(t) {
-    var item1 = {
-      'layer': 'country',
-      'parent': {
-        'country_id': '12345'
-      }
-    };
-    var item2 = {
-      'layer': 'country',
-      'parent': {
-        'country_id': '54321'
       }
     };
 

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -327,6 +327,37 @@ module.exports.tests.priority = function(test, common) {
     t.equal(res.data.length, 1, 'results have fewer items than before');
     t.end();
   });
+
+  test('continent and locality not considered synonymous, do not replace', function (t) {
+    var req = {
+      clean: {
+        text: 'Asia',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Asia' },
+          'source': 'whosonfirst',
+          'source_id': '123456',
+          'layer': 'continent'
+        },
+        {
+          'name': { 'default': 'Asia' },
+          'source': 'whosonfirst',
+          'source_id': '654321',
+          'layer': 'locality'
+        }
+      ]
+    };
+
+    var expectedCount = 2;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'no deduplication applied');
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This PR sets us up to be able to do better inter-layer deduping.

Prior to this PR we would iterate over all `parent` properties in `item1` and ensure that `item2` had identical ID values.

~~There was an exception to skip checking the parent property at the same level as the item placetype, I'm not sure why this rule existed, @orangejulius any ideas?~~

The new code only checks parent properties at ~~the same level as~~ less granular than the highest granularity item.

This will mean that if we have two different placetypes for comparison:

```
placetype = locality

locality: 'A'
localadmin: 'B'
country: 'C'
planet: 'D'
```

```
placetype = country

country: 'C'
planet: 'D'
```

the old code would expect the second document to have `localadmin` values set, so it would fail, the new code will only check `country` and `planet`

~~note: this code does not assume any placetypes are synonymous, that will need to be handled in another PR.~~

[edit] added another commit, crossed out errors