### PR TITLE
fix(search_with_ids): Skip query when not address related

### DIFF
--- a/controller/predicates/is_request_layers_any_address_related.js
+++ b/controller/predicates/is_request_layers_any_address_related.js
@@ -1,0 +1,30 @@
+const _ = require('lodash');
+const Debug = require('../../helper/debug');
+const debugLog = new Debug('controller:predicates:is_request_layers_any_address_related');
+const stackTraceLine = require('../../helper/stackTraceLine');
+
+const admin_placetypes = require('../../helper/placeTypes');
+
+// return true if any layers allowed by the query are related to an address query
+// this includes address, street, and any admin layers, but NOT venue and custom layers
+module.exports = (req, res) => {
+  const address_related_layers = admin_placetypes.concat(['address', 'street']);
+
+  const request_layers = _.get(req, 'clean.layers', []);
+  let result;
+
+  // handle case where no layers are specified
+  if (request_layers.length === 0) {
+    result = true;
+  } else {
+    const request_address_related_layers = _.intersection(request_layers, address_related_layers);
+    result = request_address_related_layers.length > 0;
+  }
+
+  debugLog.push(req, () => ({
+    reply: result,
+    stack_trace: stackTraceLine()
+  }));
+
+  return result;
+};

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -78,6 +78,7 @@ const hasResultsAtLayers = require('../controller/predicates/has_results_at_laye
 const isAddressItParse = require('../controller/predicates/is_addressit_parse');
 const hasRequestCategories = require('../controller/predicates/has_request_parameter')('categories');
 const isOnlyNonAdminLayers = require('../controller/predicates/is_only_non_admin_layers');
+const isRequestLayersAnyAddressRelated = require('../controller/predicates/is_request_layers_any_address_related');
 // this can probably be more generalized
 const isRequestSourcesOnlyWhosOnFirst = require('../controller/predicates/is_request_sources_only_whosonfirst');
 const isRequestSourcesIncludesWhosOnFirst = require('../controller/predicates/is_request_sources_includes_whosonfirst');
@@ -186,6 +187,7 @@ function addRoutes(app, peliasConfig) {
   const placeholderIdsLookupShouldExecute = all(
     not(hasResponseDataOrRequestErrors),
     isPlaceholderServiceEnabled,
+    isRequestLayersAnyAddressRelated,
     // check clean.parsed_text for several conditions that must all be true
     all(
       // run placeholder if clean.parsed_text has 'street'
@@ -201,6 +203,8 @@ function addRoutes(app, peliasConfig) {
     not(hasRequestErrors),
     // don't search-with-ids if there's a query or category
     not(hasParsedTextProperties.any('query', 'category')),
+    // at least one layer allowed by the query params must be related to addresses
+    isRequestLayersAnyAddressRelated,
     // there must be a street
     hasParsedTextProperties.any('street')
   );

--- a/test/unit/controller/predicates/is_request_layers_any_address_related.js
+++ b/test/unit/controller/predicates/is_request_layers_any_address_related.js
@@ -1,0 +1,53 @@
+const _ = require('lodash');
+const is_request_layers_any_address_related = require('../../../../controller/predicates/is_request_layers_any_address_related');
+
+module.exports.tests = {};
+
+module.exports.tests.true_conditions = (test, common) => {
+  test('empty layers (none specified) should return true', t => {
+    const req = {};
+
+    t.ok(is_request_layers_any_address_related(req));
+    t.end();
+  });
+
+  test('admin layers only should return true', t => {
+    const req = { clean: { layers: ['locality', 'county', 'country'] } };
+
+    t.ok(is_request_layers_any_address_related(req));
+    t.end();
+  });
+
+  test('street and admin layers', t => {
+    const req = { clean: { layers: ['street', 'locality', 'country'] } };
+
+    t.ok(is_request_layers_any_address_related(req));
+    t.end();
+  });
+};
+
+module.exports.tests.false_conditions = (test, common) => {
+  test('venue layers only should return false', t => {
+    const req = { clean: { layers: ['venue'] } };
+
+    t.notOk(is_request_layers_any_address_related(req));
+    t.end();
+  });
+
+  test('custom layer only should return false', t => {
+    const req = { clean: { layers: ['custom'] } };
+
+    t.notOk(is_request_layers_any_address_related(req));
+    t.end();
+  });
+};
+
+module.exports.all = (tape, common) => {
+  function test(name, testFunction) {
+    return tape(`is_request_layers_any_address_related ${name}`, testFunction);
+  }
+
+  for( const testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -29,6 +29,7 @@ var tests = [
   require('./controller/predicates/is_admin_only_analysis'),
   require('./controller/predicates/is_coarse_reverse'),
   require('./controller/predicates/is_only_non_admin_layers'),
+  require('./controller/predicates/is_request_layers_any_address_related'),
   require('./controller/predicates/is_request_sources_includes_whosonfirst'),
   require('./controller/predicates/is_request_sources_only_whosonfirst'),
   require('./controller/predicates/is_request_sources_undefined'),


### PR DESCRIPTION
The search_with_ids query (in some places more accurately referred to as the `address_search_with_ids` query), can really ONLY return addresses or related results such as streets, cities, etc. It will never return venues.

However, if the user passed `layers=venue` as a query param, this query was still executing and if any results were returned, then a non-venue record would be returned as a result.

This PR introduces a concept referred to as "address related" layers; essentially any layer that might be returned y the `address_search_with_ids` query: `address`, `street`, or any administrative layer, but **not** venue or any custom layers.

A new predicate now checks if any "address related" layers are allowed before proceeding with the `address_search_with_ids` query. The query is skipped otherwise, allowing the `addressit` style search query to return venue or custom records.

Discovered while creating a test case for #1301 and https://github.com/pelias/api/pull/1307