### PR TITLE
feat(140_chars): restrict autocomplete inputs to 140 chars

### DIFF
--- a/sanitizer/_text_addressit.js
+++ b/sanitizer/_text_addressit.js
@@ -1,6 +1,7 @@
 const addressit = require('addressit');
 const _      = require('lodash');
 const logger = require('pelias-logger').get('api');
+const MAX_TEXT_LENGTH = 140;
 
 /**
   this module provides extremely basic parsing using two methods.
@@ -27,14 +28,22 @@ function _sanitize( raw, clean ){
   // error & warning messages
   var messages = { errors: [], warnings: [] };
 
-  // invalid input 'text'
-  const text =  _.trim( _.trim( raw.text ), QUOTES );
-  if( !_.isString(text) || _.isEmpty(text) ){
-    messages.errors.push('invalid param \'text\': text length, must be >0');
+  // remove superfluous whitespace & quotes
+  let text = _.trim( _.trim( raw.text ), QUOTES );
+
+  // validate input 'text'
+  if (!_.isString(text) || _.isEmpty(text)) {
+    messages.errors.push(`invalid param 'text': text length, must be >0`);
   }
 
   // valid input 'text'
   else {
+
+    // truncate text to $MAX_TEXT_LENGTH chars
+    if (text.length > MAX_TEXT_LENGTH) {
+      messages.warnings.push(`param 'text' truncated to ${MAX_TEXT_LENGTH} characters`);
+      text = text.substring(0, MAX_TEXT_LENGTH);
+    }
 
     // parse text with query parser
     clean.text = text;

--- a/test/unit/sanitizer/_text_addressit.js
+++ b/test/unit/sanitizer/_text_addressit.js
@@ -399,6 +399,23 @@ module.exports.tests.text_parser = function(test, common) {
     t.deepEquals(messages.warnings, [], 'no warnings');
     t.end();
   });
+
+  test('should truncate very long text inputs', (t) => {
+    const raw = {
+      text: `
+Sometimes we make the process more complicated than we need to.
+We will never make a journey of a thousand miles by fretting about 
+how long it will take or how hard it will be.
+We make the journey by taking each day step by step and then repeating 
+it again and again until we reach our destination.` };
+    const clean = {};
+    const messages = sanitizer.sanitize(raw, clean);
+
+    t.equals(clean.text.length, 140);
+    t.deepEquals(messages.errors, [], 'no errors');
+    t.deepEquals(messages.warnings, [`param 'text' truncated to 140 characters`]);
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Pairs with https://github.com/pelias/api/pull/1312

This PR adds a restriction of max 140 chars for autocomplete inputs.