### PR TITLE
Remove all instances of `_type` from ES documents

### DIFF
--- a/controller/coarse_reverse.js
+++ b/controller/coarse_reverse.js
@@ -98,7 +98,6 @@ function synthesizeDoc(results) {
 
     const esDoc = doc.toESDocument();
     esDoc.data._id = esDoc._id;
-    esDoc.data._type = esDoc._type;
     return esDoc.data;
 
   } catch( e ) {

--- a/controller/placeholder.js
+++ b/controller/placeholder.js
@@ -243,7 +243,7 @@ function synthesizeDocs(boundaryCountry, result) {
 
 function buildESDoc(doc) {
   const esDoc = doc.toESDocument();
-  return _.extend(esDoc.data, { _id: esDoc._id, _type: esDoc._type });
+  return _.extend(esDoc.data, { _id: esDoc._id });
 }
 
 function setup(placeholderService, do_geometric_filters_apply, should_execute) {

--- a/service/mget.js
+++ b/service/mget.js
@@ -1,15 +1,3 @@
-/**
-
-  query must be an array of hashes, structured like so:
-
-  {
-    _index: 'myindex',
-    _type: 'mytype',
-    _id: 'myid'
-  }
-
-**/
-
 var logger = require( 'pelias-logger' ).get( 'api' );
 
 function service( esclient, query, cb ){
@@ -48,7 +36,6 @@ function service( esclient, query, cb ){
         // map metadata in to _source so we
         // can serve it up to the consumer
         doc._source._id = doc._id;
-        doc._source._type = doc._type;
 
         return doc._source;
       });

--- a/service/search.js
+++ b/service/search.js
@@ -35,7 +35,6 @@ function service( esclient, cmd, cb ){
         // map metadata in to _source so we
         // can serve it up to the consumer
         hit._source._id = hit._id;
-        hit._source._type = hit._type;
         hit._source._score = hit._score;
         hit._source._matched_queries = hit.matched_queries;
 

--- a/test/unit/controller/coarse_reverse.js
+++ b/test/unit/controller/coarse_reverse.js
@@ -256,7 +256,6 @@ module.exports.tests.success_conditions = (test, common) => {
       data: [
         {
           _id: 'whosonfirst:neighbourhood:10',
-          _type: 'doc',
           layer: 'neighbourhood',
           source: 'whosonfirst',
           source_id: '10',
@@ -374,7 +373,6 @@ module.exports.tests.success_conditions = (test, common) => {
       data: [
         {
           _id: 'whosonfirst:neighbourhood:10',
-          _type: 'doc',
           layer: 'neighbourhood',
           source: 'whosonfirst',
           source_id: '10',
@@ -450,7 +448,6 @@ module.exports.tests.success_conditions = (test, common) => {
       data: [
         {
           _id: 'whosonfirst:neighbourhood:10',
-          _type: 'doc',
           layer: 'neighbourhood',
           source: 'whosonfirst',
           source_id: '10',
@@ -525,7 +522,6 @@ module.exports.tests.success_conditions = (test, common) => {
       data: [
         {
           _id: 'whosonfirst:neighbourhood:10',
-          _type: 'doc',
           layer: 'neighbourhood',
           source: 'whosonfirst',
           source_id: '10',
@@ -607,7 +603,6 @@ module.exports.tests.success_conditions = (test, common) => {
       data: [
         {
           _id: 'whosonfirst:neighbourhood:10',
-          _type: 'doc',
           layer: 'neighbourhood',
           source: 'whosonfirst',
           source_id: '10',
@@ -689,7 +684,6 @@ module.exports.tests.success_conditions = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:10',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '10',
@@ -773,7 +767,6 @@ module.exports.tests.success_conditions = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:10',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '10',
@@ -1001,8 +994,7 @@ module.exports.tests.failure_conditions = (test, common) => {
         source: 'whosonfirst',
         layer: 'neighbourhood',
         source_id: '20',
-        _id: 'whosonfirst:neighbourhood:20',
-        _type: 'doc'
+        _id: 'whosonfirst:neighbourhood:20'
       }]
     };
 

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -217,7 +217,6 @@ module.exports.tests.success = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -269,7 +268,6 @@ module.exports.tests.success = (test, common) => {
           },
           {
             _id: 'whosonfirst:locality:456',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '456',
@@ -335,7 +333,6 @@ module.exports.tests.success = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -398,7 +395,6 @@ module.exports.tests.success = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -458,7 +454,6 @@ module.exports.tests.success = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -523,7 +518,6 @@ module.exports.tests.success = (test, common) => {
           data: [
             {
               _id: 'whosonfirst:neighbourhood:456',
-              _type: 'doc',
               layer: 'neighbourhood',
               source: 'whosonfirst',
               source_id: '456',
@@ -588,7 +582,6 @@ module.exports.tests.success = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -761,7 +754,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -778,7 +770,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:neighbourhood:10',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '10',
@@ -879,7 +870,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -896,7 +886,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:neighbourhood:2',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '2',
@@ -913,7 +902,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:neighbourhood:3',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '3',
@@ -1080,7 +1068,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -1097,7 +1084,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:neighbourhood:10',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '10',
@@ -1196,7 +1182,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -1213,7 +1198,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:neighbourhood:2',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '2',
@@ -1230,7 +1214,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:neighbourhood:3',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '3',
@@ -1350,7 +1333,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -1367,7 +1349,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:locality:3',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '3',
@@ -1384,7 +1365,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:county:5',
-            _type: 'doc',
             layer: 'county',
             source: 'whosonfirst',
             source_id: '5',
@@ -1485,7 +1465,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:1',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '1',
@@ -1502,7 +1481,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:borough:2',
-            _type: 'doc',
             layer: 'borough',
             source: 'whosonfirst',
             source_id: '2',
@@ -1519,7 +1497,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:locality:3',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '3',
@@ -1634,7 +1611,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:locality:1',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '1',
@@ -1656,7 +1632,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:locality:4',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '4',
@@ -1784,7 +1759,6 @@ module.exports.tests.result_filtering = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:locality:1',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '1',
@@ -1806,7 +1780,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:locality:3',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '3',
@@ -1828,7 +1801,6 @@ module.exports.tests.result_filtering = (test, common) => {
           },
           {
             _id: 'whosonfirst:locality:4',
-            _type: 'doc',
             layer: 'locality',
             source: 'whosonfirst',
             source_id: '4',
@@ -1911,7 +1883,6 @@ module.exports.tests.lineage_errors = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -1985,7 +1956,6 @@ module.exports.tests.lineage_errors = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -2058,7 +2028,6 @@ module.exports.tests.lineage_errors = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -2118,7 +2087,6 @@ module.exports.tests.geometry_errors = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -2177,7 +2145,6 @@ module.exports.tests.centroid_errors = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -2237,7 +2204,6 @@ module.exports.tests.centroid_errors = (test, common) => {
         data: [
           {
             _id: 'whosonfirst:neighbourhood:123',
-            _type: 'doc',
             layer: 'neighbourhood',
             source: 'whosonfirst',
             source_id: '123',
@@ -2307,7 +2273,6 @@ module.exports.tests.boundingbox_errors = (test, common) => {
           data: [
             {
               _id: 'whosonfirst:neighbourhood:123',
-              _type: 'doc',
               layer: 'neighbourhood',
               source: 'whosonfirst',
               source_id: '123',

--- a/test/unit/fixture/dedupe_elasticsearch_results.js
+++ b/test/unit/fixture/dedupe_elasticsearch_results.js
@@ -63,7 +63,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'node:357289197',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -125,7 +124,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5219083',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -206,7 +204,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5183465',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -286,7 +283,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'node:368338500',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -349,7 +345,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'way:84969670',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -420,7 +415,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5192545',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -500,7 +494,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5198085',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -571,7 +564,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5208101',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -652,7 +644,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'way:161088588',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -732,7 +723,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5200263',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -804,7 +794,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'way:34212977',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -884,7 +873,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'node:357330916',
-    '_type': 'venue',
     '_score': 0.47265986,
     '_matched_queries': [
       'fallback.venue'
@@ -955,7 +943,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': 'node:357330919',
-    '_type': 'venue',
     '_score': 0.4432487,
     '_matched_queries': [
       'fallback.venue'
@@ -1026,7 +1013,6 @@ module.exports = [
     ],
     'layer': 'venue',
     '_id': '5197082',
-    '_type': 'venue',
     '_score': 0.4432487,
     '_matched_queries': [
       'fallback.venue'

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -16,7 +16,6 @@ module.exports.tests.interface = function(test, common) {
 module.exports.tests.earth = function(test, common) {
   test('earth', function(t) {
     var earth = [{
-      '_type': 'geoname',
       '_id': '6295630',
       'source': 'whosonfirst',
       'layer': 'continent',
@@ -644,7 +643,6 @@ module.exports.tests.non_optimal_conditions = (test, common) => {
 module.exports.tests.nameAliases = function(test, common) {
   test('name aliases', function(t) {
     var aliases = [{
-      '_type': 'example',
       '_id': '1',
       'source': 'example',
       'layer': 'example',
@@ -689,7 +687,6 @@ module.exports.tests.nameAliases = function(test, common) {
 module.exports.tests.addendum = function(test, common) {
   test('addendum: not set in source', function(t) {
     var example = [{
-      '_type': 'geoname',
       '_id': '6295630',
       'source': 'whosonfirst',
       'layer': 'continent',
@@ -709,7 +706,6 @@ module.exports.tests.addendum = function(test, common) {
   });
   test('addendum: set in source', function(t) {
     var example = [{
-      '_type': 'geoname',
       '_id': '6295630',
       'source': 'whosonfirst',
       'layer': 'continent',
@@ -736,7 +732,6 @@ module.exports.tests.addendum = function(test, common) {
   });
   test('addendum: partially corrupted', function(t) {
     var example = [{
-      '_type': 'geoname',
       '_id': '6295630',
       'source': 'whosonfirst',
       'layer': 'continent',
@@ -762,7 +757,6 @@ module.exports.tests.addendum = function(test, common) {
   });
   test('addendum: all corrupted', function(t) {
     var example = [{
-      '_type': 'geoname',
       '_id': '6295630',
       'source': 'whosonfirst',
       'layer': 'continent',

--- a/test/unit/middleware/localNamingConventions.js
+++ b/test/unit/middleware/localNamingConventions.js
@@ -21,7 +21,6 @@ module.exports.tests.flipNumberAndStreet = function(test, common) {
 
   var ukAddress = {
     '_id': 'test1',
-    '_type': 'test',
     'name': { 'default': '1 Main St' },
     'center_point': { 'lon': -7.131521, 'lat': 54.428866 },
     'address_parts': {
@@ -38,7 +37,6 @@ module.exports.tests.flipNumberAndStreet = function(test, common) {
 
   var deAddress = {
     '_id': 'test2',
-    '_type': 'test',
     'name': { 'default': ['23 Grolmanstraße'] },
     'center_point': { 'lon': 13.321487, 'lat': 52.506781 },
     'address_parts': {
@@ -58,7 +56,6 @@ module.exports.tests.flipNumberAndStreet = function(test, common) {
 
   var nlAddress = {
     '_id': 'test3',
-    '_type': 'test',
     'name': { 'default': '117 Keizersgracht' },
     'center_point': { 'lon': 4.887545, 'lat': 52.376795 },
     'address_parts': {
@@ -78,7 +75,6 @@ module.exports.tests.flipNumberAndStreet = function(test, common) {
 
   var esAddress = {
     '_id': 'test4',
-    '_type': 'test',
     'name': { 'default': '2 Balmes' },
     'center_point': { 'lon': 1, 'lat': 1 },
     'address_parts': {
@@ -93,7 +89,6 @@ module.exports.tests.flipNumberAndStreet = function(test, common) {
 
   var unknownCountryAddress = {
     '_id': 'test5',
-    '_type': 'test',
     'name': { 'default': '123 Main Street' },
     'center_point': { 'lon': 30.1, 'lat': -50 },
     'address_parts': {

--- a/test/unit/service/mget.js
+++ b/test/unit/service/mget.js
@@ -50,7 +50,6 @@ module.exports.tests.error_conditions = (test, common) => {
             {
               found: true,
               _id: 'doc id',
-              _type: 'doc type',
               _source: {}
             }
           ]
@@ -107,7 +106,6 @@ module.exports.tests.success_conditions = (test, common) => {
             {
               found: true,
               _id: 'doc id 1',
-              _type: 'doc type 1',
               _source: {
                 random_key: 'value 1'
               }
@@ -115,13 +113,11 @@ module.exports.tests.success_conditions = (test, common) => {
             {
               found: false,
               _id: 'doc id 2',
-              _type: 'doc type 2',
               _source: {}
             },
             {
               found: true,
               _id: 'doc id 3',
-              _type: 'doc type 3',
               _source: {
                 random_key: 'value 3'
               }
@@ -137,12 +133,10 @@ module.exports.tests.success_conditions = (test, common) => {
     const expectedDocs = [
       {
         _id: 'doc id 1',
-        _type: 'doc type 1',
         random_key: 'value 1'
       },
       {
         _id: 'doc id 3',
-        _type: 'doc type 3',
         random_key: 'value 3'
       }
 

--- a/test/unit/service/search.js
+++ b/test/unit/service/search.js
@@ -44,7 +44,6 @@ module.exports.tests.error_conditions = (test, common) => {
             {
               found: true,
               _id: 'doc id',
-              _type: 'doc type',
               _source: {}
             }
           ]
@@ -97,7 +96,6 @@ module.exports.tests.success_conditions = (test, common) => {
               {
                 _score: 'score 1',
                 _id: 'doc id 1',
-                _type: 'doc type 1',
                 matched_queries: 'matched_queries 1',
                 _source: {
                   random_key: 'value 1'
@@ -106,7 +104,6 @@ module.exports.tests.success_conditions = (test, common) => {
               {
                 _score: 'score 2',
                 _id: 'doc id 2',
-                _type: 'doc type 2',
                 matched_queries: 'matched_queries 2',
                 _source: {
                   random_key: 'value 2'
@@ -125,14 +122,12 @@ module.exports.tests.success_conditions = (test, common) => {
       {
         _score: 'score 1',
         _id: 'doc id 1',
-        _type: 'doc type 1',
         random_key: 'value 1',
         _matched_queries: 'matched_queries 1'
       },
       {
         _score: 'score 2',
         _id: 'doc id 2',
-        _type: 'doc type 2',
         random_key: 'value 2',
         _matched_queries: 'matched_queries 2'
       }
@@ -266,7 +261,6 @@ module.exports.tests.success_conditions = (test, common) => {
               {
                 _score: 'score 1',
                 _id: 'doc id 1',
-                _type: 'doc type 1',
                 matched_queries: 'matched_queries 1',
                 _source: {
                   random_key: 'value 1'
@@ -275,7 +269,6 @@ module.exports.tests.success_conditions = (test, common) => {
               {
                 _score: 'score 2',
                 _id: 'doc id 2',
-                _type: 'doc type 2',
                 matched_queries: 'matched_queries 2',
                 _source: {
                   random_key: 'value 2'


### PR DESCRIPTION
This will help ensure that in the future no code depends on the `_type` value from Elasticsearch.

Connects https://github.com/pelias/pelias/issues/719
