### PR TITLE
feat(addressSearchUsingIds): Set default street slop to 1

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -45,6 +45,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:street:analyzer': 'peliasStreet',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 5,
+  'address:street:slop': 1,
   'address:street:cutoff_frequency': 0.01,
 
   'address:postcode:analyzer': 'peliasZip',

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -141,6 +141,35 @@ module.exports.tests.other_parameters = (test, common) => {
 
   });
 
+  test('address_parts.street slop defaults to 1', (t) => {
+    const logger = mock_logger();
+
+    const clean = {
+      parsed_text: {
+        number: 'housenumber value',
+        street: 'street value'
+      }
+    };
+    const res = {
+      data: []
+    };
+
+    const generateQuery = proxyquire('../../../query/address_search_using_ids', {
+      'pelias-logger': logger,
+      'pelias-query': {
+        layout: {
+          AddressesUsingIdsQuery: MockQuery
+        },
+        view: views,
+        Vars: require('pelias-query').Vars
+      }
+    });
+
+    const generatedQuery = generateQuery(clean, res);
+
+    t.deepEquals(generatedQuery.body.vs.var('address:street:slop').toString(), 1);
+    t.end();
+  });
 };
 
 module.exports.tests.granularity_bands = (test, common) => {


### PR DESCRIPTION
Combined with https://github.com/pelias/query/pull/101, this change allows for improved matching of streets when using the addressSearchUsingIDs query (the first query executed by the search endpoint).

Essentially, by allowing a `slop` of 1 in the `match_phrase` clauses of the Elasticsearch query, its now possible to omit a single word _in the middle_ of a street name and still match it. Omitting words at the start or end of the street name has been supported since https://github.com/pelias/schema/pull/310.

Some examples of where this helps:

| Actual street name | Newly matching input text |
| ---                | ---                       |
| SE Martin Luther King Jr Blvd | Martin Luther King Blvd |
| Carrer de Balmes | Carrer Balmes |