### PR TITLE
fix(predicate): Fix address related layers detection

### DIFF
--- a/controller/predicates/is_request_layers_any_address_related.js
+++ b/controller/predicates/is_request_layers_any_address_related.js
@@ -3,12 +3,10 @@ const Debug = require('../../helper/debug');
 const debugLog = new Debug('controller:predicates:is_request_layers_any_address_related');
 const stackTraceLine = require('../../helper/stackTraceLine');
 
-const admin_placetypes = require('../../helper/placeTypes');
-
 // return true if any layers allowed by the query are related to an address query
-// this includes address, street, and any admin layers, but NOT venue and custom layers
+// this includes address and street but NOT venue, postalcode, admin, and custom layers
 module.exports = (req, res) => {
-  const address_related_layers = admin_placetypes.concat(['address', 'street']);
+  const address_related_layers = ['address', 'street'];
 
   const request_layers = _.get(req, 'clean.layers', []);
   let result;

--- a/test/unit/controller/predicates/is_request_layers_any_address_related.js
+++ b/test/unit/controller/predicates/is_request_layers_any_address_related.js
@@ -11,15 +11,22 @@ module.exports.tests.true_conditions = (test, common) => {
     t.end();
   });
 
-  test('admin layers only should return true', t => {
-    const req = { clean: { layers: ['locality', 'county', 'country'] } };
+  test('street layer only should return true', t => {
+    const req = { clean: { layers: ['street'] } };
 
     t.ok(is_request_layers_any_address_related(req));
     t.end();
   });
 
-  test('street and admin layers', t => {
-    const req = { clean: { layers: ['street', 'locality', 'country'] } };
+  test('address and postalcode layers should return true', t => {
+    const req = { clean: { layers: ['address', 'postalcode'] } };
+
+    t.ok(is_request_layers_any_address_related(req));
+    t.end();
+  });
+
+  test('street and admin layers should return true', t => {
+    const req = { clean: { layers: ['street', 'macrocounty'] } };
 
     t.ok(is_request_layers_any_address_related(req));
     t.end();
@@ -40,6 +47,14 @@ module.exports.tests.false_conditions = (test, common) => {
     t.notOk(is_request_layers_any_address_related(req));
     t.end();
   });
+
+  test('admin layers only should return false', t => {
+    const req = { clean: { layers: ['locality', 'county', 'country'] } };
+
+    t.notOk(is_request_layers_any_address_related(req));
+    t.end();
+  });
+
 };
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
This fixes an error in the logic from https://github.com/pelias/api/pull/1307.

The `address_search_with_ids` query can only return results in the address or street layers. Admin results would come from a previous query to the Placeholder service.

However, the predicate logic was allowing the query to execute if an admin layer was specified, which could result in the API returning results from the street or address layers when not intended.