### PR TITLE
chore(test): Allow testing on the latest Node.js 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 node_js:
   - 8
   - 10
-  - "12.10"
+  - 12
 matrix:
   fast_finish: true
 script: npm run travis


### PR DESCRIPTION
It looks like Node.js 12.11.1 has fixed this issue, although its not clear why from the release notes:

https://nodejs.org/en/blog/release/v12.11.1/