### PR TITLE
Logging configurability

### DIFF
--- a/controller/coarse_reverse.js
+++ b/controller/coarse_reverse.js
@@ -102,11 +102,8 @@ function synthesizeDoc(results) {
     return esDoc.data;
 
   } catch( e ) {
-
     // an error occurred when generating a new Document
-    logger.info(`[controller:coarse_reverse][error]`);
-    logger.error(e);
-    logger.info(results);
+    logger.error('[controller:coarse_reverse][error]', e);
 
     return null;
   }

--- a/sanitizer/defer_to_addressit.js
+++ b/sanitizer/defer_to_addressit.js
@@ -17,12 +17,6 @@ module.exports = (should_execute) => {
       return next();
     }
 
-    // log the query that caused a fallback since libpostal+new-queries didn't return anything
-    if (req.path === '/v1/search') {
-      const queryText = logging.isDNT(req) ? '[text removed]' : req.clean.text;
-      logger.info(`fallback queryText: ${queryText}`);
-    }
-
     sanitizeAll.sanitize(req, sanitizers);
     next();
 

--- a/schema.js
+++ b/schema.js
@@ -17,7 +17,7 @@ module.exports = Joi.object().keys({
     version: Joi.string(),
     indexName: Joi.string(),
     host: Joi.string(),
-    accessLog: Joi.string(),
+    accessLog: Joi.string().allow(''),
     relativeScores: Joi.boolean(),
     requestRetries: Joi.number().integer().min(0),
     customBoosts: Joi.object().keys({

--- a/test/unit/sanitizer/defer_to_addressit.js
+++ b/test/unit/sanitizer/defer_to_addressit.js
@@ -37,7 +37,7 @@ module.exports.tests.sanitize = (test, common) => {
   });
 
   test('verify that _text_addressit sanitizer was called when should_execute returns true', (t) => {
-    t.plan(3);
+    t.plan(2);
 
     const logger = mock_logger();
 
@@ -74,7 +74,6 @@ module.exports.tests.sanitize = (test, common) => {
     };
 
     defer_to_addressit(req, {}, () => {
-      t.deepEquals(logger.getInfoMessages(), ['fallback queryText: this is the query text']);
       t.end();
     });
 
@@ -120,51 +119,6 @@ module.exports.tests.sanitize = (test, common) => {
     });
 
   });
-
-  test('query should be logged as [text removed] if private', (t) => {
-    t.plan(3);
-
-    const logger = mock_logger();
-
-    // rather than re-verify the functionality of all the sanitizers, this test just verifies that they
-    //  were all called correctly
-    const defer_to_addressit = proxyquire('../../../sanitizer/defer_to_addressit', {
-      '../sanitizer/_text_addressit': function () {
-        return {
-          sanitize: () => {
-            t.pass('_text_addressit should have been called');
-            return { errors: [], warnings: [] };
-          }
-        };
-      },
-      'pelias-logger': logger,
-      '../helper/logging': {
-        isDNT: () => true
-      },
-      '../sanitizer/_debug': () => {
-        return {
-          sanitize: () => {
-            t.pass('_debug should have been called');
-          return { errors: [], warnings: [] };
-          }
-        };
-      }
-    })(() => true);
-
-    const req = {
-      path: '/v1/search',
-      clean: {
-        text: 'this is the query text'
-      }
-    };
-
-    defer_to_addressit(req, {}, () => {
-      t.deepEquals(logger.getInfoMessages(), ['fallback queryText: [text removed]']);
-      t.end();
-    });
-
-  });
-
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This PR changes and improves a few logging related items:

- a log of every input text to the `/v1/search` endpoint that falls back from `libpostal` to `addressit` parsing was removed. This can be determined through other means and doesn't need to be logged explicitly
- The configuration schema now allows setting the `accessLog` setting to an empty string. The API already allowed disabling the access log by doing this, but the schema wasn't allowing it. Disabling the access log can be helpful in many cases, such as to reduce log volume.
- An error log was logging several lines, when it could have logged just one, and it was using inconsistent log levels