### PR TITLE
Handle signals in a Docker friendly way

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,3 +8,12 @@ const server = app.listen( port, host, () => {
   const listenAddress = server.address();
   logger.info( `pelias is now running on ${listenAddress.address}:${listenAddress.port}` );
 });
+
+function exitHandler() {
+  logger.info('Pelias API shutting down');
+
+  server.close();
+}
+
+process.on('SIGINT', exitHandler);
+process.on('SIGTERM', exitHandler);


### PR DESCRIPTION
Similar to https://github.com/pelias/placeholder/pull/160, this small change allows `ctrl+C` to immediately and gracefully shut down a docker container started with `docker run pelias/api`.

It's a nice user experience improvement for people running our containers on the command line.