### PR TITLE
minor edits to text_parser_addressit

### DIFF
--- a/query/text_parser_addressit.js
+++ b/query/text_parser_addressit.js
@@ -23,8 +23,9 @@ function addParsedVariablesToQueryVariables( clean, vs ){
     vs.var( 'input:name', clean.parsed_text.number + ' ' + clean.parsed_text.street );
   }
 
-  // ?
-  else if( clean.parsed_text.admin_parts ) {
+  // if the 'naive parser' was used, input is equal to 'name'
+  // see: 'sanitizer/_text_addressit.js' function 'naive'
+  else if (clean.parsed_text.admin_parts && clean.parsed_text.name ) {
     vs.var( 'input:name', clean.parsed_text.name );
   }
 


### PR DESCRIPTION
add code comments and sanity check to text_parser_addressit

added the code comment to explain what this code does in place of the prior comment '?' left by me when I couldn't figure it out ;P
looking at the code, `clean.parsed_text.name` should always be present and non-empty but it's nice to check anyway.