### PR TITLE
Add new dedup feature based on name and location

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -1,6 +1,6 @@
 const logger = require('pelias-logger').get('api');
 const _ = require('lodash');
-const isDifferent = require('../helper/diffPlaces').isDifferent;
+const diffPlaces = require('../helper/diffPlaces');
 const layerPreferences = require('../helper/diffPlaces').layerPreferences;
 const canonical_sources = require('../helper/type_mapping').canonical_sources;
 const field = require('../helper/fieldValue');
@@ -37,6 +37,9 @@ function dedupeResults(req, res, next) {
 
   // maintain a skip-list
   const skip = [];
+
+  // choose the function for dedupe
+  const isDifferent = req.clean.dedupe === 'geo' ? diffPlaces.isGeographicallyDifferent : diffPlaces.isDifferent;
 
   // use the user agent language to improve deduplication
   const lang = _.get(req, 'clean.lang.iso6393');

--- a/sanitizer/_dedupe.js
+++ b/sanitizer/_dedupe.js
@@ -1,0 +1,18 @@
+const _ = require('lodash');
+
+function _setup(){
+  return {
+    sanitize: function _sanitize( raw, clean ){
+      if ( raw.dedupe === 'geo' ) { clean.dedupe = 'geo'; }
+      return { errors: [], warnings: [] };
+    },
+
+    expected: function _expected() {
+      // add size as a valid parameter
+      return [{ name: 'dedupe' }];
+    }
+  };
+}
+
+// export function
+module.exports = _setup;

--- a/sanitizer/autocomplete.js
+++ b/sanitizer/autocomplete.js
@@ -20,7 +20,8 @@ module.exports.middleware = (_api_pelias_config) => {
       boundary_country: require('../sanitizer/_boundary_country')(),
       categories: require('../sanitizer/_categories')(),
       request_language: require('../sanitizer/_request_language')(),
-      boundary_gid: require('../sanitizer/_boundary_gid')()
+      boundary_gid: require('../sanitizer/_boundary_gid')(),
+      dedupe: require('../sanitizer/_dedupe')()
     };
 
   return ( req, res, next ) => {

--- a/sanitizer/search.js
+++ b/sanitizer/search.js
@@ -20,7 +20,8 @@ module.exports.middleware = (_api_pelias_config) => {
         // this can go away once geonames has been abrogated
         geonames_warnings: require('../sanitizer/_geonames_warnings')(),
         request_language: require('../sanitizer/_request_language')(),
-        boundary_gid: require('../sanitizer/_boundary_gid')()
+        boundary_gid: require('../sanitizer/_boundary_gid')(),
+        dedupe: require('../sanitizer/_dedupe')()
       };
 
   return ( req, res, next ) => {

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -784,6 +784,266 @@ module.exports.tests.priority = function(test, common) {
       t.end();
     });
   });
+
+  test('real-world test case Cannes: records with the same name and same coordiante should be deduped with dedupe=geo', function (t) {
+    var req = {
+      clean: {
+        text: 'Cannes',
+        size: 100,
+        dedupe: 'geo'
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'center_point': { 'lon': 7.02, 'lat': 43.55 },
+          'parent': {
+            'region_id': 85683323,
+            'macrocounty_id': 404227597,
+            'county_id': 102072227,
+            'locality_id': 6446684,
+            'localadmin_id': 1159321933
+          },
+          'name': { 'default': 'Cannes' },
+          'source': 'geonames',
+          'source_id': '6446684',
+          'layer': 'locality',
+        },
+        {
+          'center_point': { 'lon': 7.01, 'lat': 43.55 },
+          'parent': {
+            'country_id': 85633147,
+            'locality_id': 101749251,
+            'region_id': 85683323,
+          },
+          'name': { 'default': 'Cannes' },
+          'source': 'whosonfirst',
+          'source_id': '101749251',
+          'layer': 'locality',
+        },
+        {
+          'center_point': { 'lon': 7.012, 'lat': 43.551 },
+          'parent': {
+            'region_id': 85683323,
+            'macrocounty_id': 404227597,
+            'county_id': 102072227,
+            'locality_id': 3028808,
+            'localadmin_id': 1159321933
+          },
+          'name': { 'default': 'Cannes' },
+          'source': 'geonames',
+          'source_id': '3028808',
+          'layer': 'locality',
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results are deduped');
+      t.end();
+    });
+  });
+
+  test('real-world test case Cannes: records with the same name and (almost) same coordiante should not be deduped', function (t) {
+    var req = {
+      clean: {
+        text: 'Cannes',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'center_point': { 'lon': 7.021, 'lat': 43.552 },
+          'parent': {
+            'region_id': 85683323,
+            'macrocounty_id': 404227597,
+            'county_id': 102072227,
+            'locality_id': 6446684,
+            'localadmin_id': 1159321933
+          },
+          'name': { 'default': 'Cannes' },
+          'source': 'geonames',
+          'source_id': '6446684',
+          'layer': 'locality',
+        },
+        {
+          'center_point': { 'lon': 7.003, 'lat': 43.557 },
+          'parent': {
+            'country_id': 85633147,
+            'locality_id': 101749251,
+            'region_id': 85683323,
+          },
+          'name': { 'default': 'Cannes' },
+          'source': 'whosonfirst',
+          'source_id': '101749251',
+          'layer': 'locality',
+        },
+        {
+          'center_point': { 'lon': 7.012, 'lat': 43.551 },
+          'parent': {
+            'region_id': 85683323,
+            'macrocounty_id': 404227597,
+            'county_id': 102072227,
+            'locality_id': 3028808,
+            'localadmin_id': 1159321933
+          },
+          'name': { 'default': 'Cannes' },
+          'source': 'geonames',
+          'source_id': '3028808',
+          'layer': 'locality',
+        }
+
+      ]
+    };
+
+    var expectedCount = 2;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results are not deduped');
+      t.end();
+    });
+  });
+
+  test('real-world test case Place de la Bastille:' +
+    'records with the same name and near coordiantes should be deduped with dedupe=geo', function(t) {
+    var req = {
+      clean: {
+        text: 'Cannes',
+        size: 100,
+        dedupe: 'geo'
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'center_point': { 'lon': 2.369397, 'lat': 48.85291 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894255'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873807'],
+          },
+          'name': { 'default': 'Place de la Bastille' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:5788446',
+          'layer': 'street',
+        },
+        {
+          'center_point': { 'lon': 2.369484, 'lat': 48.852931 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894255'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873807'],
+          },
+          'name': { 'default': 'Place de la Bastille' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:24892926',
+          'layer': 'street',
+        },
+        {
+          'center_point': { 'lon': 2.368248, 'lat': 48.85274 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894237'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873807'],
+          },
+          'name': { 'default': 'Place de la Bastille' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:24893649',
+          'layer': 'street',
+        },
+        {
+          'center_point': { 'lon': 2.368732, 'lat': 48.853313 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894237'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873807'],
+          },
+          'name': { 'default': 'Place de la Bastille' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:5787367',
+          'layer': 'street',
+        },
+        {
+          'center_point': { 'lon': 2.368701, 'lat': 48.853394 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894237'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873807'],
+          },
+          'name': { 'default': 'Place de la Bastille' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:27627423',
+          'layer': 'street',
+        },
+        {
+          'center_point': { 'lon': 2.369266, 'lat': 48.853509 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894253'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873807'],
+          },
+          'name': { 'default': 'Place de la Bastille' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:5783673',
+          'layer': 'street',
+        },
+        {
+          'center_point': { 'lon': 2.349591, 'lat': 48.84449 },
+          'parent': {
+            'continent_id': ['102191581'],
+            'country_id': ['85633147'],
+            'macroregion_id': ['404227465'],
+            'region_id': ['85683497'],
+            'borough_id': ['1158894239'],
+            'locality_id': ['101751119'],
+            'localadmin_id': ['1159322569'],
+            'neighbourhood_id': ['85873819'],
+          },
+          'name': { 'default': 'Place de la Contrescarpe' },
+          'source': 'openstreetmap',
+          'source_id': 'polyline:5767052',
+          'layer': 'street',
+        },
+      ]
+    };
+
+    var expectedCount = 2;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results are deduped');
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
## Background

There is a lot of elements which have the same name and are close but with a different hierarchy. When we do import with WOF and Geonames, there are some duplicate items and they are not deleted with the current API.
Sometimes what matters most is the label with coordinates and not properties.

## What I did

For this, I added a new query parameter `dedupe=geo` to remove nearby items. This will mark as similar all items with the same name and which are in less than 1km away.

I'm really bad in naming (parameters/variables/constants...) :sweat_smile: 