### PR TITLE
enable cutoff_frequency for multi_match queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^5.8.0",
-    "pelias-query": "^9.9.0",
+    "pelias-query": "^9.10.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "retry": "^0.12.0",

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -52,6 +52,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:postcode:boost': 2000,
   'address:postcode:cutoff_frequency': 0.01,
 
+  // generic multi_match cutoff_frequency
+  'multi_match:cutoff_frequency': 0.01,
+
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a.ngram',
   'admin:country_a:boost': 1000,

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -52,6 +52,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:postcode:boost': 20,
   'address:postcode:cutoff_frequency': 0.01,
 
+  // generic multi_match cutoff_frequency
+  'multi_match:cutoff_frequency': 0.01,
+
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a',
   'admin:country_a:boost': 1,

--- a/test/unit/fixture/search_full_address_original.js
+++ b/test/unit/fixture/search_full_address_original.js
@@ -135,7 +135,8 @@ module.exports = {
               'parent.region_a^1'
             ],
             'query': 'new york',
-            'analyzer': 'peliasAdmin'
+            'analyzer': 'peliasAdmin',
+            'cutoff_frequency': 0.01
         }
       }],
       'filter': [

--- a/test/unit/fixture/search_partial_address_original.js
+++ b/test/unit/fixture/search_partial_address_original.js
@@ -98,7 +98,8 @@ module.exports = {
               'parent.region_a^1'
             ],
             'query': 'new york',
-            'analyzer': 'peliasAdmin'
+            'analyzer': 'peliasAdmin',
+            'cutoff_frequency': 0.01
         }
       }],
       'filter': [

--- a/test/unit/fixture/search_regions_address_original.js
+++ b/test/unit/fixture/search_regions_address_original.js
@@ -116,7 +116,8 @@ module.exports = {
               'parent.region_a^1'
             ],
             'query': 'manhattan',
-            'analyzer': 'peliasAdmin'
+            'analyzer': 'peliasAdmin',
+            'cutoff_frequency': 0.01
         }
       }],
       'filter': [


### PR DESCRIPTION
enable `cutoff_frequency` for `multi_match` queries