### PR TITLE
limit max text length to 140 characters

### DIFF
--- a/sanitizer/_text.js
+++ b/sanitizer/_text.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const MAX_TEXT_LENGTH = 140;
 
 // ref: https://en.wikipedia.org/wiki/Quotation_mark
 const QUOTES = `"'«»‘’‚‛“”„‟‹›⹂「」『』〝〞〟﹁﹂﹃﹄＂＇｢｣`;
@@ -10,11 +11,15 @@ function _sanitize( raw, clean ){
   const messages = { errors: [], warnings: [] };
 
   // invalid input 'text'
-  const text =  _.trim( _.trim( raw.text ), QUOTES );
+  let text =  _.trim( _.trim( raw.text ), QUOTES );
 
   if( !_.isString(text) || _.isEmpty(text) ){
-    messages.errors.push('invalid param \'text\': text length, must be >0');
+    messages.errors.push(`invalid param 'text': text length, must be >0`);
   } else {
+    if( text.length > MAX_TEXT_LENGTH ){
+      messages.warnings.push(`param 'text' truncated to ${MAX_TEXT_LENGTH} characters`);
+      text = text.substring(0, MAX_TEXT_LENGTH);
+    }
     clean.text = text;
   }
 

--- a/test/unit/sanitizer/_text.js
+++ b/test/unit/sanitizer/_text.js
@@ -138,6 +138,22 @@ module.exports.tests.text_parser = function(test, common) {
     t.deepEquals(messages.warnings, [], 'no warnings');
     t.end();
   });
+
+  test('should truncate very long text inputs', (t) => {
+    const raw = { text: `
+Sometimes we make the process more complicated than we need to.
+We will never make a journey of a thousand miles by fretting about 
+how long it will take or how hard it will be.
+We make the journey by taking each day step by step and then repeating 
+it again and again until we reach our destination.` };
+    const clean = {};
+    const messages = sanitizer.sanitize(raw, clean);
+
+    t.equals(clean.text.length, 140);
+    t.deepEquals(messages.errors, [], 'no errors');
+    t.deepEquals(messages.warnings, [`param 'text' truncated to 140 characters`]);
+    t.end();
+  });
 };
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
This PR limits the `?text=` parameter to 140 characters in length, truncating it and emitting a warning if it is longer.

I also considered returning an error here but on reflection the warning and truncation is a nicer user experience.

Note: this is only for `search` at this stage, it doesn't include `autocomplete` which is in transition at the moment (although we should do this for autocomplete too).

