### PR TITLE
do not reuse config for elasticsearch client

### DIFF
--- a/helper/type_mapping_discovery.js
+++ b/helper/type_mapping_discovery.js
@@ -35,7 +35,7 @@ const DISCOVERY_QUERY = {
 };
 
 module.exports = (tm, done) => {
-  const esclient = elasticsearch.Client(peliasConfig.esclient);
+  const esclient = elasticsearch.Client(_.extend({}, peliasConfig.esclient));
   esclient.search(DISCOVERY_QUERY, (err, res) => {
     
     // query error

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -109,7 +109,7 @@ const Libpostal = require('../service/configurations/Libpostal');
  * @param {object} peliasConfig
  */
 function addRoutes(app, peliasConfig) {
-  const esclient = elasticsearch.Client(peliasConfig.esclient);
+  const esclient = elasticsearch.Client(_.extend({}, peliasConfig.esclient));
 
   const pipConfiguration = new PointInPolygon(_.defaultTo(peliasConfig.api.services.pip, {}));
   const pipService = serviceWrapper(pipConfiguration);


### PR DESCRIPTION
I noticed by accident the other day that when the `auto_discover` mechanism is enabled that the message `Do not reuse objects to configure the elasticsearch Client class` is emitted in the logs.

The js elasticsearch client is particularly picky about not allowing the re-use of the config object passed to the constructor for other instantiations.

This wasn't really an issue before, but with the introduction of the `auto_discover` feature we need to be a bit more careful.

This PR uses lodash `extend()` to make a copy of the config object before it's passed to the elasticsearch client so that the original config is not mutated.