### PR TITLE
feat(query): Use match_all for subquery matching

### DIFF
--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -24,8 +24,8 @@ query.score( peliasQuery.view.ngrams, 'must' );
 // scoring boost
 query.score( peliasQuery.view.phrase );
 query.score( peliasQuery.view.focus( peliasQuery.view.phrase ) );
-query.score( peliasQuery.view.popularity( peliasQuery.view.phrase ) );
-query.score( peliasQuery.view.population( peliasQuery.view.phrase ) );
+query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );
+query.score( peliasQuery.view.population( peliasQuery.view.leaf.match_all ) );
 
 // address components
 query.score( peliasQuery.view.address('housenumber') );

--- a/test/unit/fixture/search_pelias_parser_boundary_country.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_country.js
@@ -28,16 +28,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -54,16 +45,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_boundary_gid.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_gid.js
@@ -28,16 +28,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'analyzer': 'peliasPhrase',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -54,16 +45,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'analyzer': 'peliasPhrase',
-                'cutoff_frequency': 0.01,
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_full_address.js
+++ b/test/unit/fixture/search_pelias_parser_full_address.js
@@ -29,16 +29,7 @@ module.exports = {
       {
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': '123 main st',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -55,16 +46,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': '123 main st',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
@@ -26,16 +26,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -52,16 +43,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus.js
@@ -57,16 +57,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -83,16 +74,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
@@ -57,16 +57,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -83,16 +74,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
@@ -57,16 +57,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -83,16 +74,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_linguistic_only.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_only.js
@@ -26,16 +26,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -52,16 +43,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_partial_address.js
+++ b/test/unit/fixture/search_pelias_parser_partial_address.js
@@ -28,16 +28,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'soho grand',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -54,16 +45,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'soho grand',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_regions_address.js
+++ b/test/unit/fixture/search_pelias_parser_regions_address.js
@@ -28,16 +28,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': '1 water st',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -54,16 +45,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': '1 water st',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_with_category_filtering.js
+++ b/test/unit/fixture/search_pelias_parser_with_category_filtering.js
@@ -26,16 +26,7 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -52,16 +43,7 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_pelias_parser_with_source_filtering.js
+++ b/test/unit/fixture/search_pelias_parser_with_source_filtering.js
@@ -26,16 +26,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',
@@ -52,16 +43,7 @@ module.exports = {
       },{
         'function_score': {
           'query': {
-            'match': {
-              'phrase.default': {
-                'query': 'test',
-                'cutoff_frequency': 0.01,
-                'analyzer': 'peliasPhrase',
-                'type': 'phrase',
-                'slop': 2,
-                'boost': 1
-              }
-            }
+            'match_all': { }
           },
           'max_boost': 20,
           'score_mode': 'first',

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -28,16 +28,7 @@
         },{
           "function_score": {
             "query": {
-              "match": {
-                "phrase.default": {
-                  "query": "test",
-                  "cutoff_frequency": 0.01,
-                  "analyzer": "peliasPhrase",
-                  "type": "phrase",
-                  "slop": 2,
-                  "boost": 1
-                }
-              }
+              "match_all": { }
             },
             "max_boost": 20,
             "score_mode": "first",
@@ -54,16 +45,7 @@
         },{
           "function_score": {
             "query": {
-              "match": {
-                "phrase.default": {
-                  "query": "test",
-                  "analyzer": "peliasPhrase",
-                  "cutoff_frequency": 0.01,
-                  "type": "phrase",
-                  "slop": 2,
-                  "boost": 1
-                }
-              }
+              "match_all": { }
             },
             "max_boost": 20,
             "score_mode": "first",


### PR DESCRIPTION
This PR brings the `search_pelias_parser` queries into alignment with autocomplete and `search` queries by using the `match_all` query, instead of a phrase query, for use with function scoring to apply boosts for popularity and population.

While in theory this could result in longer query times because the population and popularity scoring will be applied to more documents, its unlikely we'll notice that.

However, what we _would_ notice is if there's highly populated or popular record that does not match the phrase subquery, but does match the non-phrase query.

All that said, there are no changes to the acceptance tests with this change, so we can mostly consider it a pure refactoring that reduces complexity and technical debt.