### PR TITLE
categories updates

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -54,6 +54,7 @@ query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.boundary_rect );
 query.filter( peliasQuery.view.boundary_country );
+query.filter( peliasQuery.view.categories );
 query.filter( peliasQuery.view.boundary_gid );
 
 // --------------------------------
@@ -133,6 +134,11 @@ function generateQuery( clean ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });
+  }
+
+  // categories
+  if (clean.categories && clean.categories.length) {
+    vs.var('input:categories', clean.categories);
   }
 
   // run the address parser

--- a/query/search.js
+++ b/query/search.js
@@ -48,7 +48,7 @@ function generateQuery( clean ){
   }
 
   // categories
-  if (clean.categories) {
+  if (clean.categories && clean.categories.length) {
     vs.var('input:categories', clean.categories);
   }
 

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -75,7 +75,7 @@ function generateQuery( clean ){
   }
 
   // categories
-  if (clean.categories) {
+  if (clean.categories && clean.categories.length) {
     vs.var('input:categories', clean.categories);
   }
 

--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -1,26 +1,19 @@
 var check = require('check-types');
 var categoryTaxonomy = require('pelias-categories');
 
-var ERRORS = {
-  empty: 'Categories parameter cannot be left blank. See documentation of service for valid options.',
-  invalid: 'Invalid categories parameter value(s). See documentation of service for valid options.'
+var WARNINGS = {
+  empty: 'Categories parameter left blank, showing results from all categories.'
 };
 
 // validate inputs, convert types and apply defaults
-function _sanitize( raw, clean, categories ) {
-
+function _sanitize (raw, clean, categories) {
   categories = categories || categoryTaxonomy;
 
   // error & warning messages
-  var messages = {errors: [], warnings: []};
+  var messages = { errors: [], warnings: [] };
 
   // it's not a required parameter, so if it's not provided just move on
   if (!raw.hasOwnProperty('categories')) {
-    return messages;
-  }
-
-  if (!check.nonEmptyString(raw.categories)) {
-    messages.errors.push(ERRORS.empty);
     return messages;
   }
 
@@ -39,17 +32,14 @@ function _sanitize( raw, clean, categories ) {
       });
   } catch (err) {
     // remove everything from the list if there was any error
-    delete clean.categories;
-  }
-
-  if (check.undefined(clean.categories) || check.emptyArray(clean.categories)) {
-    messages.errors.push(ERRORS.invalid);
+    messages.warnings.push(WARNINGS.empty);
+    clean.categories = [];
   }
 
   return messages;
 }
 
-function _expected() {
+function _expected () {
   return [{ name: 'categories' }];
 }
 // export function

--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -19,21 +19,20 @@ function _sanitize (raw, clean, categories) {
 
   // if categories string has been set
   // map input categories to valid format
-  try {
-    clean.categories = raw.categories.split(',')
-      .map(function (cat) {
-        return cat.toLowerCase().trim(); // lowercase inputs
-      })
-      .filter(function (cat) {
-        if (check.nonEmptyString(cat) && categories.isValidCategory(cat)) {
-          return true;
-        }
-        throw new Error('Empty string value');
-      });
-  } catch (err) {
-    // remove everything from the list if there was any error
+  clean.categories = raw.categories.split(',')
+    .map(cat => {
+      return cat.toLowerCase().trim(); // lowercase inputs
+    })
+    .filter(cat => {
+      if (check.nonEmptyString(cat) && categories.isValidCategory(cat)) {
+        return true;
+      }
+      return false;
+    });
+
+  if( !clean.categories.length ){
+    // display a warning that the input was empty
     messages.warnings.push(WARNINGS.empty);
-    clean.categories = [];
   }
 
   return messages;

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -1,0 +1,66 @@
+module.exports = {
+  'query': {
+    'bool': {
+      'must': [{
+        'constant_score': {
+          'query': {
+            'match': {
+              'name.default': {
+                'analyzer': 'peliasQueryPartialToken',
+                'cutoff_frequency': 0.01,
+                'boost': 100,
+                'query': 'test',
+                'type': 'phrase',
+                'operator': 'and',
+                'slop': 3
+              }
+            }
+          }
+        }
+      }],
+      'should': [{
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'popularity',
+              'missing': 1
+            },
+            'weight': 1
+          }]
+        }
+      }, {
+        'function_score': {
+          'query': {
+            'match_all': {}
+          },
+          'max_boost': 20,
+          'score_mode': 'first',
+          'boost_mode': 'replace',
+          'functions': [{
+            'field_value_factor': {
+              'modifier': 'log1p',
+              'field': 'population',
+              'missing': 1
+            },
+            'weight': 3
+          }]
+        }
+      }],
+      'filter': [{
+        'terms': {
+          'category': ['retail', 'food']
+        }
+      }]
+    }
+  },
+  'sort': ['_score'],
+  'size': 20,
+  'track_scores': true
+};

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -235,6 +235,25 @@ module.exports.tests.query = function(test, common) {
     t.end();
   });
 
+  test('valid categories filter', function (t) {
+    var clean = {
+      text: 'test',
+      tokens: ['test'],
+      tokens_complete: [],
+      tokens_incomplete: ['test'],
+      categories: ['retail', 'food']
+    };
+
+    var query = generate(clean);
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/autocomplete_with_category_filtering');
+
+    t.deepEqual(compiled.type, 'autocomplete', 'query type set');
+    t.deepEqual(compiled.body, expected, 'valid autocomplete query with category filtering');
+    t.end();
+  });
+
   test('single character street address', function(t) {
     var query = generate({
       text: 'k road, laird',

--- a/test/unit/sanitizer/_categories.js
+++ b/test/unit/sanitizer/_categories.js
@@ -54,6 +54,21 @@ module.exports.tests.no_categories = function(test, common) {
     t.deepEqual(messages.warnings[0], expected_warning, 'warning returned');
     t.end();
   });
+
+  test('categories is mix of valid categories and empty strings', function (t) {
+    var req = {
+      query: {
+        categories: ',food,'
+      },
+      clean: {}
+    };
+
+    var messages = sanitizer.sanitize(req.query, req.clean);
+    t.deepEqual(req.clean.categories, ['food'], 'junk trimmed');
+    t.deepEqual(messages.errors, [], 'no errors returned');
+    t.deepEqual(messages.warnings, [], 'no warnings returned');
+    t.end();
+  });
 };
 
 module.exports.tests.valid_categories = function(test, common) {

--- a/test/unit/sanitizer/_categories.js
+++ b/test/unit/sanitizer/_categories.js
@@ -25,14 +25,14 @@ module.exports.tests.no_categories = function(test, common) {
       clean: { }
     };
 
-    var expected_error = 'Categories parameter cannot be left blank. See documentation of service for valid options.';
+    var expected_warning = 'Categories parameter left blank, showing results from all categories.';
 
     var messages = sanitizer.sanitize(req.query, req.clean);
 
-    t.equal(req.clean.categories, undefined, 'no categories should be defined');
-    t.deepEqual(messages.errors.length, 1, 'error returned');
-    t.deepEqual(messages.errors[0], expected_error, 'error returned');
-    t.deepEqual(messages.warnings, [], 'no warnings returned');
+    t.deepEqual(req.clean.categories, [], 'empty categories array should be defined');
+    t.deepEqual(messages.errors, [], 'no errors returned');
+    t.deepEqual(messages.warnings.length, 1, 'warning returned');
+    t.deepEqual(messages.warnings[0], expected_warning, 'warning returned');
     t.end();
   });
 
@@ -44,14 +44,14 @@ module.exports.tests.no_categories = function(test, common) {
       clean: { }
     };
 
-    var expected_error = 'Invalid categories parameter value(s). See documentation of service for valid options.';
+    var expected_warning = 'Categories parameter left blank, showing results from all categories.';
 
     var messages = sanitizer.sanitize(req.query, req.clean);
 
-    t.equal(req.clean.categories, undefined, 'no categories should be defined');
-    t.deepEqual(messages.errors.length, 1, 'error returned');
-    t.deepEqual(messages.errors[0], expected_error, 'error returned');
-    t.deepEqual(messages.warnings, [], 'no warnings returned');
+    t.deepEqual(req.clean.categories, [], 'empty categories array should be defined');
+    t.deepEqual(messages.errors, [], 'no errors returned');
+    t.deepEqual(messages.warnings.length, 1, 'warning returned');
+    t.deepEqual(messages.warnings[0], expected_warning, 'warning returned');
     t.end();
   });
 };
@@ -124,16 +124,16 @@ module.exports.tests.invalid_categories = function(test, common) {
       clean: { }
     };
     var expected_messages = {
-      errors: [
-        'Invalid categories parameter value(s). See documentation of service for valid options.'
-      ],
-      warnings: []
+      errors: [],
+      warnings: [
+        'Categories parameter left blank, showing results from all categories.'
+      ]
     };
 
     var messages = sanitizer.sanitize(req.query, req.clean, validCategories);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
-    t.equal(req.clean.categories, undefined, 'clean.categories should remain empty');
+    t.deepEqual(req.clean.categories, [], 'empty categories array should be defined');
     t.end();
   });
 
@@ -145,16 +145,16 @@ module.exports.tests.invalid_categories = function(test, common) {
       clean: { }
     };
     var expected_messages = {
-      errors: [
-        'Invalid categories parameter value(s). See documentation of service for valid options.'
-      ],
-      warnings: []
+      errors: [],
+      warnings: [
+        'Categories parameter left blank, showing results from all categories.'
+      ]
     };
 
     var messages = sanitizer.sanitize(req.query, req.clean, validCategories);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
-    t.equal(req.clean.categories, undefined, 'clean.categories should remain empty');
+    t.deepEqual(req.clean.categories, [], 'empty categories array should be defined');
     t.end();
   });
 


### PR DESCRIPTION
This PR actions some of the feedback received in https://github.com/pelias/api/pull/1272 and https://github.com/pelias/api/issues/1271

The current status of `categories` is still that they are in open-alpha, use at your own risk.
Having said that, there are a couple of minor issues with the existing implementation which need to be addressed:

- enable filter for autocomplete (we were allowing the param to exist but not using it in the queries)
- reveal categories in geojson even when categories param is blank (but not when unset)

@NickStallman I would suggest this we merge this PR instead of https://github.com/pelias/api/pull/1272?

The reasons being that this also enables filtering for `autocomplete` and it works slightly differently in that any time `?categories` is included in the query string then they will be exposed in the `geojson`, it does not support the magic category `true` as I felt that might be a confusing convention to adopt.

resolves https://github.com/pelias/api/issues/1271
closes https://github.com/pelias/api/pull/1272 