### PR TITLE
Netherlands use 'street number'

### DIFF
--- a/middleware/localNamingConventions.js
+++ b/middleware/localNamingConventions.js
@@ -2,7 +2,7 @@ const check = require('check-types');
 const _ = require('lodash');
 const field = require('../helper/fieldValue');
 
-var flipNumberAndStreetCountries = ['DEU', 'FIN', 'SWE', 'NOR', 'DNK', 'ISL', 'CZE', 'PRT', 'ESP', 'ROU', 'COL'];
+var flipNumberAndStreetCountries = ['DEU', 'FIN', 'SWE', 'NOR', 'DNK', 'ISL', 'CZE', 'PRT', 'ESP', 'ROU', 'COL', 'NLD'];
 
 function setup() {
   var api = require('pelias-config').generate().api;


### PR DESCRIPTION
The localized results of Pelias for the Netherlands are in the wrong order. The Dutch way is `street number`, not `number street` eg `damstraat 1`