### PR TITLE
Support for multi `boundary.country` query parameter

### DIFF
--- a/controller/placeholder.js
+++ b/controller/placeholder.js
@@ -77,7 +77,7 @@ function getLayersFilter(clean) {
 // return true if the hierarchy does not have a country.abbr
 // OR hierarchy country.abbr matches boundary.country
 function matchesBoundaryCountry(boundaryCountry, hierarchy) {
-  return !boundaryCountry || _.get(hierarchy, 'country.abbr') === boundaryCountry;
+  return !boundaryCountry || boundaryCountry.some(countryCode => _.get(hierarchy, 'country.abbr') === countryCode);
 }
 
 // return true if the result does not have a lineage

--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -179,9 +179,9 @@ function generateQuery( clean, res ){
   }
 
   // boundary country
-  if( check.string(clean['boundary.country']) ){
+  if( check.nonEmptyArray(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country']
+      'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -79,9 +79,9 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.string(clean['boundary.country']) ){
+  if( check.nonEmptyArray(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country']
+      'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -80,9 +80,9 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.string(clean['boundary.country']) ){
+  if( check.nonEmptyArray(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country']
+      'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/search.js
+++ b/query/search.js
@@ -96,9 +96,9 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.string(clean['boundary.country']) ){
+  if( check.nonEmptyArray(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country']
+      'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -123,9 +123,9 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.string(clean['boundary.country']) ){
+  if( check.nonEmptyArray(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country']
+      'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/structured_geocoding.js
+++ b/query/structured_geocoding.js
@@ -85,9 +85,9 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.string(clean['boundary.country']) ){
+  if( check.nonEmptyArray(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country']
+      'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 

--- a/sanitizer/_boundary_country.js
+++ b/sanitizer/_boundary_country.js
@@ -3,30 +3,39 @@ const iso3166 = require('../helper/iso3166');
 
 function _sanitize(raw, clean) {
   // error & warning messages
-  var messages = { errors: [], warnings: [] };
+  const messages = { errors: [], warnings: [] };
 
   // target input param
-  var country = raw['boundary.country'];
+  let countries = raw['boundary.country'];
 
   // param 'boundary.country' is optional and should not
   // error when simply not set by the user
-  if (check.assigned(country)){
+  if (check.assigned(countries)) {
 
     // must be valid string
-    if (!check.nonEmptyString(country)) {
+    if (!check.nonEmptyString(countries)) {
       messages.errors.push('boundary.country is not a string');
-    }
+    } else {
+      // support for multi countries
+      countries = countries.split(',').filter(check.nonEmptyString);
+      const invalidIsoCodes = countries.filter(country => !containsIsoCode(country));
 
-    // must be a valid ISO 3166 code
-    else if (!containsIsoCode(country)) {
-      messages.errors.push(country + ' is not a valid ISO2/ISO3 country code');
-    }
+      // country list must contains at least one element
+      if (check.emptyArray(countries)) {
+        messages.errors.push('boundary.country is empty');
+      }
 
-    // valid ISO 3166 country code, set alpha3 code on 'clean.boundary.country'
-    else {
-      // the only way for boundary.country to be assigned is if input is
-      //  a string and a known ISO2 or ISO3
-      clean['boundary.country'] = iso3166.iso3Code(country);
+      // must be a valid ISO 3166 code
+      else if (check.nonEmptyArray(invalidIsoCodes)) {
+        invalidIsoCodes.forEach(country => messages.errors.push(country + ' is not a valid ISO2/ISO3 country code'));
+      }
+
+      // valid ISO 3166 country code, set alpha3 code on 'clean.boundary.country'
+      else {
+        // the only way for boundary.country to be assigned is if input is
+        //  a string and a known ISO2 or ISO3
+        clean['boundary.country'] = countries.map(country => iso3166.iso3Code(country));
+      }
     }
   }
 

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -1551,7 +1551,7 @@ module.exports.tests.result_filtering = (test, common) => {
       t.deepEqual(req, {
         param1: 'param1 value',
         clean: {
-          'boundary.country': 'ABC'
+          'boundary.country': ['ABC']
         }
       });
 
@@ -1621,7 +1621,7 @@ module.exports.tests.result_filtering = (test, common) => {
     const req = {
       param1: 'param1 value',
       clean: {
-        'boundary.country': 'ABC'
+        'boundary.country': ['ABC']
       }
     };
     const res = { };
@@ -1693,7 +1693,7 @@ module.exports.tests.result_filtering = (test, common) => {
       t.deepEqual(req, {
         param1: 'param1 value',
         clean: {
-          'boundary.country': 'ABC'
+          'boundary.country': ['ABC']
         }
       });
 
@@ -1771,7 +1771,7 @@ module.exports.tests.result_filtering = (test, common) => {
     const req = {
       param1: 'param1 value',
       clean: {
-        'boundary.country': 'ABC'
+        'boundary.country': ['ABC']
       }
     };
     const res = { };

--- a/test/unit/fixture/search_boundary_country_multi.js
+++ b/test/unit/fixture/search_boundary_country_multi.js
@@ -1,0 +1,79 @@
+module.exports = {
+  'query': {
+    'function_score': {
+      'query': {
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.street',
+                'boost': 5,
+                'must': [
+                  {
+                    'match_phrase': {
+                      'address_parts.street': 'street value'
+                    }
+                  }
+                ],
+                'should': [],
+                'filter': {
+                  'term': {
+                    'layer': 'street'
+                  }
+                }
+              }
+            }
+          ],
+          'filter': {
+            'bool': {
+              'must': [
+                {
+                  'match': {
+                    'parent.country_a': {
+                      'analyzer': 'standard',
+                      'query': 'ABC DEF'
+                    }
+                  }
+                },
+                {
+                  'terms': {
+                    'layer': [
+                      'test'
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      'max_boost': 20,
+      'functions': [
+        {
+          'field_value_factor': {
+            'modifier': 'log1p',
+            'field': 'popularity',
+            'missing': 1
+          },
+          'weight': 1
+        },
+        {
+          'field_value_factor': {
+            'modifier': 'log1p',
+            'field': 'population',
+            'missing': 1
+          },
+          'weight': 2
+        }
+      ],
+      'score_mode': 'avg',
+      'boost_mode': 'multiply'
+    }
+  },
+  'size': 10,
+  'track_scores': true,
+  'sort': [
+    '_score'
+  ]
+};

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -374,7 +374,7 @@ module.exports.tests.boundary_filters = (test, common) => {
         number: 'housenumber value',
         street: 'street value'
       },
-      'boundary.country': 'boundary.country value'
+      'boundary.country': ['boundary.country', 'value']
     };
     const res = {};
 

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -281,7 +281,7 @@ module.exports.tests.query = function(test, common) {
       tokens: ['test'],
       tokens_complete: [],
       tokens_incomplete: ['test'],
-      'boundary.country': 'ABC'
+      'boundary.country': ['ABC']
     });
 
     var compiled = JSON.parse( JSON.stringify( query ) );

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -462,7 +462,7 @@ module.exports.tests.boundary_country = (test, common) => {
 
   test('string boundary.country should set boundary:country', t => {
     const clean = {
-      'boundary.country': 'boundary country value'
+      'boundary.country': ['boundary country', 'value']
     };
 
     const query = proxyquire('../../../query/reverse', {

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -172,13 +172,33 @@ module.exports.tests.query = function(test, common) {
       },
       text: 'test', querySize: 10,
       layers: ['test'],
-      'boundary.country': 'ABC'
+      'boundary.country': ['ABC']
     };
 
     var query = generate(clean);
 
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_boundary_country');
+
+    t.deepEqual(compiled.type, 'search_fallback', 'query type set');
+    t.deepEqual(compiled.body, expected, 'search: valid boundary.country query');
+    t.end();
+  });
+
+  test('valid multi boundary.country search', function(t) {
+    var clean = {
+      parsed_text: {
+        street: 'street value'
+      },
+      text: 'test', querySize: 10,
+      layers: ['test'],
+      'boundary.country': ['ABC', 'DEF']
+    };
+
+    var query = generate(clean);
+
+    var compiled = JSON.parse( JSON.stringify( query ) );
+    var expected = require('../fixture/search_boundary_country_multi');
 
     t.deepEqual(compiled.type, 'search_fallback', 'query type set');
     t.deepEqual(compiled.body, expected, 'search: valid boundary.country query');

--- a/test/unit/query/search_original.js
+++ b/test/unit/query/search_original.js
@@ -165,7 +165,7 @@ module.exports.tests.query = function(test, common) {
     var query = generate({
       text: 'test', querySize: 10,
       layers: ['test'],
-      'boundary.country': 'ABC'
+      'boundary.country': ['ABC']
     });
 
     var compiled = JSON.parse( JSON.stringify( query ) );

--- a/test/unit/query/structured_geocoding.js
+++ b/test/unit/query/structured_geocoding.js
@@ -575,7 +575,7 @@ module.exports.tests.boundary_country = (test, common) => {
       text: 'text value',
       sources: 'sources value',
       layers: 'layers value',
-      'boundary.country': 'boundary country value'
+      'boundary.country': ['boundary country', 'value']
     };
 
     const query = proxyquire('../../../query/structured_geocoding', {

--- a/test/unit/sanitizer/_boundary_country.js
+++ b/test/unit/sanitizer/_boundary_country.js
@@ -34,7 +34,7 @@ module.exports.tests.sanitize_boundary_country = function(test, common) {
     var raw = { 'boundary.country': 'aq' };
     var clean = {};
     var errorsAndWarnings = sanitizer.sanitize(raw, clean);
-    t.equals(clean['boundary.country'], 'ATA', 'should be uppercased ISO3');
+    t.deepEquals(clean['boundary.country'], ['ATA'], 'should be uppercased ISO3');
     t.deepEquals(errorsAndWarnings, { errors: [], warnings: [] }, 'no warnings or errors');
     t.end();
   });
@@ -43,7 +43,7 @@ module.exports.tests.sanitize_boundary_country = function(test, common) {
     var raw = { 'boundary.country': 'aTa' };
     var clean = {};
     var errorsAndWarnings = sanitizer.sanitize(raw, clean);
-    t.equals(clean['boundary.country'], 'ATA', 'should be uppercased ISO3');
+    t.deepEquals(clean['boundary.country'], ['ATA'], 'should be uppercased ISO3');
     t.deepEquals(errorsAndWarnings, { errors: [], warnings: [] }, 'no warnings or errors');
     t.end();
   });


### PR DESCRIPTION
Hi team!
I want to add a small feature : `boundary.country` for several countries.

## Background

I think this can be useful for companies working in several specific countries (eg all European countries/all French-speaking countries/USA and Canada only).

## How to use

It's the same query parameter `boundary.country`. If you want more than one country, add the other after a comma like this `boundary.country=FR,DE`.

There is no limit in the number of countries. I do not know if there will be performance issues if we put too many countries.