### PR TITLE
remove population subqueries

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -45,7 +45,6 @@ query.score( peliasQuery.view.admin('neighbourhood') );
 query.score( views.boost_exact_matches );
 query.score( peliasQuery.view.focus( views.ngrams_strict ) );
 query.score( peliasQuery.view.popularity( views.pop_subquery ) );
-query.score( peliasQuery.view.population( views.pop_subquery ) );
 query.score( views.custom_boosts( config.get('api.customBoosts') ) );
 
 // non-scoring hard filters

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -105,11 +105,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'popularity:max_boost': 20,
   'popularity:weight': 1,
 
-  'population:field': 'population',
-  'population:modifier': 'log1p',
-  'population:max_boost': 20,
-  'population:weight': 3,
-
   // boost_sources_and_layers view
   'custom:boosting:min_score': 1,           // score applied to documents which don't score anything via functions
   'custom:boosting:boost': 5,               // multiply score by this number to increase the strength of the boost

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -83,11 +83,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',
   'popularity:max_boost': 20,
-  'popularity:weight': 1,
-
-  'population:field': 'population',
-  'population:modifier': 'log1p',
-  'population:max_boost': 20,
-  'population:weight': 2
+  'popularity:weight': 1
 
 });

--- a/query/search.js
+++ b/query/search.js
@@ -12,7 +12,6 @@ var fallbackQuery = new peliasQuery.layout.FallbackQuery();
 // scoring boost
 fallbackQuery.score( peliasQuery.view.focus_only_function( peliasQuery.view.phrase ) );
 fallbackQuery.score( peliasQuery.view.popularity_only_function );
-fallbackQuery.score( peliasQuery.view.population_only_function );
 // --------------------------------
 
 // non-scoring hard filters

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -105,11 +105,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'popularity:max_boost': 20,
   'popularity:weight': 1,
 
-  'population:field': 'population',
-  'population:modifier': 'log1p',
-  'population:max_boost': 20,
-  'population:weight': 2,
-
   // used by fallback queries
   // @todo: it is also possible to specify layer boosting
   // via pelias/config, consider deprecating this config.

--- a/query/search_original.js
+++ b/query/search_original.js
@@ -26,7 +26,6 @@ query.score( peliasQuery.view.ngrams, 'must' );
 query.score( peliasQuery.view.phrase );
 query.score( peliasQuery.view.focus( peliasQuery.view.phrase ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.phrase ) );
-query.score( peliasQuery.view.population( peliasQuery.view.phrase ) );
 
 // address components
 query.score( peliasQuery.view.address('housenumber') );

--- a/query/structured_geocoding.js
+++ b/query/structured_geocoding.js
@@ -11,7 +11,6 @@ const structuredQuery = new peliasQuery.layout.StructuredFallbackQuery();
 // scoring boost
 structuredQuery.score( peliasQuery.view.focus_only_function( peliasQuery.view.phrase ) );
 structuredQuery.score( peliasQuery.view.popularity_only_function );
-structuredQuery.score( peliasQuery.view.population_only_function );
 // --------------------------------
 
 // non-scoring hard filters

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'match': {

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'multi_match': {

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -49,26 +49,6 @@
               "score_mode": "first",
               "boost_mode": "replace"
             }
-          },
-          {
-            "function_score": {
-              "query": {
-                "match_all": {}
-              },
-              "max_boost": 20,
-              "functions": [
-                {
-                  "field_value_factor": {
-                    "modifier": "log1p",
-                    "field": "population",
-                    "missing": 1
-                  },
-                  "weight": 3
-                }
-              ],
-              "score_mode": "first",
-              "boost_mode": "replace"
-            }
           },{
             "function_score": {
               "query": {

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'geo_bounding_box': {

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -42,28 +42,6 @@ module.exports = {
             'score_mode': 'first',
             'boost_mode': 'replace'
           }
-        },
-        {
-          'function_score': {
-            'query': {
-              'match_all': {
-
-              }
-            },
-            'max_boost': 20,
-            'functions': [
-              {
-                'field_value_factor': {
-                  'modifier': 'log1p',
-                  'field': 'population',
-                  'missing': 1
-                },
-                'weight': 3
-              }
-            ],
-            'score_mode': 'first',
-            'boost_mode': 'replace'
-          }
         }
       ],
       'filter': [

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -41,23 +41,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -67,23 +67,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -67,23 +67,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -60,23 +60,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -127,26 +127,6 @@ module.exports = {
             'score_mode': 'first',
             'boost_mode': 'replace'
           }
-        },
-        {
-          'function_score': {
-            'query': {
-              'match_all': {}
-            },
-            'max_boost': 20,
-            'functions': [
-              {
-                'field_value_factor': {
-                  'modifier': 'log1p',
-                  'field': 'population',
-                  'missing': 1
-                },
-                'weight': 3
-              }
-            ],
-            'score_mode': 'first',
-            'boost_mode': 'replace'
-          }
         }
       ]
     }

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -125,23 +125,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      }, {
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -35,23 +35,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match_all': {}
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 3
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -57,14 +57,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_boundary_country_multi.js
+++ b/test/unit/fixture/search_boundary_country_multi.js
@@ -57,14 +57,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_boundary_country_original.js
+++ b/test/unit/fixture/search_boundary_country_original.js
@@ -50,32 +50,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [
         {

--- a/test/unit/fixture/search_boundary_gid.js
+++ b/test/unit/fixture/search_boundary_gid.js
@@ -50,14 +50,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_boundary_gid_original.js
+++ b/test/unit/fixture/search_boundary_gid_original.js
@@ -50,32 +50,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'analyzer': 'peliasPhrase',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [
         {

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -836,14 +836,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_fallback_postalcode_only.js
+++ b/test/unit/fixture/search_fallback_postalcode_only.js
@@ -38,14 +38,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_full_address_original.js
+++ b/test/unit/fixture/search_full_address_original.js
@@ -52,32 +52,6 @@ module.exports = {
           }]
         }
       },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': '123 main st',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
-      },{
         'match': {
           'address_parts.number': {
             'query': '123',

--- a/test/unit/fixture/search_geodisambiguation.js
+++ b/test/unit/fixture/search_geodisambiguation.js
@@ -235,14 +235,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -60,14 +60,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_linguistic_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_bbox_original.js
@@ -48,32 +48,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [{
         'geo_bounding_box': {

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -63,14 +63,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -74,14 +74,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_linguistic_focus_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox_original.js
@@ -79,32 +79,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [{
         'geo_bounding_box': {

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -63,14 +63,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_linguistic_focus_null_island_original.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island_original.js
@@ -79,32 +79,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter':[{
         'terms': {

--- a/test/unit/fixture/search_linguistic_focus_original.js
+++ b/test/unit/fixture/search_linguistic_focus_original.js
@@ -79,32 +79,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [
         {

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -49,14 +49,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_linguistic_only_original.js
+++ b/test/unit/fixture/search_linguistic_only_original.js
@@ -48,32 +48,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [
         {

--- a/test/unit/fixture/search_partial_address_original.js
+++ b/test/unit/fixture/search_partial_address_original.js
@@ -50,32 +50,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'soho grand',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }, {
         'match': {
           'parent.region_a': {

--- a/test/unit/fixture/search_regions_address_original.js
+++ b/test/unit/fixture/search_regions_address_original.js
@@ -51,32 +51,6 @@ module.exports = {
           }]
         }
       },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': '1 water st',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
-      },{
         'match': {
           'address_parts.number': {
             'query': '1',

--- a/test/unit/fixture/search_with_category_filtering.js
+++ b/test/unit/fixture/search_with_category_filtering.js
@@ -50,14 +50,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_with_category_filtering_original.js
+++ b/test/unit/fixture/search_with_category_filtering_original.js
@@ -48,32 +48,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      }, {
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -53,32 +53,6 @@
         },{
           "function_score": {
             "query": {
-              "match": {
-                "phrase.default": {
-                  "query": "test",
-                  "analyzer": "peliasPhrase",
-                  "cutoff_frequency": 0.01,
-                  "type": "phrase",
-                  "slop": 2,
-                  "boost": 1
-                }
-              }
-            },
-            "max_boost": 20,
-            "score_mode": "first",
-            "boost_mode": "replace",
-            "functions": [{
-              "field_value_factor": {
-                "modifier": "log1p",
-                "field": "population",
-                "missing": 1
-              },
-              "weight": 2
-            }]
-          }
-       },{
-          "function_score": {
-            "query": {
               "match_all": {}
             },
             "min_score": 1,

--- a/test/unit/fixture/search_with_source_filtering.js
+++ b/test/unit/fixture/search_with_source_filtering.js
@@ -49,14 +49,6 @@ module.exports = {
             'missing': 1
           },
           'weight': 1
-        },
-        {
-          'field_value_factor': {
-            'modifier': 'log1p',
-            'field': 'population',
-            'missing': 1
-          },
-          'weight': 2
         }
       ],
       'score_mode': 'avg',

--- a/test/unit/fixture/search_with_source_filtering_original.js
+++ b/test/unit/fixture/search_with_source_filtering_original.js
@@ -48,32 +48,6 @@ module.exports = {
             'weight': 1
           }]
         }
-      },{
-        'function_score': {
-          'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
-          },
-          'max_boost': 20,
-          'score_mode': 'first',
-          'boost_mode': 'replace',
-          'functions': [{
-            'field_value_factor': {
-              'modifier': 'log1p',
-              'field': 'population',
-              'missing': 1
-            },
-            'weight': 2
-          }]
-        }
       }],
       'filter': [{
         'terms': {

--- a/test/unit/query/autocomplete_token_matching_permutations.js
+++ b/test/unit/query/autocomplete_token_matching_permutations.js
@@ -63,8 +63,7 @@ module.exports.tests.single_token = function(test, common) {
     assert( t, generate( clean ), {
       must: [ views.ngrams_last_token_only( vs ) ],
       should: [
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -84,8 +83,7 @@ module.exports.tests.single_token = function(test, common) {
       must: [ views.phrase_first_tokens_only( vs ) ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -104,8 +102,7 @@ module.exports.tests.single_token = function(test, common) {
     assert( t, generate( clean ), {
       must: [ views.ngrams_last_token_only( vs ) ],
       should: [
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -125,8 +122,7 @@ module.exports.tests.single_token = function(test, common) {
       must: [ views.phrase_first_tokens_only( vs ) ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -145,8 +141,7 @@ module.exports.tests.single_token = function(test, common) {
     assert( t, generate( clean ), {
       must: [ views.ngrams_last_token_only( vs ) ],
       should: [
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -166,8 +161,7 @@ module.exports.tests.single_token = function(test, common) {
       must: [ views.phrase_first_tokens_only( vs ) ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -192,8 +186,7 @@ module.exports.tests.multiple_tokens = function(test, common) {
       ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -215,8 +208,7 @@ module.exports.tests.multiple_tokens = function(test, common) {
       ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -239,8 +231,7 @@ module.exports.tests.multiple_tokens = function(test, common) {
       ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });
@@ -262,8 +253,7 @@ module.exports.tests.multiple_tokens = function(test, common) {
       ],
       should: [
         views.boost_exact_matches( vs ),
-        peliasQuery.view.popularity( views.pop_subquery )( vs ),
-        peliasQuery.view.population( views.pop_subquery )( vs )
+        peliasQuery.view.popularity( views.pop_subquery )( vs )
       ]
     });
   });

--- a/test/unit/query/structured_geocoding.js
+++ b/test/unit/query/structured_geocoding.js
@@ -7,7 +7,6 @@ const MockQuery = require('./MockQuery');
 const views = {
   focus_only_function: () => 'focus_only_function view',
   popularity_only_function: 'popularity_only_function view',
-  population_only_function: 'population_only_function view',
   boundary_country: 'boundary_country view',
   boundary_circle: 'boundary_circle view',
   boundary_rect: 'boundary_rect view',
@@ -71,8 +70,7 @@ module.exports.tests.query = (test, common) => {
 
     t.deepEquals(query.body.score_functions, [
       'focus_only_function view',
-      'popularity_only_function view',
-      'population_only_function view'
+      'popularity_only_function view'
     ]);
 
     t.deepEquals(query.body.filter_functions, [


### PR DESCRIPTION
DRAFT, for now, this will require updates to the `whosonfirst` importer before merging in order to ensure no breaking changes.

This PR removes the `population` subqueries, as per the discussion in  https://github.com/pelias/openstreetmap/pull/493#issuecomment-503025012 we could copy `population` info to the `popularity` field for admin areas and have one less subquery.

There is some momentum building at the moment to improve `popularity` scoring (which was always enabled but rarely used).
If we decide to go down that path then this PR will remove all the `population` subqueries.

There should be a PR in `pelias/whosonfirst` or `pelias/model` before this is merged which is responsible for setting the popularity.
Note: if the schema and API are out-of-sync then admin areas could receive a 'double-boost' until this code is deployed, if that is a concern then it might be better to 'move' population info to popularity (setting population to 0) for a short migration period.

Finally, if we truly never need to search on `population` then `pelias/schema` could be updated to ensure that the field isn't indexed.