### PR TITLE
enable fallback queries when placeholder returns 0 results

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -224,8 +224,7 @@ function addRoutes(app, peliasConfig) {
   // defer to addressit for analysis IF there's no response AND placeholder should not have executed
   const shouldDeferToAddressIt = all(
     not(hasRequestErrors),
-    not(hasResponseData),
-    not(placeholderShouldHaveExecuted)
+    not(hasResponseData)
   );
 
   // call very old prod query if addressit was the parser


### PR DESCRIPTION
This is a fix for nasty bug I've been trying to track down for some time 🎉 

We're noticing more and more erroneous `libpostal` parses, and in some cases they result in 0 results when we could have fallen back and used an alternate query approach to satisfy the query.

A good example is this query for Changi Airport in Singapore:

```
/v1/search?text=changi

no features
```

The reason for this is that `libpostal` is incorrectly parsing the input as a `city`:

```
"parsed_text": {
  "city": "changi"
}
```

Following on from the parse, the next step is to query placeholder for matching cities, which returns 0 results.

Looking at the code, I believe the intended fallback strategy is to re-parse the input using `addressit` and then perform a query more similar to how we do autocomplete.

The issue is with one of the predecates, it prevents `shouldDeferToAddressIt` from returning true and so all other query steps are skipped and 0 results are returned.