### PR TITLE
Allow ?categories= and ?categories=true as an indicator to return cat…

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -94,7 +94,7 @@ function generateQuery( clean ){
   }
 
   // categories
-  if (clean.categories) {
+  if (clean.categories && !check.boolean(clean.categories)) {
     vs.var('input:categories', clean.categories);
   }
 

--- a/query/search.js
+++ b/query/search.js
@@ -48,7 +48,7 @@ function generateQuery( clean ){
   }
 
   // categories
-  if (clean.categories) {
+  if (clean.categories && !check.boolean(clean.categories)) {
     vs.var('input:categories', clean.categories);
   }
 

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -75,7 +75,7 @@ function generateQuery( clean ){
   }
 
   // categories
-  if (clean.categories) {
+  if (clean.categories && !check.boolean(clean.categories)) {
     vs.var('input:categories', clean.categories);
   }
 

--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -2,7 +2,6 @@ var check = require('check-types');
 var categoryTaxonomy = require('pelias-categories');
 
 var ERRORS = {
-  empty: 'Categories parameter cannot be left blank. See documentation of service for valid options.',
   invalid: 'Invalid categories parameter value(s). See documentation of service for valid options.'
 };
 
@@ -19,8 +18,8 @@ function _sanitize( raw, clean, categories ) {
     return messages;
   }
 
-  if (!check.nonEmptyString(raw.categories)) {
-    messages.errors.push(ERRORS.empty);
+  if (!check.nonEmptyString(raw.categories) || raw.categories === 'true') {
+    clean.categories = true;
     return messages;
   }
 

--- a/test/unit/sanitizer/_categories.js
+++ b/test/unit/sanitizer/_categories.js
@@ -25,13 +25,10 @@ module.exports.tests.no_categories = function(test, common) {
       clean: { }
     };
 
-    var expected_error = 'Categories parameter cannot be left blank. See documentation of service for valid options.';
-
     var messages = sanitizer.sanitize(req.query, req.clean);
 
-    t.equal(req.clean.categories, undefined, 'no categories should be defined');
-    t.deepEqual(messages.errors.length, 1, 'error returned');
-    t.deepEqual(messages.errors[0], expected_error, 'error returned');
+    t.equal(req.clean.categories, true, 'empty parameter should return true');
+    t.deepEqual(messages.errors.length, 0, 'error returned');
     t.deepEqual(messages.warnings, [], 'no warnings returned');
     t.end();
   });


### PR DESCRIPTION
This will indicate that categories should be returned in a result, without performing any filter on the categories.

Allowed:
?categories
?categories=
?categories=true