### PR TITLE
display population & popularity in geojson when debug flag enabled

### DIFF
--- a/helper/geojsonify_place_details.js
+++ b/helper/geojsonify_place_details.js
@@ -59,6 +59,11 @@ const DETAILS_PROPS = [
   { name: 'category',          type: 'array',     condition: checkCategoryParam }
 ];
 
+const EXTENDED_PROPS = DETAILS_PROPS.concat([
+  { name: 'population', type: 'default' },
+  { name: 'popularity', type: 'default' }
+]);
+
 // returns true IFF source a country_gid property
 function hasCountry(params, source) {
   return source.hasOwnProperty('country_gid');
@@ -77,7 +82,12 @@ function checkCategoryParam(params) {
  * @param {object} dst
  */
 function collectProperties( params, source ) {
-  return DETAILS_PROPS.reduce((result, prop) => {
+  let props = DETAILS_PROPS;
+
+  // extended properties when debugging mode is enabled
+  if (params.enableDebug === true) { props = EXTENDED_PROPS; }
+
+  return props.reduce((result, prop) => {
     // if condition isn't met, don't set the property
     if (_.isFunction(prop.condition) && !prop.condition(params, source)) {
       return result;

--- a/test/unit/helper/geojsonify_place_details.js
+++ b/test/unit/helper/geojsonify_place_details.js
@@ -578,6 +578,55 @@ module.exports.tests.empire_specific = (test, common) => {
 
 };
 
+module.exports.tests.debug_flag = (test, common) => {
+
+  test('debug: no-op when debug flag disabled', t => {
+    const clean = {};
+    const source = { population: 100000, popularity: 1000 };
+    const expected = {};
+    const actual = geojsonify(clean, source);
+    t.deepEqual(actual, expected);
+    t.end();
+  });
+
+  test('debug: population and popularity set', t => {
+    const clean = { enableDebug: true };
+    const source = { population: 100000, popularity: 1000 };
+    const expected = { population: 100000, popularity: 1000 };
+    const actual = geojsonify(clean, source);
+    t.deepEqual(actual, expected);
+    t.end();
+  });
+
+  test('debug: only population set', t => {
+    const clean = { enableDebug: true };
+    const source = { population: 100000 };
+    const expected = { population: 100000 };
+    const actual = geojsonify(clean, source);
+    t.deepEqual(actual, expected);
+    t.end();
+  });
+
+  test('debug: only popularity set', t => {
+    const clean = { enableDebug: true };
+    const source = { popularity: 1000 };
+    const expected = { popularity: 1000 };
+    const actual = geojsonify(clean, source);
+    t.deepEqual(actual, expected);
+    t.end();
+  });
+
+  test('debug: neither property set', t => {
+    const clean = { enableDebug: true };
+    const source = {};
+    const expected = {};
+    const actual = geojsonify(clean, source);
+    t.deepEqual(actual, expected);
+    t.end();
+  });
+
+};
+
 module.exports.all = (tape, common) => {
 
   function test(name, testFunction) {


### PR DESCRIPTION
as per the title, this PR allows developers to view the `population` and `popularity` information when the `?debug=true` param is enabled.