### PR TITLE
[inter_layer_deduping] Compare parent layers above lowest record

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -54,7 +54,7 @@ function isParentHierarchyDifferent(item1, item2){
   if( !isPojo1 && !isPojo2 ){ return false; }
 
   // if only one has parent info, we consider them the same
-  // note: this really shouldn't happen as at least on parent should exist
+  // note: this really shouldn't happen as at least one parent should exist
   if( !isPojo1 || !isPojo2 ){ return false; }
 
   // else both have parent info
@@ -70,7 +70,7 @@ function isParentHierarchyDifferent(item1, item2){
     placeTypes.findIndex(el => el === item2.layer)
   );
 
-  // in the case where we couldn't find either later in the $placeTypes array
+  // in the case where we couldn't find either layer in the $placeTypes array
   // we will enforce that all parent fields are checked.
   if( highestLayerIndex === -1 ){ highestLayerIndex = Infinity; }
 

--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -61,23 +61,23 @@ function isParentHierarchyDifferent(item1, item2){
 
   // iterate over all the placetypes, comparing between items
 
-  // we only want to check parent items representing places less granular
-  // than the highest matched layer.
-  // eg. if we are comparing layer=address & layer=country then we only
-  // check for differences in layers above country, so continent, planet etc.
-  let highestLayerIndex = Math.min(
+  // only check layers higher than the lower of the two record layers
+  // eg. if we are comparing layer=locality & layer=country then we only
+  // check for differences in layers localadmin, region, country, etc.
+  const lowestRecordLayer = Math.min(
     placeTypes.findIndex(el => el === item1.layer),
     placeTypes.findIndex(el => el === item2.layer)
   );
 
   // in the case where we couldn't find either layer in the $placeTypes array
   // we will enforce that all parent fields are checked.
-  if( highestLayerIndex === -1 ){ highestLayerIndex = Infinity; }
+  const lowestLayerToCheck = lowestRecordLayer === -1 ? Infinity : lowestRecordLayer + 1;
 
   return placeTypes.some((placeType, pos) => {
 
-    // skip layers that are less granular than, or equal to the highest matched layer
-    if( pos >= highestLayerIndex ){ return false; }
+    // skip layers that are less granular than lowest layer to check
+    // note: "higher" layers have smaller indices
+    if( pos >= lowestLayerToCheck){ return false; }
 
     // ensure the parent ids are the same for all placetypes
     return isPropertyDifferent( item1.parent, item2.parent, placeType + '_id' );

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -94,7 +94,7 @@ module.exports.tests.dedupe = function(test, common) {
       }
     };
 
-    t.false(isDifferent(item1, item2), 'should be different');
+    t.true(isDifferent(item1, item2), 'should be different');
     t.end();
   });
 
@@ -115,6 +115,31 @@ module.exports.tests.dedupe = function(test, common) {
     };
 
     t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do compare parentage at higher levels than the lowest item placetypes', function(t) {
+    var item1 = {
+      name: {
+        default: 'theplace'
+      },
+      'layer': 'localadmin',
+      'parent': {
+        'localadmin_id': '12345',
+        'country_id': '5'
+      }
+    };
+    var item2 = {
+      name: {
+        default: 'theplace'
+      },
+      'layer': 'country',
+      'parent': {
+        'country_id': '5'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should be different');
     t.end();
   });
 

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -591,10 +591,51 @@ module.exports.tests.priority = function(test, common) {
       ]
     };
 
-    var expectedCount = 1;
+    var expectedCount = 2;
     dedupe(req, res, function () {
       t.equal(res.data.length, expectedCount, 'results have fewer items than before');
-      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.deepEqual(res.data[1].layer, 'locality', 'locality result not removed');
+      t.end();
+    });
+  });
+
+  test('real-world test case Pennsylvania: records without shared hierarchy should not be deduped', function (t) {
+    var req = {
+      clean: {
+        text: 'Pennsylvania',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': {
+            'default': 'Pennsylvania'
+          },
+          'source': 'whosonfirst',
+          'source_id': '85688481',
+          'layer': 'region',
+          'parent': {
+            'region_id': 85688481
+          },
+        },
+        {
+          'name': {
+            'default': 'Pennsylvania'
+          },
+          'source': 'whosonfirst',
+          'source_id': '404499535',
+          'layer': 'localadmin',
+          'parent': {
+            'region_id': 4 //not the same as above
+          }
+        }
+      ]
+    };
+
+    var expectedCount = 2;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results are not deduped');
       t.end();
     });
   });


### PR DESCRIPTION
This expands the layers checked for hierarchy difference to be any layer
higher than the _lower_ of the two records being compared. Previously,
it was any layer higher than the _higher_ of the two record (another way
to think about it was it was only comparing hierarchy elements that BOTH
records have).

This fixes the issue where the city of Pennsylvania, Illinois was being
considered a duplicate of the state of Pennsylvania.

This is a PR into #1230, not master