### PR TITLE
feat(deps): Remove `tmp` devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "proxyquire": "^2.0.0",
     "source-map": "^0.7.0",
     "tap-dot": "^2.0.0",
-    "tape": "^4.5.1",
-    "tmp": "^0.0.33"
+    "tape": "^4.5.1"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
This package hasn't been used since 33341b7c998508c2c5a48399918eabb148060db5, which used it for testing the interpolation service interface. That interface was later removed in favor of the [microservice-wrapper](https://github.com/pelias/microservice-wrapper).

Closes https://github.com/pelias/api/pull/1266