### PR TITLE
discover sources & layers by querying elasticsearch

### DIFF
--- a/helper/TypeMapping.js
+++ b/helper/TypeMapping.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const elasticsearch = require('elasticsearch');
+const loadFromElasticsearch = require('./type_mapping_discovery');
 
 var TypeMapping = function(){
 
@@ -129,40 +129,8 @@ TypeMapping.prototype.load = function( done ){
     return;
   }
 
-  if( 'function' === typeof done ){ done(); }
-  return;
-
   // load values from elasticsearch
-
-  // create connection to elasticsearch
-  // const esclient = elasticsearch.Client(peliasConfig.esclient);
-
-  // const query = {
-  //   requestCache: true,
-  //   preference: '_replica_first',
-  //   timeout: '10s',
-  //   body: {
-  //     aggs: {
-  //       sources: {
-  //         terms: {
-  //           field: 'source',
-  //           size: 100
-  //         }
-  //       },
-  //       layers: {
-  //         terms: {
-  //           field: 'layer',
-  //           size: 100
-  //         }
-  //       }
-  //     },
-  //     size: 0
-  //   }
-  // };
-
-  // esclient.search( query, ( err, res ) => {
-  //   console.error( err, res );
-  // });
+  loadFromElasticsearch(this, done);
 };
 
 module.exports = TypeMapping;

--- a/helper/type_mapping_discovery.js
+++ b/helper/type_mapping_discovery.js
@@ -12,7 +12,6 @@ const logger = require('pelias-logger').get('api:type_mapping_discovery');
 
 const DISCOVERY_QUERY = {
   requestCache: true,
-  preference: '_replica_first',
   timeout: '10s',
   body: {
     aggs: {

--- a/helper/type_mapping_discovery.js
+++ b/helper/type_mapping_discovery.js
@@ -1,0 +1,73 @@
+const _ = require('lodash');
+const elasticsearch = require('elasticsearch');
+const peliasConfig = require('pelias-config').generate();
+const logger = require('pelias-logger').get('api:type_mapping_discovery');
+
+/**
+ * This module allows discovery of the sources and layers used
+ * in an existing elasticsearch index.
+ * 
+ * note: this will override any previously configured type mappings.
+ */
+
+const DISCOVERY_QUERY = {
+  requestCache: true,
+  preference: '_replica_first',
+  timeout: '10s',
+  body: {
+    aggs: {
+      sources: {
+        terms: {
+          field: 'source',
+          size: 100
+        },
+        aggs: {
+          layers: {
+            terms: {
+              field: 'layer',
+              size: 100
+            }
+          }
+        }
+      }
+    },
+    size: 0
+  }
+};
+
+module.exports = (tm, done) => {
+  const esclient = elasticsearch.Client(peliasConfig.esclient);
+  esclient.search(DISCOVERY_QUERY, (err, res) => {
+    
+    // query error
+    if( err ){ logger.error( err ); }
+    
+    // invalid response
+    else if( !res || !res.hits || !res.hits.total ){
+      logger.error( 'no hits for aggregation' );
+    }
+    
+    // valid response
+    else {
+
+      // generate a layers_by_source mapping from the aggregation
+      let layersBySource = {};
+      let sources = _.get(res, 'aggregations.sources.buckets', []);
+      sources.forEach( source => {
+        let layers = _.get(source, 'layers.buckets', []);
+        layers.forEach( layer => logger.debug( `${source.key} > ${layer.key}`, `= ${layer.doc_count}` ) );
+        layersBySource[source.key] = layers.map( layer => layer.key );
+      });
+
+      // update type mapping from aggregation data
+      if( !!Object.keys( layersBySource ).length ){
+        logger.info( 'total hits', res.hits.total );
+        logger.info( 'total sources', sources.length );
+        logger.info( 'successfully discovered type mapping from elasticsearch' );
+        tm.setLayersBySource( layersBySource );
+      }
+    }
+
+    if ('function' === typeof done) { done(); }
+  });
+};


### PR DESCRIPTION
This is a feature I started a while back but never quite finished.
It allows users to set [api.targets.auto_discover](https://github.com/pelias/config/blob/master/config/defaults.json#L42) to `true` in order to query a list of `sources` and `layers` from elasticsearch when the api starts up.

It works by sending an aggregation to elasticsearch, this query can take some time (up to several seconds for a full planet build) and so isn't recommended for a production build. (which is why it's disabled by default).

It is, however, very useful for clients who use a lot of custom layer names and forget to update the list manually.
I caught an example of this today from a client, combined with the `address_layer_filter` can cause these custom layers to be excluded from search results when we were only intending to filter `address` documents.

It's probably worth enabling this for all docker projects by default and explicitly disabling it in production environments where either the mapping is well known ahead of time, or where startup performance is sensitive.