### PR TITLE
feat(place): Only query for new GID based _ids

### DIFF
--- a/controller/place.js
+++ b/controller/place.js
@@ -33,25 +33,13 @@ function setup( apiConfig, esclient ){
     // setup a new operation
     const operation = retry.operation(operationOptions);
 
-    //generate old and new style Elasticsearch mget entries
-    //New: the Elasticsearch ID is the Pelias GID, type not used
-    //Old: the Elasticsearch ID is the Source ID, type is the layer
-    const ids = req.clean.ids.map( function(id) {
+    //generate Elasticsearch mget entries based on GID
+    const cmd = req.clean.ids.map( function(id) {
       return {
         _index: apiConfig.indexName,
         _id: `${id.source}:${id.layer}:${id.id}`
       };
     });
-
-    const old_ids = req.clean.ids.map( function(id) {
-      return {
-        _index: apiConfig.indexName,
-        _type: id.layer,
-        _id: id.id
-      };
-    });
-
-    const cmd = old_ids.concat(ids);
 
     logger.debug( '[ES req]', cmd );
     debugLog.push(req, {ES_req: cmd});

--- a/test/unit/controller/place.js
+++ b/test/unit/controller/place.js
@@ -29,16 +29,6 @@ module.exports.tests.success = (test, common) => {
         t.deepEqual(query, [
           {
             _index: 'indexName value',
-            _type: 'layer1',
-            _id: 'id1'
-          },
-          {
-            _index: 'indexName value',
-            _type: 'layer2',
-            _id: 'id2'
-          },
-          {
-            _index: 'indexName value',
             _id: 'source1:layer1:id1'
           },
           {


### PR DESCRIPTION
BREAKING_CHANGE: Importers using pelias-model 6.0.0 or greater (https://github.com/pelias/model/pull/121) are required with this change.

*This change completes step 4 of the Elasticsearch _id migration plan laid out in https://github.com/pelias/pelias/issues/672#issuecomment-508837195*

This is a follow up to https://github.com/pelias/api/pull/1329, removing the querying of the "old" `_id` contents, requiring the new style, where the full Pelias GID is stored in the Elasticsearch ID field.

It also removes the very last usage of the Elasticsearch `_type` field, as part of [supporting Elasticsearch 6](https://github.com/pelias/pelias/issues/719)!
