### PR TITLE
chore(test): Make test name more clear

### DIFF
--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -201,7 +201,7 @@ module.exports.tests.query = function(test, common) {
     var expected = require('../fixture/search_boundary_country_multi');
 
     t.deepEqual(compiled.type, 'search_fallback', 'query type set');
-    t.deepEqual(compiled.body, expected, 'search: valid boundary.country query');
+    t.deepEqual(compiled.body, expected, 'search: valid multi boundary.country query');
     t.end();
   });
 


### PR DESCRIPTION
Two tests had the same expectation name, making it hard to decide which fixture to edit when making changes.