### PR TITLE
fix for size=1 returning two results

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -22,6 +22,11 @@ function dedupeResults(req, res, next) {
   // iterate over res.data using an old-school for loop starting at index 1
   // we can call break at any time to end the iterator
   for( let i=1; i<res.data.length; i++){
+
+    // stop iterating when requested size has been reached in unique
+    if( unique.length >= req.clean.size ){ break; }
+
+    // pointer to hit at location $i
     let hit = res.data[i];
 
     // if there are multiple items in results, loop through them to find a dupe
@@ -55,9 +60,6 @@ function dedupeResults(req, res, next) {
         hit: field.getStringValue(hit.name.default) + ' ' + hit.source + ':' + hit._id
       });
     }
-
-    // stop iterating when requested size has been reached in unique
-    if( unique.length >= req.clean.size ){ break; }
   }
 
   // replace the original data with only the unique hits

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -59,6 +59,23 @@ module.exports.tests.dedupe = function(test, common) {
     });
   });
 
+  test('truncate results based on size 1', function(t) {
+    var req = {
+      clean: {
+        text: 'lampeter strasburg high school',
+        size: 1
+      }
+    };
+    var res = {
+      data: data
+    };
+
+    dedupe(req, res, function () {
+      t.equal(res.data.length, req.clean.size, 'should only return 1 result');
+      t.end();
+    });
+  });
+
   test('deduplicate between custom layers and venue layers', function(t) {
     var req = {
       clean: {


### PR DESCRIPTION
This PR fixes a bug where `size=1` returns two results.

resolves https://github.com/pelias/api/issues/1246