### PR TITLE
chore(query): Remove more unused function parameters

### DIFF
--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -10,7 +10,7 @@ const check = require('check-types');
 const addressUsingIdsQuery = new peliasQuery.layout.AddressesUsingIdsQuery();
 
 // scoring boost
-addressUsingIdsQuery.score( peliasQuery.view.focus_only_function( peliasQuery.view.phrase ) );
+addressUsingIdsQuery.score( peliasQuery.view.focus_only_function( ) );
 // --------------------------------
 
 // non-scoring hard filters

--- a/query/structured_geocoding.js
+++ b/query/structured_geocoding.js
@@ -9,7 +9,7 @@ const peliasQuery = require('pelias-query'),
 const structuredQuery = new peliasQuery.layout.StructuredFallbackQuery();
 
 // scoring boost
-structuredQuery.score( peliasQuery.view.focus_only_function( peliasQuery.view.phrase ) );
+structuredQuery.score( peliasQuery.view.focus_only_function( ) );
 structuredQuery.score( peliasQuery.view.popularity_only_function );
 structuredQuery.score( peliasQuery.view.population_only_function );
 // --------------------------------


### PR DESCRIPTION
Similar to https://github.com/pelias/api/pull/1358, this removes two parameters to query construction functions that are unused.

They both made it appear as if the non ES6-compatible `phrase` view from pelias/query was being used. In reality, it wasn't.
