### PR TITLE
revert ccb9bc8180535bc5a1e55a523843a53334bc1c07

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -53,47 +53,47 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:postcode:cutoff_frequency': 0.01,
 
   'admin:country_a:analyzer': 'standard',
-  'admin:country_a:field': 'parent.country_a.ngram',
+  'admin:country_a:field': 'parent.country_a',
   'admin:country_a:boost': 1000,
   'admin:country_a:cutoff_frequency': 0.01,
 
   'admin:country:analyzer': 'peliasAdmin',
-  'admin:country:field': 'parent.country.ngram',
+  'admin:country:field': 'parent.country',
   'admin:country:boost': 800,
   'admin:country:cutoff_frequency': 0.01,
 
   'admin:region:analyzer': 'peliasAdmin',
-  'admin:region:field': 'parent.region.ngram',
+  'admin:region:field': 'parent.region',
   'admin:region:boost': 600,
   'admin:region:cutoff_frequency': 0.01,
 
   'admin:region_a:analyzer': 'peliasAdmin',
-  'admin:region_a:field': 'parent.region_a.ngram',
+  'admin:region_a:field': 'parent.region_a',
   'admin:region_a:boost': 600,
   'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:county:analyzer': 'peliasAdmin',
-  'admin:county:field': 'parent.county.ngram',
+  'admin:county:field': 'parent.county',
   'admin:county:boost': 400,
   'admin:county:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
-  'admin:localadmin:field': 'parent.localadmin.ngram',
+  'admin:localadmin:field': 'parent.localadmin',
   'admin:localadmin:boost': 200,
   'admin:localadmin:cutoff_frequency': 0.01,
 
   'admin:locality:analyzer': 'peliasAdmin',
-  'admin:locality:field': 'parent.locality.ngram',
+  'admin:locality:field': 'parent.locality',
   'admin:locality:boost': 200,
   'admin:locality:cutoff_frequency': 0.01,
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
-  'admin:neighbourhood:field': 'parent.neighbourhood.ngram',
+  'admin:neighbourhood:field': 'parent.neighbourhood',
   'admin:neighbourhood:boost': 200,
   'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'admin:borough:analyzer': 'peliasAdmin',
-  'admin:borough:field': 'parent.borough.ngram',
+  'admin:borough:field': 'parent.borough',
   'admin:borough:boost': 600,
   'admin:borough:cutoff_frequency': 0.01,
 

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -55,7 +55,7 @@ module.exports = {
       }],
       'filter': [{
         'match': {
-          'parent.country_a.ngram': {
+          'parent.country_a': {
             'analyzer': 'standard',
             'query': 'ABC'
           }

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -18,7 +18,7 @@ module.exports = {
       'should': [
         {
           'match': {
-            'parent.country.ngram': {
+            'parent.country': {
               'analyzer': 'peliasAdmin',
               'boost': 800,
               'cutoff_frequency': 0.01,
@@ -28,7 +28,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.region.ngram': {
+            'parent.region': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -38,7 +38,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.region_a.ngram': {
+            'parent.region_a': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -48,7 +48,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.county.ngram': {
+            'parent.county': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 400,
@@ -58,7 +58,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.borough.ngram': {
+            'parent.borough': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -68,7 +68,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.localadmin.ngram': {
+            'parent.localadmin': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -78,7 +78,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.locality.ngram': {
+            'parent.locality': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -88,7 +88,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.neighbourhood.ngram': {
+            'parent.neighbourhood': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 200,

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -25,7 +25,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.country.ngram': {
+            'parent.country': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 800,
@@ -34,7 +34,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.region.ngram': {
+            'parent.region': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -43,7 +43,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.region_a.ngram': {
+            'parent.region_a': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -52,7 +52,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.county.ngram': {
+            'parent.county': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 400,
@@ -61,7 +61,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.borough.ngram': {
+            'parent.borough': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -70,7 +70,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.localadmin.ngram': {
+            'parent.localadmin': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -79,7 +79,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.locality.ngram': {
+            'parent.locality': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -88,7 +88,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.neighbourhood.ngram': {
+            'parent.neighbourhood': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 200,


### PR DESCRIPTION
This PR reverts commit `ccb9bc8180535bc5a1e55a523843a53334bc1c07`

I just merged https://github.com/pelias/api/pull/1259 because it's been reviewed and tested.
It's probably a better idea to leave some time between merging https://github.com/pelias/schema/pull/347 and the API PR in order to allow users to catch up.

The potential issue I'm trying to avoid with this PR is that when users with older indices upgrade to a new `pelias/api` docker image they will presumably have errors when trying to use autocomplete due to the ngrams indices being missing.