### PR TITLE
Query for old and new contents of `_id` field in `/v1/place` endpoint

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -33,13 +33,25 @@ function setup( apiConfig, esclient ){
     // setup a new operation
     const operation = retry.operation(operationOptions);
 
-    const cmd = req.clean.ids.map( function(id) {
+    //generate old and new style Elasticsearch mget entries
+    //New: the Elasticsearch ID is the Pelias GID, type not used
+    //Old: the Elasticsearch ID is the Source ID, type is the layer
+    const ids = req.clean.ids.map( function(id) {
+      return {
+        _index: apiConfig.indexName,
+        _id: `${id.source}:${id.layer}:${id.id}`
+      };
+    });
+
+    const old_ids = req.clean.ids.map( function(id) {
       return {
         _index: apiConfig.indexName,
         _type: id.layer,
         _id: id.id
       };
     });
+
+    const cmd = old_ids.concat(ids);
 
     logger.debug( '[ES req]', cmd );
     debugLog.push(req, {ES_req: cmd});

--- a/test/unit/controller/place.js
+++ b/test/unit/controller/place.js
@@ -36,6 +36,14 @@ module.exports.tests.success = (test, common) => {
             _index: 'indexName value',
             _type: 'layer2',
             _id: 'id2'
+          },
+          {
+            _index: 'indexName value',
+            _id: 'source1:layer1:id1'
+          },
+          {
+            _index: 'indexName value',
+            _id: 'source2:layer2:id2'
           }
         ]);
 
@@ -49,10 +57,12 @@ module.exports.tests.success = (test, common) => {
       clean: {
         ids: [
           {
+            source: 'source1',
             id: 'id1',
             layer: 'layer1'
           },
           {
+            source: 'source2',
             id: 'id2',
             layer: 'layer2'
           }


### PR DESCRIPTION
_This change completes step 2 of the `_id` field contents migration described in https://github.com/pelias/pelias/issues/672#issuecomment-508837195_

As part of the transition away from Elasticsearch types, we must change the contents of the `_id` field in our Elasticsearch documents.

This change modifies the `/v1/place` endpoint so that it queries Elasticsearch for documents based on both the old and new contents of the `_id` field, allowing the same API code to work regardless of the version of Pelias used to import data.

Connects https://github.com/pelias/pelias/issues/672