### PR TITLE
use fallback query for parses which contain a "query" and at least one admin field

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -33,7 +33,6 @@ function generateQuery( clean ){
 
   const vs = new peliasQuery.Vars( defaults );
 
-
   // input text
   vs.var( 'input:name', clean.text );
 
@@ -122,7 +121,7 @@ function generateQuery( clean ){
 }
 
 function getQuery(vs) {
-  if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithCountry(vs)) {
+  if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithCountry(vs) || isVenuePlusAdmin(vs)) {
     return {
       type: 'search_fallback',
       body: fallbackQuery.render(vs)
@@ -135,52 +134,58 @@ function getQuery(vs) {
 
 }
 
-function determineQueryType(vs) {
-  if (vs.isset('input:housenumber') && vs.isset('input:street')) {
-    return 'address';
-  }
-  else if (vs.isset('input:street')) {
-    return 'street';
-  }
-  else if (vs.isset('input:query')) {
-    return 'venue';
-  }
-  else if (['neighbourhood', 'borough', 'postcode', 'county', 'region','country'].some(
-    layer => vs.isset(`input:${layer}`)
-  )) {
-    return 'admin';
-  }
-  return 'other';
-}
+// function determineQueryType(vs) {
+//   if (vs.isset('input:housenumber') && vs.isset('input:street')) {
+//     return 'address';
+//   }
+//   else if (vs.isset('input:street')) {
+//     return 'street';
+//   }
+//   else if (vs.isset('input:query')) {
+//     return 'venue';
+//   }
+//   else if (['neighbourhood', 'borough', 'postcode', 'county', 'region','country'].some(
+//     layer => vs.isset(`input:${layer}`)
+//   )) {
+//     return 'admin';
+//   }
+//   return 'other';
+// }
 
 function hasStreet(vs) {
   return vs.isset('input:street');
 }
 
 function isPostalCodeOnly(vs) {
-  var isSet = layer => vs.isset(`input:${layer}`);
+  let isSet = layer => vs.isset(`input:${layer}`);
 
   var allowedFields = ['postcode'];
   var disallowedFields = ['query', 'category', 'housenumber', 'street',
     'neighbourhood', 'borough', 'county', 'region', 'country'];
 
-  return allowedFields.every(isSet) &&
-    !disallowedFields.some(isSet);
-
+  return allowedFields.every(isSet) && !disallowedFields.some(isSet);
 }
 
-
 function isPostalCodeWithCountry(vs) {
-    var isSet = (layer) => {
-        return vs.isset(`input:${layer}`);
-    };
+  let isSet = layer => vs.isset(`input:${layer}`);
 
-    var allowedFields = ['postcode', 'country'];
-    var disallowedFields = ['query', 'category', 'housenumber', 'street', 'locality',
-                          'neighbourhood', 'borough', 'county', 'region'];
+  var allowedFields = ['postcode', 'country'];
+  var disallowedFields = ['query', 'category', 'housenumber', 'street', 'locality',
+                        'neighbourhood', 'borough', 'county', 'region'];
 
-    return allowedFields.every(isSet) &&
-        !disallowedFields.some(isSet);
+  return allowedFields.every(isSet) && !disallowedFields.some(isSet);
+}
+
+// venue queries such as 'starbucks nyc' which are parsed as 'query' and one
+// or more admin properties such as 'locality' etc.
+function isVenuePlusAdmin(vs) {
+  if( !vs.isset('input:query') ){ return false; }
+
+  var allowedFields = ['neighbourhood', 'borough', 'locality', 'county', 'region', 'country'];
+  var disallowedFields = ['postcode', 'category', 'housenumber', 'street'];
+
+  let isSet = layer => vs.isset(`input:${layer}`);
+  return allowedFields.some(isSet) && !disallowedFields.some(isSet);
 }
 
 module.exports = generateQuery;

--- a/test/unit/fixture/search_venue_plus_country.json
+++ b/test/unit/fixture/search_venue_plus_country.json
@@ -1,0 +1,196 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.venue",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "query value",
+                      "type": "phrase",
+                      "fields": [
+                        "phrase.default"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "venue"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a",
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.dependency",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.dependency",
+                        "parent.dependency_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "dependency"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.country",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "country value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.country",
+                        "parent.country_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "country"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "max_boost": 20,
+      "functions": [
+        {
+          "field_value_factor": {
+            "modifier": "log1p",
+            "field": "popularity",
+            "missing": 1
+          },
+          "weight": 1
+        },
+        {
+          "field_value_factor": {
+            "modifier": "log1p",
+            "field": "population",
+            "missing": 1
+          },
+          "weight": 2
+        }
+      ],
+      "score_mode": "avg",
+      "boost_mode": "multiply"
+    }
+  },
+  "sort": [
+    "_score"
+  ],
+  "size": 20,
+  "track_scores": true
+}

--- a/test/unit/fixture/search_venue_plus_state.json
+++ b/test/unit/fixture/search_venue_plus_state.json
@@ -1,0 +1,196 @@
+{
+  "query": {
+    "function_score": {
+      "query": {
+        "bool": {
+          "minimum_should_match": 1,
+          "should": [
+            {
+              "bool": {
+                "_name": "fallback.venue",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "query value",
+                      "type": "phrase",
+                      "fields": [
+                        "phrase.default"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a",
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "venue"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.locality",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.locality",
+                        "parent.locality_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "locality"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.localadmin",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "city value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.localadmin",
+                        "parent.localadmin_a"
+                      ]
+                    }
+                  },
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a",
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "localadmin"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.region",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.region",
+                        "parent.region_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "region"
+                  }
+                }
+              }
+            },
+            {
+              "bool": {
+                "_name": "fallback.macroregion",
+                "must": [
+                  {
+                    "multi_match": {
+                      "query": "state value",
+                      "type": "phrase",
+                      "fields": [
+                        "parent.macroregion",
+                        "parent.macroregion_a"
+                      ]
+                    }
+                  }
+                ],
+                "filter": {
+                  "term": {
+                    "layer": "macroregion"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "max_boost": 20,
+      "functions": [
+        {
+          "field_value_factor": {
+            "modifier": "log1p",
+            "field": "popularity",
+            "missing": 1
+          },
+          "weight": 1
+        },
+        {
+          "field_value_factor": {
+            "modifier": "log1p",
+            "field": "population",
+            "missing": 1
+          },
+          "weight": 2
+        }
+      ],
+      "score_mode": "avg",
+      "boost_mode": "multiply"
+    }
+  },
+  "sort": [
+    "_score"
+  ],
+  "size": 20,
+  "track_scores": true
+}

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -285,7 +285,7 @@ module.exports.tests.city_state = function(test, common) {
 
   });
 
-  test('city/state with query should return undefined', function(t) {
+  test('city/state with query should return venue matching query', function(t) {
     var clean = {
       parsed_text: {
         city: 'city value',
@@ -296,7 +296,11 @@ module.exports.tests.city_state = function(test, common) {
 
     var query = generate(clean);
 
-    t.equals(query, undefined, 'should have returned undefined');
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/search_venue_plus_state.json');
+
+    t.deepEqual(compiled.type, 'search_fallback', 'query type set');
+    t.deepEqual(compiled.body, expected, 'valid search query with category filtering');
     t.end();
 
   });
@@ -443,7 +447,7 @@ module.exports.tests.city_country = function(test, common) {
 
   });
 
-  test('city/country with query should return undefined', function(t) {
+  test('city/country with query should return venue matching query', function(t) {
     var clean = {
       parsed_text: {
         city: 'city value',
@@ -454,7 +458,11 @@ module.exports.tests.city_country = function(test, common) {
 
     var query = generate(clean);
 
-    t.equals(query, undefined, 'should have returned undefined');
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/search_venue_plus_country.json');
+
+    t.deepEqual(compiled.type, 'search_fallback', 'query type set');
+    t.deepEqual(compiled.body, expected, 'valid search query with category filtering');
     t.end();
 
   });


### PR DESCRIPTION
Our current parser logic for `/v1/search` only uses a `libpostal` parse in the case of:
```
if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithCountry(vs)) {
```

If the inputs don't match one of those conditions then we discard the `libpostal` parse and use `addressit` instead.

This PR adds an additional condition `isVenuePlusAdmin(vs)` so that we can use the `libpostal` parse for some venue matching queries.

This type of query is already supported by the `pelias/query` module, so no changes are required there.

In the case of a parse such as this:

```
[
  {
    "label": "house",
    "value": "starbucks"
  },
  {
    "label": "city",
    "value": "lake oswego"
  }
]
```

.. we can generate a venue query which targets all venues with a matching name within the admin location, if no venue by that name is found then we 'fallback' to returning the centroid of the most granularly matched admin area.

I'm not super familiar with this code and not 💯 on why this wasn't already the case, maybe @trescube might remember? I'm going with the assumption that it was just missed due to venues not being part of the original work.