### PR TITLE
Support pelias-query 9.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^5.8.0",
-    "pelias-query": "^9.10.0",
+    "pelias-query": "^9.13.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "retry": "^0.12.0",

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_boundary_country_multi.js
+++ b/test/unit/fixture/search_boundary_country_multi.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_boundary_gid.js
+++ b/test/unit/fixture/search_boundary_gid.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -101,12 +101,16 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.number': 'number value'
+                      'address_parts.number': {
+                        'query': 'number value'
+                      }
                     }
                   },
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   },
                   {
@@ -181,7 +185,9 @@ module.exports = {
                 'should': [
                   {
                     'match_phrase': {
-                      'address_parts.zip': 'postalcode value'
+                      'address_parts.zip': {
+                        'query': 'postalcode value'
+                      }
                     }
                   }
                 ],
@@ -268,7 +274,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   },
                   {
@@ -343,7 +351,9 @@ module.exports = {
                 'should': [
                   {
                     'match_phrase': {
-                      'address_parts.zip': 'postalcode value'
+                      'address_parts.zip': {
+                        'query': 'postalcode value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_with_category_filtering.js
+++ b/test/unit/fixture/search_with_category_filtering.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],

--- a/test/unit/fixture/search_with_source_filtering.js
+++ b/test/unit/fixture/search_with_source_filtering.js
@@ -12,7 +12,9 @@ module.exports = {
                 'must': [
                   {
                     'match_phrase': {
-                      'address_parts.street': 'street value'
+                      'address_parts.street': {
+                        'query': 'street value'
+                      }
                     }
                   }
                 ],


### PR DESCRIPTION
This PR upgrades to pelias-query 9.13.0, which uses a new format for all `match_phrase` queries.

Connects https://github.com/pelias/query/pull/100