### PR TITLE
bugfix for same layer deduplication

### DIFF
--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -80,24 +80,6 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
-  test('isParentHierarchyDifferent: do not compare parentage at the same level as the item placetypes', function(t) {
-    var item1 = {
-      'layer': 'country',
-      'parent': {
-        'country_id': '12345'
-      }
-    };
-    var item2 = {
-      'layer': 'country',
-      'parent': {
-        'country_id': '54321'
-      }
-    };
-
-    t.true(isDifferent(item1, item2), 'should be different');
-    t.end();
-  });
-
   test('isParentHierarchyDifferent: do compare parentage at higher levels than the highest item placetypes', function(t) {
     var item1 = {
       'layer': 'country',

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -670,6 +670,88 @@ module.exports.tests.priority = function(test, common) {
       t.end();
     });
   });
+
+  test('real-world test case Philadelphia: geonames hierarchy should not prevent deduping', function (t) {
+    var req = {
+      clean: {
+        text: 'Philadelphia',
+        size: 10
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'source': 'geonames',
+          'source_id': '4560349',
+          'layer': 'locality',
+          'name': {
+            'default': 'Philadelphia'
+          },
+          'parent': {
+            'continent': [ 'North America' ],
+            'continent_id': [ '102191575' ],
+            'continent_a': [ null ],
+            'country': [ 'United States' ],
+            'country_id': [ '85633793' ],
+            'country_a': [ 'USA' ],
+            'region': [ 'Pennsylvania' ],
+            'region_id': [ '85688481' ],
+            'region_a': [ 'PA' ],
+            'county': [ 'Philadelphia County' ],
+            'county_id': [ '102081353' ],
+            'county_a': [ 'PH' ],
+            'locality': [ 'Philadelphia' ],
+            'locality_id': [ '4560349' ],
+            'locality_a': [ null ],
+            'localadmin': [ 'Philadelphia' ],
+            'localadmin_id': [ '404483701' ],
+            'localadmin_a': [ null ]
+          }
+        },
+        {
+          'source': 'whosonfirst',
+          'source_id': '101718083',
+          'layer': 'locality',
+          'name': {
+            'default': [
+              'Philadelphia',
+              'Colonial Penn (Brm)',
+              'Phila',
+              'Philly'
+            ]
+          },
+          'parent': {
+            'continent': [ 'North America' ],
+            'continent_id': [ '102191575' ],
+            'continent_a': [ null ],
+            'country': [ 'United States' ],
+            'country_id': [ '85633793' ],
+            'country_a': [ 'USA' ],
+            'county': [ 'Philadelphia County' ],
+            'county_id': [ '102081353' ],
+            'county_a': [ null ],
+            'localadmin': [ 'Philadelphia' ],
+            'localadmin_id': [ '404483701' ],
+            'localadmin_a': [ null ],
+            'locality': [ 'Philadelphia' ],
+            'locality_id': [ '101718083' ],
+            'locality_a': [ null ],
+            'region': [ 'Pennsylvania' ],
+            'region_id': [ '85688481' ],
+            'region_a': [ 'PA' ]
+          }
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data[0].name.default[0], 'Philadelphia');
+      t.equal(res.data[0].source, 'whosonfirst');
+      t.equal(res.data.length, expectedCount, 'results are deduped');
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This issue was recently reported and proved tricky to track down.
I've taken the opportunity to refactor [middleware/dedupe.js](https://github.com/pelias/api/pull/1366) and now `helper/diffPlaces.js` for readability and in order to make subsequent improvements to deduplication easier to do.

The heart of the issue was in how we select which parent layers are considered for equality checking.
- In the case where both records are from the same layer, we can simply check all less granular layers.
- In the case of disparate layers the existing behaviour remains, using the layer of the least granular of the two records to start equality checks.

I've introduced the concept of a 'rank', this greatly reduces complexity in variable naming and makes the whole issue easier to discuss and debug.