### PR TITLE
Focus point distance filter

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -13,7 +13,8 @@ var views = {
   phrase_first_tokens_only:   require('./view/phrase_first_tokens_only'),
   pop_subquery:               require('./view/pop_subquery'),
   boost_exact_matches:        require('./view/boost_exact_matches'),
-  max_character_count_layer_filter:   require('./view/max_character_count_layer_filter')
+  max_character_count_layer_filter:   require('./view/max_character_count_layer_filter'),
+  focus_point_filter:         require('./view/focus_point_distance_filter')
 };
 
 //------------------------------
@@ -57,6 +58,7 @@ query.filter( peliasQuery.view.boundary_circle );
 query.filter( peliasQuery.view.boundary_country );
 query.filter( peliasQuery.view.categories );
 query.filter( peliasQuery.view.boundary_gid );
+query.filter( views.focus_point_filter );
 
 // --------------------------------
 

--- a/query/view/focus_point_distance_filter.js
+++ b/query/view/focus_point_distance_filter.js
@@ -1,0 +1,55 @@
+const _ = require('lodash');
+
+const config = require('pelias-config');
+const type_mapping = require('../../helper/type_mapping');
+
+module.exports = function( vs ) {
+
+  if ( !vs.isset('input:name') ||
+       !vs.isset('centroid:field') ||
+       !vs.isset('focus:point:lat') ||
+       !vs.isset('focus:point:lon') ) {
+    return null;
+  }
+
+  const text_length = vs.var('input:name').get().length;
+
+  if (text_length > 8) {
+    return null;
+  }
+
+  const all_layers_except_address_and_street = _.without(type_mapping.layers, 'address', 'street');
+
+  const length_to_distance_mapping = {
+    1: '100km',
+    2: '200km',
+    3: '400km',
+    4: '600km',
+    5: '900km',
+    6: '1200km',
+    7: '1600km',
+    8: '2000km'
+  };
+
+  const query = {
+    bool: {
+      minimum_should_match: 1,
+      should: [{
+        terms: {
+          layer: all_layers_except_address_and_street
+        }
+      },{
+        geo_distance: {
+          distance: length_to_distance_mapping[text_length],
+          distance_type: 'plane',
+          [vs.var('centroid:field')]: {
+            lat: vs.var('focus:point:lat'),
+            lon: vs.var('focus:point:lon')
+          }
+        }
+      }]
+    }
+  };
+
+  return query;
+};

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -84,6 +84,48 @@ module.exports = {
             'weight': 3
           }]
         }
+      }],
+      'filter': [{
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'terms': {
+                'layer': [
+                  'venue',
+                  'country',
+                  'macroregion',
+                  'region',
+                  'county',
+                  'localadmin',
+                  'locality',
+                  'borough',
+                  'neighbourhood',
+                  'continent',
+                  'empire',
+                  'dependency',
+                  'macrocounty',
+                  'macrohood',
+                  'microhood',
+                  'disputed',
+                  'postalcode',
+                  'ocean',
+                  'marinearea'
+                ]
+              }
+            },
+            {
+              'geo_distance': {
+                'distance': '600km',
+                'distance_type': 'plane',
+                'center_point': {
+                  'lat': 29.49136,
+                  'lon': -82.50622
+                }
+              }
+            }
+          ]
+        }
       }]
     }
   },

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -84,6 +84,46 @@ module.exports = {
             'weight': 3
           }]
         }
+      }],
+      'filter': [{
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [{
+            'terms': {
+              'layer': [
+                'venue',
+                'country',
+                'macroregion',
+                'region',
+                'county',
+                'localadmin',
+                'locality',
+                'borough',
+                'neighbourhood',
+                'continent',
+                'empire',
+                'dependency',
+                'macrocounty',
+                'macrohood',
+                'microhood',
+                'disputed',
+                'postalcode',
+                'ocean',
+                'marinearea'
+              ]
+            }
+          },
+          {
+            'geo_distance': {
+              'distance': '600km',
+              'distance_type': 'plane',
+              'center_point': {
+                'lat': 0,
+                'lon': 0
+              }
+            }
+          }]
+        }
       }]
     }
   },


### PR DESCRIPTION
This PR builds on the work in https://github.com/pelias/api/pull/1215 to improve the performance of autocomplete queries with the `focus.point` parameter, while ensuring the results are as similar as possible.

It works by adding an Elasticsearch filter to autocomplete queries. Results must now pass one of the following tests to be scored and shown:

1. It must be in any layer except address or street (calculated in a performance-friendly way by enumerating all other layers)
2. or, it must be within a certain distance from the focus point

The allowed distance grows with the text length, and after some experimentation I settled on a hand tuned table of distances. As it stands the filter is active up to text lengths of 8, although the distance limit is a generous 2000km by then.

Currently, addresses and streets represent 565 million of the 605 million records in a full planet index, or about 93%. So in some cases this can filter out _lots_ of results.

There are zero changes at all to either the acceptance tests or autocomplete acceptance tests, which hopefully confirms this change is pretty conservative. I feel like that's a great way for it to start out, and then we can tweak it more over time.

## Potential future work
There are several things this PR doesn't try to tackle at all but that we should do in the future, using the groundwork laid here.

I actually really like the filter pattern used, with several clauses in the `should` block and `minimum_should_match` set to one. This basically means we could easily add more conditions and as long as any one of them is true, the record will not be filtered out

### Popularity

Once we have more popularity values from work like https://github.com/pelias/openstreetmap/pull/493 we could experiment with filtering out far away results below a popularity threshold. This would allow us to filter out some of the ~30 million venues, and possibly some of the 6.5M localities, currently in the index, providing another nice boost to performance.

### Zoom

The example of searching for addresses in Australian coastal cities with a viewport centered on the middle of Australia was raised in https://github.com/pelias/pelias/issues/658. This PR doesn't make that case worse, but it doesn't help either.

However, if we did introduce a zoom parameter, we could consider having it modify the distance limits so that the entire viewport was likely to be within that limit.