### PR TITLE
chore(query): Remove unused function parameter

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -10,7 +10,7 @@ const logger = require('pelias-logger').get('api');
 var fallbackQuery = new peliasQuery.layout.FallbackQuery();
 
 // scoring boost
-fallbackQuery.score( peliasQuery.view.focus_only_function( peliasQuery.view.phrase ) );
+fallbackQuery.score( peliasQuery.view.focus_only_function( ) );
 fallbackQuery.score( peliasQuery.view.popularity_only_function );
 fallbackQuery.score( peliasQuery.view.population_only_function );
 // --------------------------------


### PR DESCRIPTION
At first glance, this code made it appear that the phrase query was being used across the focus point filter functionality on libpostal based search queries, but it turns out it's not!

The `focus_only_function` view constructor [takes no parameters](
https://github.com/pelias/query/blob/7c70ae03429440677b43a15b76720d51a0c92e9b/view/focus_only_function.js#L2), so this code wasn't having any effect.
