### PR TITLE
feat(deps): Remove unused source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "pelias-mock-logger": "^1.3.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
-    "source-map": "^0.7.0",
     "tap-dot": "^2.0.0",
     "tape": "^4.5.1"
   },


### PR DESCRIPTION
Like https://github.com/pelias/api/pull/1269, this dev dependency was not being used.

We added it long ago to try to fix issues with resolving NPM dependencies, but those issues haven't been seen recently.