### PR TITLE
replace usage of peliasQueryPartialToken and peliasQueryFullToken analyzers

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -16,12 +16,12 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:rect:type': 'indexed',
 
-  'ngram:analyzer': 'peliasQueryPartialToken',
+  'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 100,
   'ngram:cutoff_frequency': 0.01,
 
-  'phrase:analyzer': 'peliasQueryFullToken',
+  'phrase:analyzer': 'peliasQuery',
   'phrase:field': 'name.default',
   'phrase:boost': 1,
   'phrase:slop': 3,

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -17,7 +17,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:rect:type': 'indexed',
 
-  'ngram:analyzer': 'peliasQueryPartialToken',
+  'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 1,
 

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -16,7 +16,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'boundary:rect:type': 'indexed',
 
-  'ngram:analyzer': 'peliasQueryFullToken',
+  'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 1,
   'ngram:cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
                 'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
                 'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -7,7 +7,7 @@
           {
             "match": {
               "name.default": {
-                "analyzer": "peliasQueryFullToken",
+                "analyzer": "peliasQuery",
                 "cutoff_frequency": 0.01,
                 "type": "phrase",
                 "boost": 1,

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
                 'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -7,7 +7,7 @@ module.exports = {
             'query': {
               'match': {
                 'name.default': {
-                  'analyzer': 'peliasQueryPartialToken',
+                  'analyzer': 'peliasQuery',
                   'boost': 100,
                   'query': 'test',
                   'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -4,7 +4,7 @@ module.exports = {
       'must': [{
         'match': {
           'name.default': {
-            'analyzer': 'peliasQueryFullToken',
+            'analyzer': 'peliasQuery',
             'cutoff_frequency': 0.01,
             'boost': 1,
             'slop': 3,

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
@@ -23,7 +23,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
@@ -23,7 +23,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -4,7 +4,7 @@ module.exports = {
       'must': [{
         'match': {
           'name.default': {
-            'analyzer': 'peliasQueryFullToken',
+            'analyzer': 'peliasQuery',
             'type': 'phrase',
             'boost': 1,
             'slop': 3,
@@ -18,7 +18,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'three',
                 'type': 'phrase',

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 't',
                 'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
                 'type': 'phrase',

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'tes',
                 'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'te',
                 'cutoff_frequency': 0.01,

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -5,7 +5,7 @@ module.exports = {
         {
           'match': {
             'name.default': {
-              'analyzer': 'peliasQueryFullToken',
+              'analyzer': 'peliasQuery',
               'type': 'phrase',
               'boost': 1,
               'slop': 3,

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -4,7 +4,7 @@ module.exports = {
       'must': [{
         'match': {
           'name.default': {
-            'analyzer': 'peliasQueryFullToken',
+            'analyzer': 'peliasQuery',
             'cutoff_frequency': 0.01,
             'type': 'phrase',
             'boost': 1,

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -6,7 +6,7 @@ module.exports = {
           'query': {
             'match': {
               'name.default': {
-                'analyzer': 'peliasQueryPartialToken',
+                'analyzer': 'peliasQuery',
                 'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',

--- a/test/unit/fixture/search_boundary_country_original.js
+++ b/test/unit/fixture/search_boundary_country_original.js
@@ -9,7 +9,7 @@ module.exports = {
               'cutoff_frequency': 0.01,
               'boost': 1,
               'minimum_should_match': '1<-1 3<-25%',
-              'analyzer': 'peliasQueryFullToken'
+              'analyzer': 'peliasQuery'
             }
           }
         }

--- a/test/unit/fixture/search_boundary_gid_original.js
+++ b/test/unit/fixture/search_boundary_gid_original.js
@@ -7,8 +7,8 @@ module.exports = {
             'name.default': {
               'query': 'test',
               'boost': 1,
-              'analyzer': 'peliasQueryFullToken',
               'minimum_should_match': '1<-1 3<-25%',
+              'analyzer': 'peliasQuery',
               'cutoff_frequency': 0.01
             }
           }

--- a/test/unit/fixture/search_full_address_original.js
+++ b/test/unit/fixture/search_full_address_original.js
@@ -8,8 +8,8 @@ module.exports = {
           'name.default': {
             'query': '123 main st',
             'cutoff_frequency': 0.01,
-            'analyzer': 'peliasQueryFullToken',
             'minimum_should_match': '1<-1 3<-25%',
+            'analyzer': 'peliasQuery',
             'boost': 1
           }
         }

--- a/test/unit/fixture/search_linguistic_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_bbox_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],

--- a/test/unit/fixture/search_linguistic_focus_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],

--- a/test/unit/fixture/search_linguistic_focus_null_island_original.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],

--- a/test/unit/fixture/search_linguistic_focus_original.js
+++ b/test/unit/fixture/search_linguistic_focus_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],

--- a/test/unit/fixture/search_linguistic_only_original.js
+++ b/test/unit/fixture/search_linguistic_only_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],

--- a/test/unit/fixture/search_partial_address_original.js
+++ b/test/unit/fixture/search_partial_address_original.js
@@ -8,8 +8,8 @@ module.exports = {
           'name.default': {
             'query': 'soho grand',
             'cutoff_frequency': 0.01,
-            'analyzer': 'peliasQueryFullToken',
             'minimum_should_match': '1<-1 3<-25%',
+            'analyzer': 'peliasQuery',
             'boost': 1
           }
         }

--- a/test/unit/fixture/search_regions_address_original.js
+++ b/test/unit/fixture/search_regions_address_original.js
@@ -8,8 +8,8 @@ module.exports = {
           'name.default': {
             'query': '1 water st',
             'cutoff_frequency': 0.01,
-            'analyzer': 'peliasQueryFullToken',
             'minimum_should_match': '1<-1 3<-25%',
+            'analyzer': 'peliasQuery',
             'boost': 1
           }
         }

--- a/test/unit/fixture/search_with_category_filtering_original.js
+++ b/test/unit/fixture/search_with_category_filtering_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -10,7 +10,7 @@
               "boost": 1,
               "cutoff_frequency": 0.01,
               "minimum_should_match": "1<-1 3<-25%",
-              "analyzer": "peliasQueryFullToken"
+              "analyzer": "peliasQuery"
             }
           }
         }],

--- a/test/unit/fixture/search_with_source_filtering_original.js
+++ b/test/unit/fixture/search_with_source_filtering_original.js
@@ -8,7 +8,7 @@ module.exports = {
             'cutoff_frequency': 0.01,
             'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
-            'analyzer': 'peliasQueryFullToken'
+            'analyzer': 'peliasQuery'
           }
         }
       }],


### PR DESCRIPTION
replace usage of `peliasQueryPartialToken` and `peliasQueryFullToken` analyzers with the new `peliasQuery` analyzer.
related schema PR: https://github.com/pelias/schema/pull/370

this PR will ensure that query-time synonym substitution is disabled for clauses targeting the `name.*` fields.
see: the schema PR linked above for more info.

I am hoping to see a performance improvement as a result and expect to see 0 regressions 🤞 