### PR TITLE
Use a consistent name for the final search query

### DIFF
--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -29,7 +29,7 @@ function computeScores(req, res, next) {
   // do nothing if no result data set or if query is not of the original variety
   if (check.undefined(req.clean) || check.undefined(res) ||
       check.undefined(res.data) || check.undefined(res.meta) ||
-      res.meta.query_type !== 'search_original') {
+      res.meta.query_type !== 'search_addressit') {
     return next();
   }
 

--- a/query/search_addressit.js
+++ b/query/search_addressit.js
@@ -142,7 +142,7 @@ function generateQuery( clean ){
   }
 
   return {
-    type: 'search_original',
+    type: 'search_addressit',
     body: query.render(vs)
   };
 }

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -38,7 +38,7 @@ var controllers = {
 
 var queries = {
   cascading_fallback: require('../query/search'),
-  very_old_prod: require('../query/search_original'),
+  search_addressit: require('../query/search_addressit'),
   structured_geocoding: require('../query/structured_geocoding'),
   reverse: require('../query/reverse'),
   autocomplete: require('../query/autocomplete'),
@@ -230,8 +230,8 @@ function addRoutes(app, peliasConfig) {
     not(hasResponseData)
   );
 
-  // call very old prod query if addressit was the parser
-  const oldProdQueryShouldExecute = all(
+  // call search addressit query if addressit was the parser
+  const searchAddressitShouldExecute = all(
     not(hasRequestErrors),
     isAddressItParse
   );
@@ -288,11 +288,11 @@ function addRoutes(app, peliasConfig) {
       controllers.libpostal(libpostalService, libpostalShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderGeodisambiguationShouldExecute),
       controllers.placeholder(placeholderService, geometricFiltersApply, placeholderIdsLookupShouldExecute),
-      // try 3 different query types: address search using ids, cascading fallback, addressit(very_old_prod)
+      // try 3 different query types: address search using ids, cascading fallback, addressit
       controllers.search(peliasConfig.api, esclient, queries.address_using_ids, searchWithIdsShouldExecute),
       controllers.search(peliasConfig.api, esclient, queries.cascading_fallback, fallbackQueryShouldExecute),
       sanitizers.defer_to_addressit(shouldDeferToAddressIt), //run additional sanitizers needed for addressit parser
-      controllers.search(peliasConfig.api, esclient, queries.very_old_prod, oldProdQueryShouldExecute),
+      controllers.search(peliasConfig.api, esclient, queries.search_addressit, searchAddressitShouldExecute),
       postProc.trimByGranularity(),
       postProc.distances('focus.point.'),
       postProc.confidenceScores(peliasConfig.api),

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -1,5 +1,5 @@
 {
-  "type": "search_original",
+  "type": "search_addressit",
   "body": {
     "query": {
       "bool": {

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -47,7 +47,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'search_original'
+        query_type: 'search_addressit'
       }
     };
 
@@ -89,7 +89,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'search_original'
+        query_type: 'search_addressit'
       }
     };
 
@@ -125,7 +125,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'search_original'
+        query_type: 'search_addressit'
       }
     };
 
@@ -134,7 +134,7 @@ module.exports.tests.confidenceScore = function(test, common) {
     t.end();
   });
 
-  test('should only work for search_original query_type', function(t) {
+  test('should only work for search_addressit query_type', function(t) {
     var req = {
       clean: {
         text: '123 Main St, City, NM',
@@ -191,7 +191,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'search_original'
+        query_type: 'search_addressit'
       }
     };
 
@@ -223,7 +223,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       }],
       meta: {
         scores: [10],
-        query_type: 'search_original'
+        query_type: 'search_addressit'
       }
     };
 

--- a/test/unit/query/search_addressit.js
+++ b/test/unit/query/search_addressit.js
@@ -6,7 +6,7 @@ const defaultPeliasConfig = {
   }
 };
 
-var generate = proxyquire('../../../query/search_original', {
+var generate = proxyquire('../../../query/search_addressit', {
   'pelias-config': defaultPeliasConfig
 });
 
@@ -34,7 +34,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_linguistic_focus_bbox_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_linguistic_focus_bbox_original');
     t.end();
   });
@@ -52,7 +52,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_linguistic_bbox_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_linguistic_bbox');
     t.end();
   });
@@ -66,7 +66,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_linguistic_only_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_linguistic_only');
     t.end();
   });
@@ -81,7 +81,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_linguistic_focus_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_linguistic_focus');
     t.end();
   });
@@ -96,7 +96,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_linguistic_focus_null_island_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_linguistic_focus_null_island');
     t.end();
   });
@@ -118,7 +118,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_full_address_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_full_address');
     t.end();
   });
@@ -137,7 +137,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_partial_address_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_partial_address');
     t.end();
   });
@@ -156,7 +156,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_regions_address_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search_regions_address');
     t.end();
   });
@@ -171,7 +171,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_boundary_country_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search: valid boundary.country query');
     t.end();
   });
@@ -185,7 +185,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_with_source_filtering_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search: valid search query with source filtering');
     t.end();
   });
@@ -199,7 +199,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_with_category_filtering_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'valid search query with category filtering');
     t.end();
   });
@@ -214,7 +214,7 @@ module.exports.tests.query = function(test, common) {
     var compiled = JSON.parse( JSON.stringify( query ) );
     var expected = require('../fixture/search_boundary_gid_original');
 
-    t.deepEqual(compiled.type, 'search_original', 'query type set');
+    t.deepEqual(compiled.type, 'search_addressit', 'query type set');
     t.deepEqual(compiled.body, expected, 'search: valid boundary.gid filter');
     t.end();
   });

--- a/test/unit/query/search_with_custom_boosts.js
+++ b/test/unit/query/search_with_custom_boosts.js
@@ -31,7 +31,7 @@ module.exports.tests.query = function(test, common) {
 
     var expected_query = require('../fixture/search_with_custom_boosts.json');
 
-    const search_query_module = proxyquire('../../../query/search_original', {
+    const search_query_module = proxyquire('../../../query/search_addressit', {
       'pelias-config': config_with_boosts
     });
 

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -71,7 +71,7 @@ var tests = [
   require('./query/search'),
   require('./query/search_with_custom_boosts'),
   require('./query/search_defaults'),
-  require('./query/search_original'),
+  require('./query/search_addressit'),
   require('./query/structured_geocoding'),
   require('./query/text_parser'),
   require('./query/view/boost_sources_and_layers'),


### PR DESCRIPTION
_Branched off of https://github.com/pelias/api/pull/1314, please merge that first_

The search endpoint uses multiple query types that are executed one after the other: if the first does not return acceptable results, the next is executed, and so on.

The last query in this list used to be the only query the search endpoint had. Partially because it's been around for a long time, it is referred to in several different ways across different parts of the code.

This change unifies all of them so that the query is called `search_addressit` everywhere.