### PR TITLE
Allow postalcode + admin area queries

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -122,7 +122,7 @@ function generateQuery( clean ){
 }
 
 function getQuery(vs) {
-  if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithCountry(vs)) {
+  if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithAdmin(vs)) {
     return {
       type: 'search_fallback',
       body: fallbackQuery.render(vs)
@@ -166,21 +166,18 @@ function isPostalCodeOnly(vs) {
 
   return allowedFields.every(isSet) &&
     !disallowedFields.some(isSet);
-
 }
 
 
-function isPostalCodeWithCountry(vs) {
+function isPostalCodeWithAdmin(vs) {
     var isSet = (layer) => {
         return vs.isset(`input:${layer}`);
     };
 
-    var allowedFields = ['postcode', 'country'];
-    var disallowedFields = ['query', 'category', 'housenumber', 'street', 'locality',
-                          'neighbourhood', 'borough', 'county', 'region'];
+    var disallowedFields = ['query', 'category', 'housenumber', 'street'];
 
-    return allowedFields.every(isSet) &&
-        !disallowedFields.some(isSet);
+    return isSet('postcode') &&
+      !disallowedFields.some(isSet);
 }
 
 module.exports = generateQuery;

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -396,7 +396,8 @@ module.exports.tests.city_state = function(test, common) {
 
     var query = generate(clean);
 
-    t.equals(query, undefined, 'should have returned undefined');
+    // query will be similar to other postalcode or admin queries, It's not worth creating another fixture
+    t.equals(typeof query, 'object', 'should return a query');
     t.end();
 
   });
@@ -533,22 +534,6 @@ module.exports.tests.city_country = function(test, common) {
         city: 'city value',
         country: 'country value',
         borough: 'borough value'
-      }
-    };
-
-    var query = generate(clean);
-
-    t.equals(query, undefined, 'should have returned undefined');
-    t.end();
-
-  });
-
-  test('city/country with postalcode should return undefined', function(t) {
-    var clean = {
-      parsed_text: {
-        city: 'city value',
-        country: 'country value',
-        postalcode: 'postalcode value'
       }
     };
 


### PR DESCRIPTION
We currently have very strict logic for which combinations of inputs the fallback search query supports. Any input that is out of alignment with those expectations will be deferred to the lower quality addressit query system.

This changes some of that expectation logic. Where previously it ignored inputs with a postcode and any other field, now a postcode in combination with any administrative fields are allowed.

This is so, for example, a user can query for '90210, California' and hopefully see postalcodes called 90210 that are in California first in the results.

Obviously postalcodes are complex so there might be a few cases that don't work, but it should help. As a bonus, it will remove fragility and complexity from our query generation.