### PR TITLE
Fix error code handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "async": "^2.0.0",
     "check-types": "^7.0.0",
     "elasticsearch": "^15.0.0",
-    "elasticsearch-exceptions": "0.0.4",
     "express": "^4.8.8",
     "geojson": "^0.5.0",
     "geolib": "^2.0.18",

--- a/sanitizer/PeliasParameterError.js
+++ b/sanitizer/PeliasParameterError.js
@@ -1,0 +1,15 @@
+class PeliasParameterError extends Error {
+  constructor(message = '') {
+    super(message);
+  }
+
+  toString() {
+    return this.message;
+  }
+
+  toJSON() {
+    return this.message;
+  }
+}
+
+module.exports = PeliasParameterError;

--- a/sanitizer/sanitizeAll.js
+++ b/sanitizer/sanitizeAll.js
@@ -1,3 +1,5 @@
+const PeliasParameterError = require('./PeliasParameterError');
+
 function sanitize( req, sanitizers ){
   // init an object to store clean (sanitized) input parameters if not initialized
   req.clean = req.clean || {};
@@ -18,6 +20,19 @@ function sanitize( req, sanitizers ){
     if( sanity.errors.length ){
       req.errors = req.errors.concat( sanity.errors );
     }
+
+    // all errors must be returned as PeliasParameterError object to trigger HTTP 400 errors
+    req.errors = req.errors.map(function(error) {
+      // replace any existing Error objects with the right class
+      // preserve the message and stack trace
+      if (error instanceof Error) {
+        const new_error = new PeliasParameterError(error.message);
+        new_error.stack = error.stack;
+        return new_error;
+      } else {
+        return new PeliasParameterError(error);
+      }
+    });
 
     // if warnings occurred then set them
     // on the req object.

--- a/test/unit/middleware/sendJSON.js
+++ b/test/unit/middleware/sendJSON.js
@@ -70,7 +70,7 @@ module.exports.tests.default_error_status = function(test, common) {
 
     res.status = function( code ){
       return { json: function( body ){
-        t.equal( code, 400, '400 Bad Request' );
+        t.equal( code, 500, '500 Internal Server Error is default error' );
         t.deepEqual( body, res.body, 'body set' );
         t.end();
       }};
@@ -214,7 +214,7 @@ module.exports.tests.unknown_exception = function(test, common) {
 
     res.status = function( code ){
       return { json: function( body ){
-        t.equal( code, 400, '400 Bad Request' );
+        t.equal( code, 500, '500 error returned' );
         t.deepEqual( body, res.body, 'body set' );
         t.end();
       }};


### PR DESCRIPTION
## Background

For a long time, Pelias has used 400 as the default HTTP error code, and only a select few Elasticsearch exceptions would result in an HTTP 500 response.

This has the effect of hiding a lot of times when something was in fact wrong.

Since HTTP 400 generally signals that the request from the user has been incorrectly crafted, sending 400 error codes instead of 500 is a big problem. Besides sending a misleading signal that it's user error, many user agents will not retry after a 400 response.

Additionally, it makes it harder to monitor the health of a Pelias install. There's no way to tell if users are sending lots of genuinely invalid requests, or if the service is unhealthy.

## Changes

This PR adds a new exception class, `PeliasParameterError`. All sanitizers now return errors that are instances of this class, and `middleware/sendJSON` checks if any errors it sees are instances of the class.

Requests that result in known sanitizer errors and one or two known Elasticsearch exceptions result in specific error codes. Everything else is now considered an unknown error and results in a 500.

The complexity of the error handling code is greatly reduced. As a bonus, we can now finally get rid of the 4 year old, massively out of date [elasticsearch-exceptions](https://www.npmjs.com/package/elasticsearch-exceptions) NPM module dependency.

Fixes https://github.com/pelias/api/issues/1108