### PR TITLE
Prefer OSM records over Geonames

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -94,10 +94,10 @@ function isPreferred(existingHit, candidateHit) {
   if( existingHit.source !== candidateHit.source ){
     switch( existingHit.source ){
       // WOF has bbox and is generally preferred
-      case 'geonames': return candidateHit.source === 'whosonfirst';
+      case 'geonames': return candidateHit.source === 'whosonfirst' || candidateHit.source === 'openstreetmap';
       // addresses are generally better in OA
       case 'openstreetmap': return candidateHit.source === 'openaddresses';
-      // venues are better in OSM
+      // venues are better in OSM than WOF
       case 'whosonfirst': return candidateHit.source === 'openstreetmap';
     }
   }

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -229,6 +229,37 @@ module.exports.tests.priority = function(test, common) {
     });
   });
 
+  test('openstreetmap takes priority over geonames venues', function (t) {
+    var req = {
+      clean: {
+        text: 'Lancaster Dairy Farm',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Lancaster Dairy Farm' },
+          'source': 'geonames',
+          'source_id': '654321',
+          'layer': 'venue'
+        }, {
+          'name': { 'default': 'Lancaster Dairy Farm' },
+          'source': 'openstreetmap',
+          'source_id': '123456',
+          'layer': 'venue'
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].source, 'openstreetmap', 'openstreetmap result won');
+      t.end();
+    });
+  });
+
   test('openaddresses takes priority over openstreetmap', function (t) {
     var req = {
       clean: {


### PR DESCRIPTION
OSM has much better venues than Geonames, and OSM records are being augmented with [addendum data](https://github.com/pelias/openstreetmap/pull/487) such as airport codes.

Therefore, in general we should prefer an OSM match over Geonames.