### PR TITLE
Upgrade to pelias-query 9.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^5.8.0",
-    "pelias-query": "^9.13.0",
+    "pelias-query": "^9.14.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "retry": "^0.12.0",

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -13,7 +13,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:circle:radius': '50km',
   'boundary:circle:distance_type': 'plane',
-  'boundary:circle:optimize_bbox': 'indexed',
 
   'boundary:rect:type': 'indexed',
 

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -14,7 +14,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:circle:radius': '1km',
   'boundary:circle:distance_type': 'plane',
-  'boundary:circle:optimize_bbox': 'indexed',
 
   'boundary:rect:type': 'indexed',
 

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -13,7 +13,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:circle:radius': '50km',
   'boundary:circle:distance_type': 'plane',
-  'boundary:circle:optimize_bbox': 'indexed',
 
   'boundary:rect:type': 'indexed',
 

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -71,7 +71,6 @@ module.exports = {
           'geo_distance': {
             'distance': '20km',
             'distance_type': 'plane',
-            'optimize_bbox': 'indexed',
             'center_point': {
               'lat': 37.83239,
               'lon': -122.35698

--- a/test/unit/query/autocomplete.js
+++ b/test/unit/query/autocomplete.js
@@ -327,7 +327,7 @@ module.exports.tests.query = function(test, common) {
     var expected = require('../fixture/autocomplete_linguistic_circle_san_francisco');
 
     t.deepEqual(compiled.type, 'autocomplete', 'query type set');
-    t.deepEqual(compiled.body, expected, 'autocomplete_linguistic_focus_null_island');
+    t.deepEqual(compiled.body, expected, 'query matches autocomplete_linguistic_circle_san_francisco fixture');
     t.end();
   });
 


### PR DESCRIPTION
This requires moving the deprecated `optimize_bbox` parameter from our fixtures.

Connects https://github.com/pelias/query/pull/102