### PR TITLE
WIP: fuzzy autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -10,7 +10,7 @@ var views = {
   custom_boosts:              require('./view/boost_sources_and_layers'),
   ngrams_strict:              require('./view/ngrams_strict'),
   ngrams_last_token_only:     require('./view/ngrams_last_token_only'),
-  phrase_first_tokens_only:   require('./view/phrase_first_tokens_only'),
+  phrase_first_tokens_only:   require('./view/phrase_first_tokens_only')(require('./view/fuzzy_match')),
   pop_subquery:               require('./view/pop_subquery'),
   boost_exact_matches:        require('./view/boost_exact_matches'),
   max_character_count_layer_filter:   require('./view/max_character_count_layer_filter')

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -27,6 +27,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'phrase:boost': 1,
   'phrase:slop': 3,
   'phrase:cutoff_frequency': 0.01,
+  'phrase:fuzziness': 1,
+  'phrase:prefix_length': 1,
+  'phrase:max_expansions': 10,
 
   'focus:function': 'exp',
   'focus:offset': '0km',

--- a/query/view/fuzzy_match.js
+++ b/query/view/fuzzy_match.js
@@ -1,0 +1,39 @@
+module.exports = function (vs) {
+
+  // validate required params
+  if (!vs.isset('input:name') ||
+    !vs.isset('phrase:analyzer') ||
+    !vs.isset('phrase:field') ||
+    !vs.isset('phrase:boost') ||
+    !vs.isset('phrase:slop')) {
+    return null;
+  }
+
+  // base view
+  var view = { 'match': {} };
+
+  // match query
+  view.match[vs.var('phrase:field')] = {
+    analyzer: vs.var('phrase:analyzer'),
+    boost: vs.var('phrase:boost'),
+    slop: vs.var('phrase:slop'),
+    query: vs.var('input:name')
+  };
+
+  if (vs.isset('phrase:fuzziness')) {
+    view.match[vs.var('phrase:field')].fuzziness = vs.var('phrase:fuzziness');
+
+    if (vs.isset('phrase:prefix_length')) {
+      view.match[vs.var('phrase:field')].prefix_length = vs.var('phrase:prefix_length');
+    }
+    if (vs.isset('phrase:max_expansions')) {
+      view.match[vs.var('phrase:field')].max_expansions = vs.var('phrase:max_expansions');
+    }
+  }
+
+  if (vs.isset('phrase:cutoff_frequency')) {
+    view.match[vs.var('phrase:field')].cutoff_frequency = vs.var('phrase:cutoff_frequency');
+  }
+
+  return view;
+};

--- a/query/view/phrase_first_tokens_only.js
+++ b/query/view/phrase_first_tokens_only.js
@@ -11,20 +11,25 @@ var peliasQuery = require('pelias-query');
   unaltered form by other views.
 **/
 
-module.exports = function( vs ){
+module.exports = function( view ){
+  return function( vs ){
 
-  // get a copy of the *complete* tokens produced from the input:name
-  var tokens = vs.var('input:name:tokens_complete').get();
+    // view to use for generating phrase query.
+    if (!view) { return null; } // view validation failed
 
-  // no valid tokens to use, fail now, don't render this view.
-  if( !tokens || tokens.length < 1 ){ return null; }
+    // get a copy of the *complete* tokens produced from the input:name
+    var tokens = vs.var('input:name:tokens_complete').get();
 
-  // make a copy Vars so we don't mutate the original
-  var vsCopy = new peliasQuery.Vars( vs.export() );
+    // no valid tokens to use, fail now, don't render this view.
+    if( !tokens || tokens.length < 1 ){ return null; }
 
-  // set the 'name' variable in the copy to all but the last token
-  vsCopy.var('input:name').set( tokens.join(' ') );
+    // make a copy Vars so we don't mutate the original
+    var vsCopy = new peliasQuery.Vars( vs.export() );
 
-  // return the view rendered using the copy
-  return peliasQuery.view.phrase( vsCopy );
+    // set the 'name' variable in the copy to all but the last token
+    vsCopy.var('input:name').set( tokens.join(' ') );
+
+    // return the view rendered using the copy
+    return view(vsCopy);
+  };
 };

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -9,9 +9,11 @@
               "name.default": {
                 "analyzer": "peliasQueryFullToken",
                 "cutoff_frequency": 0.01,
-                "type": "phrase",
                 "boost": 1,
                 "slop": 3,
+                "fuzziness": 1,
+                "prefix_length": 1,
+                "max_expansions": 10,
                 "query": "foo"
               }
             }
@@ -26,6 +28,7 @@
                 "type": "phrase",
                 "boost": 1,
                 "slop": 3,
+                "fuzziness": 1,
                 "query": "foo"
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -8,8 +8,10 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'slop': 3,
-            'query': 'one',
-            'type': 'phrase'
+            'fuzziness': 1,
+            'prefix_length': 1,
+            'max_expansions': 10,
+            'query': 'one'
           }
         }
       }],
@@ -20,6 +22,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'slop': 3,
+            'fuzziness': 1,
             'query': 'one',
             'type': 'phrase'
           }

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -5,9 +5,11 @@ module.exports = {
         'match': {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
-            'type': 'phrase',
             'boost': 1,
             'slop': 3,
+            'fuzziness': 1,
+            'prefix_length': 1,
+            'max_expansions': 10,
             'cutoff_frequency': 0.01,
             'query': 'one two'
           }
@@ -38,6 +40,7 @@ module.exports = {
               'type' : 'phrase',
               'boost' : 1,
               'slop' : 3,
+              'fuzziness': 1,
               'cutoff_frequency': 0.01,
               'query' : 'one two'
             }

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -6,9 +6,11 @@ module.exports = {
           'match': {
             'name.default': {
               'analyzer': 'peliasQueryFullToken',
-              'type': 'phrase',
               'boost': 1,
               'slop': 3,
+              'fuzziness': 1,
+              'prefix_length': 1,
+              'max_expansions': 10,
               'cutoff_frequency': 0.01,
               'query': 'one two'
             }
@@ -104,6 +106,7 @@ module.exports = {
               'type' : 'phrase',
               'boost' : 1,
               'slop' : 3,
+              'fuzziness': 1,
               'query' : 'one two'
             }
           }

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -6,9 +6,11 @@ module.exports = {
           'name.default': {
             'analyzer': 'peliasQueryFullToken',
             'cutoff_frequency': 0.01,
-            'type': 'phrase',
             'boost': 1,
             'slop': 3,
+            'fuzziness': 1,
+            'prefix_length': 1,
+            'max_expansions': 10,
             'query': 'k road'
           }
         }
@@ -103,6 +105,7 @@ module.exports = {
               'type' : 'phrase',
               'boost' : 1,
               'slop' : 3,
+              'fuzziness': 1,
               'cutoff_frequency': 0.01,
               'query' : 'k road'
             }

--- a/test/unit/query/autocomplete_token_matching_permutations.js
+++ b/test/unit/query/autocomplete_token_matching_permutations.js
@@ -16,7 +16,7 @@ const defaults = new peliasQuery.Vars( require('../../../query/autocomplete_defa
 // additional views
 const views = {
   ngrams_last_token_only:     require('../../../query/view/ngrams_last_token_only'),
-  phrase_first_tokens_only:   require('../../../query/view/phrase_first_tokens_only'),
+  phrase_first_tokens_only: require('../../../query/view/phrase_first_tokens_only')(require('../../../query/view/fuzzy_match')),
   pop_subquery:               require('../../../query/view/pop_subquery'),
   boost_exact_matches:        require('../../../query/view/boost_exact_matches')
 };

--- a/test/unit/query/autocomplete_with_custom_boosts.js
+++ b/test/unit/query/autocomplete_with_custom_boosts.js
@@ -40,7 +40,7 @@ module.exports.tests.query = function(test, common) {
 
     const actual_query = JSON.parse( JSON.stringify( autocomplete_query_module(clean) ) );
 
-    t.deepEqual(actual_query, expected_query, 'query as expected');
+    t.deepEqual(actual_query, expected_query, 'autocomplete_custom_boosts');
     t.pass();
     t.end();
   });


### PR DESCRIPTION
This PR is WIP and I wouldn't suggest merging it as-is, it's open for testing, discussion and feedback.

One confusing and under-documented feature of the elasticsearch `match` query is that it supports `type: phrase` and also `fuzziness: *` but not both at the same time 🤷‍♀️ 

There are unfortunately no warnings about this, which is what's contributing to the confusion, it might be the same for `cutoff_frequency` and `phrase`.

So this PR simply rewrites the top `MUST` query for most queries generated for autocomplete to remove `phrase` and enable `fuzziness`.

I've chosen conservative values for `fuzziness` in order to avoid increasing the CPU usage significantly, a `fuzziness` of 1 means that the Levenshtein edit distance is 1, so a single character can be added, removed or replaced.

The `prefix_length` is set to 1, this means that the first character is not considered for edits, the default is 0 which would obviously generate a lot more permutations and require a lot more CPU, the tradeoff here is that if someone mistypes the first letter then they're doomed from the get-go.

Lastly the `max_expansions` is set to 10, I'm not 100% sure what the correct setting for this should be so I again chose something conservative, my understanding of this is that only a maximum of 10 tokens in the index will be used to generate an 'OR' type condition.

Things I would like to change before merging:
- Clean up the queries, they are becoming confusing and we might be able to simplify them
- The other `phrase` queries now have `'fuzziness': 1` which, as I explained above, will do nothing and only serve to confuse.
- Test the performance implications of running this on every keypress for a global index.