### PR TITLE
autocomplete: remove empty tokens

### DIFF
--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -9,7 +9,7 @@ const logger = require('pelias-logger').get('api');
   are not happy with either of these methods but they remain in place
   for purely legacy reasons.
 
-  'naïve parser' provides the following fields:
+  'naive parser' provides the following fields:
   'name', 'admin_parts'
 
   'addressit parser' provides the following fields:
@@ -47,7 +47,7 @@ function _sanitize( raw, clean ){
 
 // naive approach - for admin matching during query time
 // split 'flatiron, new york, ny' into 'flatiron' and 'new york, ny'
-var naïve = function(tokens) {
+var naive = function(tokens) {
   var parsed_text = {};
 
   if( tokens.length > 1 ){
@@ -64,11 +64,13 @@ var naïve = function(tokens) {
 
 function parse(clean) {
 
-  // split query on delimiter
-  var tokens = clean.text.split(DELIM).map( part => part.trim() );
+  // split query on delimiter, trim tokens and remove empty elements
+  var tokens = clean.text.split(DELIM)
+                         .map( part => part.trim() )
+                         .filter( part => part.length > 0 );
 
-  // call the naïve parser to try and split tokens
-  var parsed_text = naïve(tokens);
+  // call the naive parser to try and split tokens
+  var parsed_text = naive(tokens);
 
   // join tokens back togther with normalized delimiters
   var joined = tokens.join(`${DELIM} `);

--- a/test/unit/sanitizer/_text_addressit.js
+++ b/test/unit/sanitizer/_text_addressit.js
@@ -32,7 +32,7 @@ module.exports.tests.text_parser = function(test, common) {
       var clean = {};
 
       var expected_clean = {
-        text: query.name + ', ' + query.admin_parts,
+        text: raw.text.trim(),
         parser: 'addressit',
         parsed_text: {
           name: query.name,
@@ -57,7 +57,7 @@ module.exports.tests.text_parser = function(test, common) {
       var clean = {};
 
       var expected_clean = {
-        text: query.name + ',' + query.admin_parts,
+        text: raw.text.trim(),
         parser: 'addressit',
         parsed_text: {
           name: query.name,
@@ -75,6 +75,30 @@ module.exports.tests.text_parser = function(test, common) {
 
     });
 
+    test('naive parsing ' + query + ' with leading and trailing junk', function(t) {
+      var raw = {
+        text: ' , ' + query.name + ',' + query.admin_parts + ' , '
+      };
+      var clean = {};
+
+      var expected_clean = {
+        text: raw.text.trim(),
+        parser: 'addressit',
+        parsed_text: {
+          name: query.name,
+          regions: [ query.name ],
+          admin_parts: query.admin_parts,
+          state: query.state
+        }
+      };
+
+      var messages = sanitizer.sanitize(raw, clean);
+
+      t.deepEqual(messages, { errors: [], warnings: [] } );
+      t.deepEqual(clean, expected_clean);
+      t.end();
+
+    });
   });
 
   var nonUSQueries = [


### PR DESCRIPTION
fixes a bug where empty tokens (blank strings) were not being correctly removed from the naïve parser.

this would cause errors in some situations such as:

```
,2057+Fair+Park+Ave,+Los+Angeles,+CA+90041

{ name: '',
  admin_parts: '2057 Fair Park Ave, Los Angeles, CA 90041',
  number: '2057',
  street: 'Fair Park Ave',
  state: 'CA',
  postalcode: '90041',
  regions: [ 'Los Angeles' ] }
```

resolves https://github.com/pelias/api/issues/1245