### PR TITLE
do not consider parses with only the unit number as "admin only"

### DIFF
--- a/controller/predicates/is_admin_only_analysis.js
+++ b/controller/predicates/is_admin_only_analysis.js
@@ -10,7 +10,7 @@ module.exports = (request, response) => {
   }
 
   // return true only if all non-admin properties of parsed_text are empty
-  const is_admin_only_analysis = ['number', 'street', 'query', 'category', 'postalcode'].every((prop) => {
+  const is_admin_only_analysis = ['unit', 'number', 'street', 'query', 'category', 'postalcode'].every((prop) => {
     return _.isEmpty(request.clean.parsed_text[prop]);
   });
 

--- a/test/unit/controller/predicates/is_admin_only_analysis.js
+++ b/test/unit/controller/predicates/is_admin_only_analysis.js
@@ -45,15 +45,15 @@ module.exports.tests.false_conditions = (test, common) => {
   });
 
   test('parsed_text with non-admin properties should return false', (t) => {
-    ['number', 'street', 'query', 'category', 'postalcode'].forEach((property) => {
+    ['unit', 'number', 'street', 'query', 'category', 'postalcode'].forEach((property) => {
       const req = {
         clean: {
-          parsed_text: {}
+          parsed_text: {
+            [property]: `${property} value`
+          }
         }
       };
       const res = {};
-
-      req.clean.parsed_text[property] = `${property} value`;
 
       t.notOk(is_admin_only_analysis(req, res));
 


### PR DESCRIPTION
this PR updates the predicate `is_admin_only_analysis`.

prior to this PR any parse which **only** contained the `parsed_text.unit` would be converted to an admin-only query and sent to `placeholder`.

eg.

```javascript
{
  "query": {
    "enableDebug": true,
    "text": "stop 13331",
    "size": 10,
    "private": false,
    "focus.point.lat": 45.52,
    "focus.point.lon": -122.67,
    "lang": {
      "name": "English",
      "iso6391": "en",
      "iso6393": "eng",
      "defaulted": false
    },
    "querySize": 20,
    "parser": "libpostal",
    "parsed_text": {
      "unit": "stop 13331"
    }
  }
}
```

the libpostal parse itself is wrong, but the issue being resolved here is that this case shouldn't be considered 'admin-only'.