### PR TITLE
Inter-layer deduping

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -39,11 +39,26 @@ function isParentHierarchyDifferent(item1, item2){
   if( !isPojo1 || !isPojo2 ){ return false; }
 
   // else both have parent info
-  // iterate over all the placetypes, comparing between items
-  return placeTypes.some( placeType => {
 
-    // skip the parent field corresponding to the item placetype
-    if( placeType === item1.layer ){ return false; }
+  // iterate over all the placetypes, comparing between items
+
+  // we only want to check parent items representing places less granular
+  // than the highest matched layer.
+  // eg. if we are comparing layer=address & layer=country then we only
+  // check for differences in layers above country, so continent, planet etc.
+  let highestLayerIndex = Math.min(
+    placeTypes.findIndex(el => el === item1.layer),
+    placeTypes.findIndex(el => el === item2.layer)
+  );
+
+  // in the case where we couldn't find either later in the $placeTypes array
+  // we will enforce that all parent fields are checked.
+  if( highestLayerIndex === -1 ){ highestLayerIndex = Infinity; }
+
+  return placeTypes.some((placeType, pos) => {
+
+    // skip layers that are less granular than the highest matched layer
+    if( pos > highestLayerIndex ){ return false; }
 
     // ensure the parent ids are the same for all placetypes
     return isPropertyDifferent( item1.parent, item2.parent, placeType + '_id' );

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -14,6 +14,10 @@ function isLayerDifferent(item1, item2){
         ( item2.layer === 'venue' || !_.includes( canonicalLayers, item2.layer ) ) ){
       return false;
     }
+    // consider some layers to be synonymous
+    if( _.includes( placeTypes, item1.layer ) && _.includes( placeTypes, item2.layer ) ){
+      return false;
+    }
     return true;
   }
   return false;

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -54,7 +54,7 @@ function isParentHierarchyDifferent(item1, item2){
  * Compare the name properties if they exist.
  * Returns false if the objects are the same, else true.
  */
-function isNameDifferent(item1, item2){
+function isNameDifferent(item1, item2, requestLanguage){
   let names1 = _.get(item1, 'name');
   let names2 = _.get(item2, 'name');
 
@@ -72,15 +72,17 @@ function isNameDifferent(item1, item2){
   // else both have name info
 
   // iterate over all the languages in item2, comparing them to the
-  // 'default' name of item1
+  // 'default' name of item1 and also against the language requested by the user.
   for( let lang in names2 ){
     if( !isPropertyDifferent({[lang]: names1.default}, names2, lang) ){ return false; }
+    if( requestLanguage && !isPropertyDifferent({[lang]: names1[requestLanguage]}, names2, lang) ){ return false; }
   }
 
   // iterate over all the languages in item1, comparing them to the
-  // 'default' name of item2
+  // 'default' name of item2 and also against the language requested by the user.
   for( let lang in names1 ){
     if( !isPropertyDifferent({[lang]: names2.default}, names1, lang) ){ return false; }
+    if( requestLanguage && !isPropertyDifferent({[lang]: names2[requestLanguage]}, names1, lang) ){ return false; }
   }
 
   return true;
@@ -119,11 +121,12 @@ function isAddressDifferent(item1, item2){
 
 /**
  * Compare the two records and return true if they differ and false if same.
+ * Optionally provide $requestLanguage (req.clean.lang.iso6393) to improve name deduplication.
  */
-function isDifferent(item1, item2){
+function isDifferent(item1, item2, requestLanguage){
   if( isLayerDifferent( item1, item2 ) ){ return true; }
   if( isParentHierarchyDifferent( item1, item2 ) ){ return true; }
-  if( isNameDifferent( item1, item2 ) ){ return true; }
+  if( isNameDifferent( item1, item2, requestLanguage ) ){ return true; }
   if( isAddressDifferent( item1, item2 ) ){ return true; }
   return false;
 }

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -3,6 +3,21 @@ const placeTypes = require('./placeTypes');
 const canonicalLayers = require('../helper/type_mapping').getCanonicalLayers();
 const field = require('../helper/fieldValue');
 
+// only consider these layers as synonymous for deduplication purposes.
+// when performing inter-layer deduping, layers coming earlier in this list take
+// preference to those appearing later.
+const layerPreferences = [
+  'locality',
+  'country',
+  'localadmin',
+  'county',
+  'region',
+  'neighbourhood',
+  'macrocounty',
+  'macroregion',
+  'empire'
+];
+
 /**
  * Compare the layer properties if they exist.
  * Returns false if the objects are the same, else true.
@@ -15,7 +30,7 @@ function isLayerDifferent(item1, item2){
       return false;
     }
     // consider some layers to be synonymous
-    if( _.includes( placeTypes, item1.layer ) && _.includes( placeTypes, item2.layer ) ){
+    if( _.includes( layerPreferences, item1.layer ) && _.includes( layerPreferences, item2.layer ) ){
       return false;
     }
     return true;
@@ -61,8 +76,8 @@ function isParentHierarchyDifferent(item1, item2){
 
   return placeTypes.some((placeType, pos) => {
 
-    // skip layers that are less granular than the highest matched layer
-    if( pos > highestLayerIndex ){ return false; }
+    // skip layers that are less granular than, or equal to the highest matched layer
+    if( pos >= highestLayerIndex ){ return false; }
 
     // ensure the parent ids are the same for all placetypes
     return isPropertyDifferent( item1.parent, item2.parent, placeType + '_id' );
@@ -187,3 +202,4 @@ function normalizeString(str){
 }
 
 module.exports.isDifferent = isDifferent;
+module.exports.layerPreferences = layerPreferences;

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -54,7 +54,7 @@ function isParentHierarchyDifferent(item1, item2){
   if( !isPojo1 && !isPojo2 ){ return false; }
 
   // if only one has parent info, we consider them the same
-  // note: this really shouldn't happen as at least on parent should exist
+  // note: this really shouldn't happen as at least one parent should exist
   if( !isPojo1 || !isPojo2 ){ return false; }
 
   // else both have parent info
@@ -70,7 +70,7 @@ function isParentHierarchyDifferent(item1, item2){
     placeTypes.findIndex(el => el === item2.layer)
   );
 
-  // in the case where we couldn't find either later in the $placeTypes array
+  // in the case where we couldn't find either layer in the $placeTypes array
   // we will enforce that all parent fields are checked.
   if( highestLayerIndex === -1 ){ highestLayerIndex = Infinity; }
 

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -61,23 +61,23 @@ function isParentHierarchyDifferent(item1, item2){
 
   // iterate over all the placetypes, comparing between items
 
-  // we only want to check parent items representing places less granular
-  // than the highest matched layer.
-  // eg. if we are comparing layer=address & layer=country then we only
-  // check for differences in layers above country, so continent, planet etc.
-  let highestLayerIndex = Math.min(
+  // only check layers higher than the lower of the two record layers
+  // eg. if we are comparing layer=locality & layer=country then we only
+  // check for differences in layers localadmin, region, country, etc.
+  const lowestRecordLayer = Math.min(
     placeTypes.findIndex(el => el === item1.layer),
     placeTypes.findIndex(el => el === item2.layer)
   );
 
   // in the case where we couldn't find either layer in the $placeTypes array
   // we will enforce that all parent fields are checked.
-  if( highestLayerIndex === -1 ){ highestLayerIndex = Infinity; }
+  const lowestLayerToCheck = lowestRecordLayer === -1 ? Infinity : lowestRecordLayer + 1;
 
   return placeTypes.some((placeType, pos) => {
 
-    // skip layers that are less granular than, or equal to the highest matched layer
-    if( pos >= highestLayerIndex ){ return false; }
+    // skip layers that are less granular than lowest layer to check
+    // note: "higher" layers have smaller indices
+    if( pos >= lowestLayerToCheck){ return false; }
 
     // ensure the parent ids are the same for all placetypes
     return isPropertyDifferent( item1.parent, item2.parent, placeType + '_id' );

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -1,12 +1,9 @@
 const logger = require('pelias-logger').get('api');
 const _ = require('lodash');
 const isDifferent = require('../helper/diffPlaces').isDifferent;
+const layerPreferences = require('../helper/diffPlaces').layerPreferences;
 const canonical_sources = require('../helper/type_mapping').canonical_sources;
 const field = require('../helper/fieldValue');
-
-// when performing inter-layer deduping, layers coming earlier in this list take
-// preference to those appearing later or not at all.
-const layerPreferences = [ 'locality', 'country', 'localadmin', 'region', 'neighbourhood' ];
 
 function dedupeResults(req, res, next) {
 

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -17,7 +17,7 @@ function dedupeResults(req, res, next) {
   let unique = [ res.data[0] ];
 
   // convenience function to search unique array for an existing element which matches a hit
-  let findMatch = (hit) => unique.findIndex(elem => !isDifferent(elem, hit));
+  let findMatch = (hit) => unique.findIndex(elem => !isDifferent(elem, hit, _.get(req, 'clean.lang.iso6393') ));
 
   // iterate over res.data using an old-school for loop starting at index 1
   // we can call break at any time to end the iterator

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -60,6 +60,82 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('isParentHierarchyDifferent: do not compare parentage at lower levels to the highest item placetypes', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '12345',
+        'locality_id': '54321'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '56789',
+        'locality_id': '98765'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do compare parentage at the same level as the item placetypes', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '12345'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '54321'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do compare parentage at higher levels than the highest item placetypes', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '12345',
+        'ocean_id': '54321'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'localadmin_id': '56789',
+        'ocean_id': '98765'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: consider parentage at same level as placetype for comparison', function(t) {
+    var item1 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '12345'
+      }
+    };
+    var item2 = {
+      'layer': 'country',
+      'parent': {
+        'country_id': '54321'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
   test('catch diff name', function(t) {
     var item1 = {
       'name': {

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -80,7 +80,7 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
-  test('isParentHierarchyDifferent: do compare parentage at the same level as the item placetypes', function(t) {
+  test('isParentHierarchyDifferent: do not compare parentage at the same level as the item placetypes', function(t) {
     var item1 = {
       'layer': 'country',
       'parent': {
@@ -94,7 +94,7 @@ module.exports.tests.dedupe = function(test, common) {
       }
     };
 
-    t.true(isDifferent(item1, item2), 'should be different');
+    t.false(isDifferent(item1, item2), 'should be different');
     t.end();
   });
 
@@ -111,24 +111,6 @@ module.exports.tests.dedupe = function(test, common) {
       'parent': {
         'localadmin_id': '56789',
         'ocean_id': '98765'
-      }
-    };
-
-    t.true(isDifferent(item1, item2), 'should be different');
-    t.end();
-  });
-
-  test('isParentHierarchyDifferent: consider parentage at same level as placetype for comparison', function(t) {
-    var item1 = {
-      'layer': 'country',
-      'parent': {
-        'country_id': '12345'
-      }
-    };
-    var item2 = {
-      'layer': 'country',
-      'parent': {
-        'country_id': '54321'
       }
     };
 

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -94,7 +94,7 @@ module.exports.tests.dedupe = function(test, common) {
       }
     };
 
-    t.false(isDifferent(item1, item2), 'should be different');
+    t.true(isDifferent(item1, item2), 'should be different');
     t.end();
   });
 
@@ -115,6 +115,31 @@ module.exports.tests.dedupe = function(test, common) {
     };
 
     t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do compare parentage at higher levels than the lowest item placetypes', function(t) {
+    var item1 = {
+      name: {
+        default: 'theplace'
+      },
+      'layer': 'localadmin',
+      'parent': {
+        'localadmin_id': '12345',
+        'country_id': '5'
+      }
+    };
+    var item2 = {
+      name: {
+        default: 'theplace'
+      },
+      'layer': 'country',
+      'parent': {
+        'country_id': '5'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should be different');
     t.end();
   });
 

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -150,6 +150,42 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('improved matching across languages - if default different, but user language matches default, consider this a match', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'English Name',
+        'eng': 'A Name'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'A Name'
+      }
+    };
+
+    t.false(isDifferent(item1, item2, 'eng'), 'should be the same');
+    t.end();
+  });
+
+
+  test('improved matching across languages - if default different, but user language matches (fra), consider this a match', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'Name',
+        'fra': 'French Name'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'Another Name',
+        'fra': 'French Name'
+      }
+    };
+
+    t.false(isDifferent(item1, item2, 'fra'), 'should be the same');
+    t.end();
+  });
+
   test('improved matching across languages - default names differ but match another language', function(t) {
     var item1 = {
       'name': {

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -128,6 +128,50 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('improved matching across languages - if default name is the same, consider this a match', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'Bern',
+        'eng': 'Bern',
+        'deu': 'Kanton Bern',
+        'fra': 'Berne'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'Bern',
+        'eng': 'Berne',
+        'deu': 'Bundesstadt', // note: this is wrong, see: https://github.com/whosonfirst-data/whosonfirst-data/issues/1363
+        'fra': 'Berne'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should be the same');
+    t.end();
+  });
+
+  test('improved matching across languages - default names differ but match another language', function(t) {
+    var item1 = {
+      'name': {
+        'default': 'Berne',
+        'eng': 'Bern',
+        'deu': 'Kanton Bern',
+        'fra': 'Berne'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': 'Bern',
+        'eng': 'Berne',
+        'deu': 'Bundesstadt',
+        'fra': 'Berne'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should be the same');
+    t.end();
+  });
+
   test('catch diff address', function(t) {
     var item1 = {
       'address_parts': {
@@ -162,6 +206,14 @@ module.exports.tests.dedupe = function(test, common) {
         'street': 'Main Street'
       }
     };
+
+    t.false(isDifferent(item1, item2), 'should be the same');
+    t.end();
+  });
+
+  test('completely empty objects', function(t) {
+    var item1 = {};
+    var item2 = {};
 
     t.false(isDifferent(item1, item2), 'should be the same');
     t.end();

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -111,6 +111,24 @@ module.exports.tests.dedupe = function(test, common) {
       t.end();
     });
   });
+
+  test('test records with no address except one has postalcode', function(t) {
+    var req = {
+      clean: {
+        size: 20
+      }
+    };
+    var res = {
+      data: onlyPostalcodeDiffersData
+    };
+    var expected = onlyPostalcodeDiffersData[1]; // record with postcode
+
+    dedupe(req, res, function () {
+      t.equal(res.data.length, 1, 'only one result displayed');
+      t.equal(res.data[0], expected, 'record with postalcode is preferred');
+      t.end();
+    });
+  });
 };
 
 

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -532,6 +532,72 @@ module.exports.tests.priority = function(test, common) {
       t.end();
     });
   });
+
+  test('real-world test case Vientiane: two regions and one locality', function (t) {
+    var req = {
+      clean: {
+        text: 'Vientiane',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': {
+            'default': 'Vientiane',
+            'eng': 'Viangchan'
+          },
+          'source': 'whosonfirst',
+          'source_id': '85673437',
+          'layer': 'region',
+          'parent': {
+            'continent_id': 102191569,
+            'country_id': 85632241,
+            'region_id': 85673437
+          },
+        },
+        {
+          'name': {
+            'default': 'Vientiane (prefecture)',
+            'eng': 'Viangchan',
+            'dut': 'Vientiane'
+          },
+          'source': 'whosonfirst',
+          'source_id': '85673433',
+          'layer': 'region',
+          'parent': {
+            'continent_id': 102191569,
+            'country_id': 85632241,
+            'region_id': 85673433
+          },
+        },
+        {
+          'name': {
+            'default': 'Vientiane',
+            'eng': 'Vientiane',
+            'dut': 'Vientiane'
+          },
+          'source': 'whosonfirst',
+          'source_id': '421168913',
+          'layer': 'locality',
+          'parent': {
+            'continent_id': 102191569,
+            'country_id': 85632241,
+            'region_id': 85673433,
+            'county_id': 1092027747,
+            'locality_id': 21168913
+          },
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -591,10 +591,51 @@ module.exports.tests.priority = function(test, common) {
       ]
     };
 
-    var expectedCount = 1;
+    var expectedCount = 2;
     dedupe(req, res, function () {
       t.equal(res.data.length, expectedCount, 'results have fewer items than before');
-      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.deepEqual(res.data[1].layer, 'locality', 'locality result not removed');
+      t.end();
+    });
+  });
+
+  test('real-world test case Pennsylvania: records without shared hierarchy should not be deduped', function (t) {
+    var req = {
+      clean: {
+        text: 'Pennsylvania',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': {
+            'default': 'Pennsylvania'
+          },
+          'source': 'whosonfirst',
+          'source_id': '85688481',
+          'layer': 'region',
+          'parent': {
+            'region_id': 85688481
+          },
+        },
+        {
+          'name': {
+            'default': 'Pennsylvania'
+          },
+          'source': 'whosonfirst',
+          'source_id': '404499535',
+          'layer': 'localadmin',
+          'parent': {
+            'region_id': 4 //not the same as above
+          }
+        }
+      ]
+    };
+
+    var expectedCount = 2;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results are not deduped');
       t.end();
     });
   });

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -362,6 +362,146 @@ module.exports.tests.priority = function(test, common) {
     t.equal(res.data.length, 1, 'results have fewer items than before');
     t.end();
   });
+
+  test('locality takes priority over country, replace', function (t) {
+    var req = {
+      clean: {
+        text: 'Singapore',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Singapore' },
+          'source': 'whosonfirst',
+          'source_id': '123456',
+          'layer': 'country'
+        },
+        {
+          'name': { 'default': 'Singapore' },
+          'source': 'whosonfirst',
+          'source_id': '654321',
+          'layer': 'locality'
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.end();
+    });
+  });
+
+  test('locality takes priority over county, replace', function (t) {
+    var req = {
+      clean: {
+        text: 'Auckland',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Auckland' },
+          'source': 'whosonfirst',
+          'source_id': '123456',
+          'layer': 'county'
+        },
+        {
+          'name': { 'default': 'Auckland' },
+          'source': 'whosonfirst',
+          'source_id': '654321',
+          'layer': 'locality'
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.end();
+    });
+  });
+
+  test('localadmin takes priority over region, replace', function (t) {
+    var req = {
+      clean: {
+        text: 'Bern',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Bern' },
+          'source': 'whosonfirst',
+          'source_id': '123456',
+          'layer': 'region'
+        },
+        {
+          'name': { 'default': 'Bern' },
+          'source': 'whosonfirst',
+          'source_id': '654321',
+          'layer': 'localadmin'
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].layer, 'localadmin', 'localadmin result won');
+      t.end();
+    });
+  });
+
+  test('locality takes priority over county, neighbourhood and localadmin, replace', function (t) {
+    var req = {
+      clean: {
+        text: 'Parramatta',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Parramatta' },
+          'source': 'whosonfirst',
+          'source_id': '123456',
+          'layer': 'county'
+        },
+        {
+          'name': { 'default': 'Parramatta' },
+          'source': 'whosonfirst',
+          'source_id': '7890',
+          'layer': 'neighbourhood'
+        },
+        {
+          'name': { 'default': 'Parramatta' },
+          'source': 'whosonfirst',
+          'source_id': '0987',
+          'layer': 'localadmin'
+        },
+        {
+          'name': { 'default': 'Parramatta' },
+          'source': 'whosonfirst',
+          'source_id': '654321',
+          'layer': 'locality'
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -363,6 +363,36 @@ module.exports.tests.priority = function(test, common) {
     t.end();
   });
 
+  test('continent and locality not considered synonymous, do not replace', function (t) {
+    var req = {
+      clean: {
+        text: 'Asia',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Asia' },
+          'source': 'whosonfirst',
+          'source_id': '123456',
+          'layer': 'continent'
+        },
+        {
+          'name': { 'default': 'Asia' },
+          'source': 'whosonfirst',
+          'source_id': '654321',
+          'layer': 'locality'
+        }
+      ]
+    };
+
+    var expectedCount = 2;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'no deduplication applied');
+      t.end();
+    });
+  });
   test('locality takes priority over country, replace', function (t) {
     var req = {
       clean: {


### PR DESCRIPTION
branched off https://github.com/pelias/api/pull/1229, please merge that PR first.
[comparison](https://github.com/pelias/api/compare/dedupe_improved_parent_matching...inter_layer_deduping)

This PR enables inter-layer deduplication and provides a mechanism to prefer some layers over others.

Examples:

```
# before
1) Parramatta, NSW, Australia
2) Parramatta (C), NSW, Australia
3) Parramatta, NSW, Australia
4) Parramatta, NSW, Australia

# after
1) Parramatta, NSW, Australia
```

```
# before
1) Singapore
2) Singapore, Singapore
3) Central Singapore, Singapore

# after
1) Singapore, Singapore
2) Central Singapore, Singapore
```

I suspect this might make some acceptance-tests fail :)