### PR TITLE
feat(admin_ngrams): Restore admin ngrams functionality

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -53,47 +53,47 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:postcode:cutoff_frequency': 0.01,
 
   'admin:country_a:analyzer': 'standard',
-  'admin:country_a:field': 'parent.country_a',
+  'admin:country_a:field': 'parent.country_a.ngram',
   'admin:country_a:boost': 1000,
   'admin:country_a:cutoff_frequency': 0.01,
 
   'admin:country:analyzer': 'peliasAdmin',
-  'admin:country:field': 'parent.country',
+  'admin:country:field': 'parent.country.ngram',
   'admin:country:boost': 800,
   'admin:country:cutoff_frequency': 0.01,
 
   'admin:region:analyzer': 'peliasAdmin',
-  'admin:region:field': 'parent.region',
+  'admin:region:field': 'parent.region.ngram',
   'admin:region:boost': 600,
   'admin:region:cutoff_frequency': 0.01,
 
   'admin:region_a:analyzer': 'peliasAdmin',
-  'admin:region_a:field': 'parent.region_a',
+  'admin:region_a:field': 'parent.region_a.ngram',
   'admin:region_a:boost': 600,
   'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:county:analyzer': 'peliasAdmin',
-  'admin:county:field': 'parent.county',
+  'admin:county:field': 'parent.county.ngram',
   'admin:county:boost': 400,
   'admin:county:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
-  'admin:localadmin:field': 'parent.localadmin',
+  'admin:localadmin:field': 'parent.localadmin.ngram',
   'admin:localadmin:boost': 200,
   'admin:localadmin:cutoff_frequency': 0.01,
 
   'admin:locality:analyzer': 'peliasAdmin',
-  'admin:locality:field': 'parent.locality',
+  'admin:locality:field': 'parent.locality.ngram',
   'admin:locality:boost': 200,
   'admin:locality:cutoff_frequency': 0.01,
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
-  'admin:neighbourhood:field': 'parent.neighbourhood',
+  'admin:neighbourhood:field': 'parent.neighbourhood.ngram',
   'admin:neighbourhood:boost': 200,
   'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'admin:borough:analyzer': 'peliasAdmin',
-  'admin:borough:field': 'parent.borough',
+  'admin:borough:field': 'parent.borough.ngram',
   'admin:borough:boost': 600,
   'admin:borough:cutoff_frequency': 0.01,
 

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -55,7 +55,7 @@ module.exports = {
       }],
       'filter': [{
         'match': {
-          'parent.country_a': {
+          'parent.country_a.ngram': {
             'analyzer': 'standard',
             'query': 'ABC'
           }

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -18,7 +18,7 @@ module.exports = {
       'should': [
         {
           'match': {
-            'parent.country': {
+            'parent.country.ngram': {
               'analyzer': 'peliasAdmin',
               'boost': 800,
               'cutoff_frequency': 0.01,
@@ -28,7 +28,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.region': {
+            'parent.region.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -38,7 +38,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.region_a': {
+            'parent.region_a.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -48,7 +48,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.county': {
+            'parent.county.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 400,
@@ -58,7 +58,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.borough': {
+            'parent.borough.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -68,7 +68,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.localadmin': {
+            'parent.localadmin.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -78,7 +78,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.locality': {
+            'parent.locality.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -88,7 +88,7 @@ module.exports = {
         },
         {
           'match': {
-            'parent.neighbourhood': {
+            'parent.neighbourhood.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 200,

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -25,7 +25,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.country': {
+            'parent.country.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 800,
@@ -34,7 +34,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.region': {
+            'parent.region.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -43,7 +43,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.region_a': {
+            'parent.region_a.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -52,7 +52,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.county': {
+            'parent.county.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 400,
@@ -61,7 +61,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.borough': {
+            'parent.borough.ngram': {
               'analyzer': 'peliasAdmin',
               'cutoff_frequency': 0.01,
               'boost': 600,
@@ -70,7 +70,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.localadmin': {
+            'parent.localadmin.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -79,7 +79,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.locality': {
+            'parent.locality.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 200,
@@ -88,7 +88,7 @@ module.exports = {
           }
         }, {
           'match': {
-            'parent.neighbourhood': {
+            'parent.neighbourhood.ngram': {
               'query': 'laird',
               'cutoff_frequency': 0.01,
               'boost': 200,


### PR DESCRIPTION
This restores the functionality from https://github.com/pelias/api/pull/1259 to allow autocomplete on partial administrative area names.

It's a solid improvement, and we are waiting to merge only to give the community time to update their schema settings.

This reverts commit 43a4bed31227ac353b79d5299194a45680d410e3.