### PR TITLE
improve localNamingConventions middleware to support records with name/street aliases

### DIFF
--- a/middleware/localNamingConventions.js
+++ b/middleware/localNamingConventions.js
@@ -60,16 +60,15 @@ function applyLocalNamingConventions(req, res, next) {
   // loop through data items and flip relevant number/street
   res.data.filter(function(place){
     // do nothing for records with no admin info
-    if (!place.parent || !place.parent.country_a) { return false; }
+    if (!_.has(place, 'parent.country_a')) { return false; }
 
     // relevant for some countries
-    var flip = place.parent.country_a.some(function(country) {
+    const flip = place.parent.country_a.some(country => {
       return _.includes(flipNumberAndStreetCountries, country);
     });
     if (!flip){ return false; }
-    if( !place.hasOwnProperty('address_parts') ){ return false; }
-    if( !place.address_parts.hasOwnProperty('number') ){ return false; }
-    if( !place.address_parts.hasOwnProperty('street') ){ return false; }
+    if (!_.has(place, 'address_parts.number')) { return false; }
+    if (!_.has(place, 'address_parts.street')) { return false; }
 
     return true;
   })
@@ -81,12 +80,13 @@ function applyLocalNamingConventions(req, res, next) {
 // flip the housenumber and street name
 // eg. '101 Grolmanstraße' -> 'Grolmanstraße 101'
 function flipNumberAndStreet(place) {
-  var standard = ( place.address_parts.number + ' ' + place.address_parts.street ),
-      flipped  = ( place.address_parts.street + ' ' + place.address_parts.number );
+  const number = field.getStringValue(_.get(place, 'address_parts.number'));
+  const street = field.getStringValue(_.get(place, 'address_parts.street'));
+  const name = field.getStringValue(_.get(place, 'name.default'));
 
   // flip street name and housenumber
-  if( field.getStringValue(place.name.default) === standard ){
-    place.name.default = flipped;
+  if (name === `${number} ${street}`) {
+    place.name.default = `${street} ${number}`;
   }
 }
 

--- a/test/unit/middleware/localNamingConventions.js
+++ b/test/unit/middleware/localNamingConventions.js
@@ -37,12 +37,12 @@ module.exports.tests.flipNumberAndStreet = function(test, common) {
 
   var deAddress = {
     '_id': 'test2',
-    'name': { 'default': ['23 Grolmanstraße'] },
+    'name': { 'default': ['23 Grolmanstraße', '23 Grolman Straße'] },
     'center_point': { 'lon': 13.321487, 'lat': 52.506781 },
     'address_parts': {
        'zip': '10623',
        'number': '23',
-       'street': 'Grolmanstraße'
+       'street': ['Grolmanstraße', 'Grolman Straße']
     },
     'parent': {
       'region': ['Berlin'],


### PR DESCRIPTION
improve `localNamingConventions` middleware to support records with name/street aliases

when testing https://github.com/pelias/model/pull/119 I noticed that the European-style addresses were no longer being 'flipped' correctly to the form of `{street} {number}`

turns out the code was a bit old and pre-dated support for name/street aliases.
this PR modernizes that code (in terms of ES6 and use of lodash and support for aliases), fixing the bug.

I suspect that this hasn't yet been an issue but is good to merge ahead of the linked PR in order to avoid breaking changes.