### PR TITLE
remove geocoding.query.tokens array

### DIFF
--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -61,6 +61,7 @@ function convertToGeocodeJSON(req, res, next, opts) {
   res.body.geocoding.query = req.clean;
 
   // remove arrays produced by the tokenizer (only intended to be used internally).
+  delete res.body.geocoding.query.tokens;
   delete res.body.geocoding.query.tokens_complete;
   delete res.body.geocoding.query.tokens_incomplete;
 


### PR DESCRIPTION
I'm trying to split off whatever I can from https://github.com/pelias/api/pull/1287

This is a pretty simple PR, it prevents an array from being output in the geojson:

<img width="467" alt="Screenshot 2019-08-07 at 16 57 12" src="https://user-images.githubusercontent.com/738069/62633445-6bd3ee80-b934-11e9-954e-a1fa4b0790b4.png">

The 'tokens' array has been in the response for some time but it doesn't really serve any purpose, I would like to remove it.

note: it is only currently present for `/v1/autocomplete` queries