### PR TITLE
feat(search): Use minimum_should_match to filter hits

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -20,6 +20,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:field': 'name.default',
   'ngram:boost': 1,
   'ngram:cutoff_frequency': 0.01,
+  'ngram:minimum_should_match': '1<-1 3<-25%',
 
   'phrase:analyzer': 'peliasPhrase',
   'phrase:field': 'phrase.default',

--- a/test/unit/fixture/search_boundary_country_original.js
+++ b/test/unit/fixture/search_boundary_country_original.js
@@ -8,6 +8,7 @@ module.exports = {
               'query': 'test',
               'cutoff_frequency': 0.01,
               'boost': 1,
+              'minimum_should_match': '1<-1 3<-25%',
               'analyzer': 'peliasQueryFullToken'
             }
           }

--- a/test/unit/fixture/search_boundary_gid_original.js
+++ b/test/unit/fixture/search_boundary_gid_original.js
@@ -8,6 +8,7 @@ module.exports = {
               'query': 'test',
               'boost': 1,
               'analyzer': 'peliasQueryFullToken',
+              'minimum_should_match': '1<-1 3<-25%',
               'cutoff_frequency': 0.01
             }
           }

--- a/test/unit/fixture/search_full_address_original.js
+++ b/test/unit/fixture/search_full_address_original.js
@@ -9,6 +9,7 @@ module.exports = {
             'query': '123 main st',
             'cutoff_frequency': 0.01,
             'analyzer': 'peliasQueryFullToken',
+            'minimum_should_match': '1<-1 3<-25%',
             'boost': 1
           }
         }

--- a/test/unit/fixture/search_linguistic_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_bbox_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }

--- a/test/unit/fixture/search_linguistic_focus_bbox_original.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }

--- a/test/unit/fixture/search_linguistic_focus_null_island_original.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }

--- a/test/unit/fixture/search_linguistic_focus_original.js
+++ b/test/unit/fixture/search_linguistic_focus_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }

--- a/test/unit/fixture/search_linguistic_only_original.js
+++ b/test/unit/fixture/search_linguistic_only_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }

--- a/test/unit/fixture/search_partial_address_original.js
+++ b/test/unit/fixture/search_partial_address_original.js
@@ -9,6 +9,7 @@ module.exports = {
             'query': 'soho grand',
             'cutoff_frequency': 0.01,
             'analyzer': 'peliasQueryFullToken',
+            'minimum_should_match': '1<-1 3<-25%',
             'boost': 1
           }
         }

--- a/test/unit/fixture/search_regions_address_original.js
+++ b/test/unit/fixture/search_regions_address_original.js
@@ -9,6 +9,7 @@ module.exports = {
             'query': '1 water st',
             'cutoff_frequency': 0.01,
             'analyzer': 'peliasQueryFullToken',
+            'minimum_should_match': '1<-1 3<-25%',
             'boost': 1
           }
         }

--- a/test/unit/fixture/search_with_category_filtering_original.js
+++ b/test/unit/fixture/search_with_category_filtering_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -9,6 +9,7 @@
               "query": "test",
               "boost": 1,
               "cutoff_frequency": 0.01,
+              "minimum_should_match": "1<-1 3<-25%",
               "analyzer": "peliasQueryFullToken"
             }
           }

--- a/test/unit/fixture/search_with_source_filtering_original.js
+++ b/test/unit/fixture/search_with_source_filtering_original.js
@@ -7,6 +7,7 @@ module.exports = {
             'query': 'test',
             'cutoff_frequency': 0.01,
             'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQueryFullToken'
           }
         }


### PR DESCRIPTION
This change utilizes the [minimum_should_match](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-minimum-should-match.html) Elasticsearch query parameter to reduce the number of hits to search queries. For now, autocomplete is not changed, we can take a look at that later.

Previously, only one token in an input had to match, regardless of the input size. This allows for queries to potentially match a huge number of documents, especially as the number of tokens grows.

Now, most `ngrams` queries have the `minimum_should_match` parameter set to `1<-1 3<-25%`

Breaking this down, it means that the number of optional tokens follows this pattern:

| token count | optional tokens |
| --- | --- |
| 1   | 0 (obviously) |
| 2   | 1   |
| 3   | 1   |
| 4   | 1   |
| 5   | 1   |
| 6+  | at least 75% of tokens must match |

This should help ensure quality results are returned where possible, even if long inputs contain a few extraneous bits of information, while reducing the chance of extremely expensive queries.