### PR TITLE
ES6 compatible queries

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -22,11 +22,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:cutoff_frequency': 0.01,
   'ngram:minimum_should_match': '1<-1 3<-25%',
 
-  'phrase:analyzer': 'peliasPhrase',
-  'phrase:field': 'phrase.default',
-  'phrase:boost': 1,
-  'phrase:slop': 2,
-  'phrase:cutoff_frequency': 0.01,
+  'match_phrase:main:analyzer': 'peliasPhrase',
+  'match_phrase:main:field': 'phrase.default',
+  'match_phrase:main:boost': 1,
+  'match_phrase:main:slop': 2,
 
   'focus:function': 'exp',
   'focus:offset': '0km',

--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -22,8 +22,10 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 query.score( peliasQuery.view.ngrams, 'must' );
 
 // scoring boost
-query.score( peliasQuery.view.phrase );
-query.score( peliasQuery.view.focus( peliasQuery.view.phrase ) );
+const phrase_view = peliasQuery.view.leaf.match_phrase('main');
+
+query.score( phrase_view );
+query.score( peliasQuery.view.focus( phrase_view ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.population( peliasQuery.view.leaf.match_all ) );
 
@@ -58,6 +60,7 @@ function generateQuery( clean ){
 
   // input text
   vs.var( 'input:name', clean.text );
+  vs.var( 'match_phrase:main:input', clean.text );
 
   // sources
   if( check.array(clean.sources) && clean.sources.length ) {

--- a/query/text_parser_pelias.js
+++ b/query/text_parser_pelias.js
@@ -18,6 +18,7 @@ function addParsedVariablesToQueryVariables(clean, vs) {
   // name
   if (!_.isEmpty(clean.parsed_text.subject)) {
     vs.var('input:name', clean.parsed_text.subject);
+    vs.var('match_phrase:main:input', clean.parsed_text.subject);
   }
 
   // housenumber

--- a/query/view/ngrams_strict.js
+++ b/query/view/ngrams_strict.js
@@ -14,11 +14,12 @@ module.exports = function( vs ){
     return null;
   }
 
-  var view = peliasQuery.view.ngrams( vs );
+  vs.var('match_phrase:ngrams_strict:input', vs.var('input:name').get());
+  vs.var('match_phrase:ngrams_strict:field', vs.var('ngram:field').get());
 
-  view.match['name.default'].type = 'phrase';
-  view.match['name.default'].operator = 'and';
-  view.match['name.default'].slop = vs.var('phrase:slop');
+  vs.var('match_phrase:ngrams_strict:analyzer', vs.var('ngram:analyzer').get());
+  vs.var('match_phrase:ngrams_strict:slop', vs.var('phrase:slop').get());
+  vs.var('match_phrase:ngrams_strict:boost', vs.var('ngram:boost').get());
 
-  return view;
+  return peliasQuery.view.leaf.match_phrase('ngrams_strict')(vs);
 };

--- a/query/view/phrase_first_tokens_only.js
+++ b/query/view/phrase_first_tokens_only.js
@@ -1,30 +1,28 @@
-var peliasQuery = require('pelias-query');
+const peliasQuery = require('pelias-query');
 
 /**
   Phrase view which trims the 'input:name' and uses ALL BUT the last token.
 
   eg. if the input was "100 foo str", then 'input:name' would only be '100 foo'
   note: it is assumed that the rest of the input is matched using another view.
-
-  code notes: this view makes a copy of the $vs object in order to change their
-  values without mutating the original values, which may be expected in their
-  unaltered form by other views.
 **/
 
 module.exports = function( vs ){
+  const view_name = 'first_tokens_only';
 
   // get a copy of the *complete* tokens produced from the input:name
-  var tokens = vs.var('input:name:tokens_complete').get();
+  const tokens = vs.var('input:name:tokens_complete').get();
 
   // no valid tokens to use, fail now, don't render this view.
   if( !tokens || tokens.length < 1 ){ return null; }
 
-  // make a copy Vars so we don't mutate the original
-  var vsCopy = new peliasQuery.Vars( vs.export() );
+  // set the 'input' variable to all but the last token
+  vs.var(`match_phrase:${view_name}:input`).set( tokens.join(' ') );
+  vs.var(`match_phrase:${view_name}:field`).set(vs.var('phrase:field').get());
 
-  // set the 'name' variable in the copy to all but the last token
-  vsCopy.var('input:name').set( tokens.join(' ') );
+  vs.var(`match_phrase:${view_name}:analyzer`).set(vs.var('phrase:analyzer').get());
+  vs.var(`match_phrase:${view_name}:boost`).set(vs.var('phrase:boost').get());
+  vs.var(`match_phrase:${view_name}:slop`).set(vs.var('phrase:slop').get());
 
-  // return the view rendered using the copy
-  return peliasQuery.view.phrase( vsCopy );
+  return peliasQuery.view.leaf.match_phrase(view_name)( vs );
 };

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -5,11 +5,9 @@
       "bool": {
         "must": [
           {
-            "match": {
+            "match_phrase": {
               "phrase.default": {
                 "analyzer": "peliasQuery",
-                "cutoff_frequency": 0.01,
-                "type": "phrase",
                 "boost": 1,
                 "slop": 3,
                 "query": "foo"

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -5,14 +5,11 @@ module.exports = {
         {
           'constant_score': {
             'query': {
-              'match': {
+              'match_phrase': {
                 'name.default': {
                   'analyzer': 'peliasQuery',
                   'boost': 100,
                   'query': 'test',
-                  'cutoff_frequency': 0.01,
-                  'type': 'phrase',
-                  'operator': 'and',
                   'slop': 3
                 }
               }

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -2,14 +2,12 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
-            'cutoff_frequency': 0.01,
             'boost': 1,
             'slop': 3,
-            'query': 'one',
-            'type': 'phrase'
+            'query': 'one'
           }
         }
       }],

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }
@@ -21,14 +18,11 @@ module.exports = {
       'should': [{
         'function_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }
@@ -21,14 +18,11 @@ module.exports = {
       'should': [{
         'function_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -2,13 +2,11 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
-            'type': 'phrase',
             'boost': 1,
             'slop': 3,
-            'cutoff_frequency': 0.01,
             'query': 'one two'
           }
         }

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -2,13 +2,11 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
-            'type': 'phrase',
             'boost': 1,
             'slop': 3,
-            'cutoff_frequency': 0.01,
             'query': '1 2'
           }
         }

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -16,14 +16,11 @@ module.exports = {
       {
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'three',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 't',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
-                'cutoff_frequency': 0.01,
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'tes',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
                 'boost': 100,
                 'query': 'te',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -3,13 +3,11 @@ module.exports = {
     'bool': {
       'must': [
         {
-          'match': {
+          'match_phrase': {
             'phrase.default': {
               'analyzer': 'peliasQuery',
-              'type': 'phrase',
               'boost': 1,
               'slop': 3,
-              'cutoff_frequency': 0.01,
               'query': 'one two'
             }
           }

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -2,11 +2,9 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
-            'cutoff_frequency': 0.01,
-            'type': 'phrase',
             'boost': 1,
             'slop': 3,
             'query': 'k road'

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -4,14 +4,11 @@ module.exports = {
       'must': [{
         'constant_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',
-                'cutoff_frequency': 0.01,
                 'boost': 100,
                 'query': 'test',
-                'type': 'phrase',
-                'operator': 'and',
                 'slop': 3
               }
             }

--- a/test/unit/fixture/search_pelias_parser_boundary_country.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_country.js
@@ -15,12 +15,10 @@ module.exports = {
         }
       ],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }

--- a/test/unit/fixture/search_pelias_parser_boundary_gid.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_gid.js
@@ -15,12 +15,10 @@ module.exports = {
         }
       ],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
             'analyzer': 'peliasPhrase',
-            'cutoff_frequency': 0.01,
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }

--- a/test/unit/fixture/search_pelias_parser_full_address.js
+++ b/test/unit/fixture/search_pelias_parser_full_address.js
@@ -15,12 +15,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': '123 main st',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'slop': 2,
             'boost': 1
           }

--- a/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }
@@ -26,13 +24,11 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'phrase.default': {
                 'analyzer': 'peliasPhrase',
-                'type': 'phrase',
                 'boost': 1,
                 'slop': 2,
-                'cutoff_frequency': 0.01,
                 'query': 'test'
               }
             }

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }
@@ -26,13 +24,11 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'phrase.default': {
                 'analyzer': 'peliasPhrase',
-                'type': 'phrase',
                 'boost': 1,
                 'slop': 2,
-                'cutoff_frequency': 0.01,
                 'query': 'test'
               }
             }

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }
@@ -26,13 +24,11 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match': {
+            'match_phrase': {
               'phrase.default': {
                 'analyzer': 'peliasPhrase',
-                'type': 'phrase',
                 'boost': 1,
                 'slop': 2,
-                'cutoff_frequency': 0.01,
                 'query': 'test'
               }
             }

--- a/test/unit/fixture/search_pelias_parser_linguistic_only.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_only.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }

--- a/test/unit/fixture/search_pelias_parser_partial_address.js
+++ b/test/unit/fixture/search_pelias_parser_partial_address.js
@@ -15,12 +15,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'soho grand',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'slop': 2,
             'boost': 1
           }

--- a/test/unit/fixture/search_pelias_parser_regions_address.js
+++ b/test/unit/fixture/search_pelias_parser_regions_address.js
@@ -15,12 +15,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': '1 water st',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'slop': 2,
             'boost': 1
           }

--- a/test/unit/fixture/search_pelias_parser_with_category_filtering.js
+++ b/test/unit/fixture/search_pelias_parser_with_category_filtering.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }

--- a/test/unit/fixture/search_pelias_parser_with_source_filtering.js
+++ b/test/unit/fixture/search_pelias_parser_with_source_filtering.js
@@ -13,12 +13,10 @@ module.exports = {
         }
       }],
       'should': [{
-        'match': {
+        'match_phrase': {
           'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
             'analyzer': 'peliasPhrase',
-            'type': 'phrase',
             'boost': 1,
             'slop': 2
           }

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -15,12 +15,10 @@
           }
         }],
         "should": [{
-          "match": {
+          "match_phrase": {
             "phrase.default": {
               "query": "test",
-              "cutoff_frequency": 0.01,
               "analyzer": "peliasPhrase",
-              "type": "phrase",
               "boost": 1,
               "slop": 2
             }


### PR DESCRIPTION
This PR uses the work in https://github.com/pelias/query/pull/109 to convert our Elasticsearch queries into an ES6 compatible format.

The main change is that we can no longer set the `phrase` property on `match` queries. Phrase queries must now use the `match_phrase` query which makes the distinction between the two query types much more clear

Note: this PR is currently based on top of https://github.com/pelias/api/pull/1356, which should be merged first.

Closes https://github.com/pelias/api/issues/1261
Connects https://github.com/pelias/pelias/issues/719