### PR TITLE
dedupe placetype in name

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -131,6 +131,11 @@ function isNameDifferent(item1, item2, requestLanguage){
   // note: this really shouldn't happen as name is a mandatory field
   if( !isPojo1 || !isPojo2 ){ return false; }
 
+  // apply 'layer dependent normalization' to the names
+  // this ensures that 'Foo' and 'City of Foo' match for localities.
+  names1 = layerDependentNormalization(names1, _.get(item1, 'layer'));
+  names2 = layerDependentNormalization(names2, _.get(item2, 'layer'));
+
   // else both have name info
 
   // iterate over all the languages in item2, comparing them to the
@@ -249,6 +254,61 @@ function getPlaceTypeRank(item) {
  * apply unicode normalization, lowercase characters and remove
  * diacritics and some punctuation.
  */
+function layerDependentNormalization(names, layer) {
+
+  // sanity checking inputs
+  if (!_.isPlainObject(names)) { return names; }
+  if (!_.isString(layer)) { return names; }
+
+  // clone the names to avoid mutating the response data
+  const copy = _.cloneDeep(names);
+
+  // region
+  if (layer === 'region') {
+    _.forEach(names, (value, lang) => {
+      copy[lang] = field.getArrayValue(value).map(name => {
+        return name
+          .replace(/^state\sof(?!\s?the)\s?(.*)$/i, '$1')
+          .replace(/^(.*)\sstate$/i, '$1')
+          .trim();
+      });
+    });
+  }
+
+  // county
+  if( layer === 'county' ){
+    _.forEach(names, (value, lang) => {
+      copy[lang] = field.getArrayValue(value).map(name => {
+        return name
+          .replace(/^county\sof(?!\s?the)\s?(.*)$/i, '$1')
+          .replace(/^(.*)\scounty$/i, '$1')
+          .trim();
+      });
+    });
+  }
+
+  // locality/localadmin
+  if (layer === 'locality' || layer === 'localadmin') {
+    _.forEach(names, (value, lang) => {
+      copy[lang] = field.getArrayValue(value).map(name => {
+        return name
+          .replace(/^city\sof(?!\s?the)\s?(.*)$/i, '$1')
+          .replace(/^(.*)\scity$/i, '$1')
+          .replace(/^town\sof(?!\s?the)\s?(.*)$/i, '$1')
+          .replace(/^(.*)\stown$/i, '$1')
+          .replace(/^township\sof(?!\s?the)\s?(.*)$/i, '$1')
+          .replace(/^(.*)\stownship$/i, '$1')
+          .trim();
+      });
+    });
+  }
+
+  return copy;
+}
+
+/**
+ * lowercase characters and remove diacritics and some punctuation
+ */
 function normalizeString(str){
   return removeAccents(unicode.normalize(str)).toLowerCase().split(/[ ,-]+/).join(' ');
 }
@@ -257,3 +317,4 @@ module.exports.isDifferent = isDifferent;
 module.exports.layerPreferences = layerPreferences;
 module.exports.isNameDifferent = isNameDifferent;
 module.exports.normalizeString = normalizeString;
+module.exports.layerDependentNormalization = layerDependentNormalization;

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -1,6 +1,8 @@
+const _ = require('lodash');
 const isDifferent = require('../../../helper/diffPlaces').isDifferent;
 const isNameDifferent = require('../../../helper/diffPlaces').isNameDifferent;
 const normalizeString = require('../../../helper/diffPlaces').normalizeString;
+const layerDependentNormalization = require('../../../helper/diffPlaces').layerDependentNormalization;
 
 module.exports.tests = {};
 
@@ -575,6 +577,99 @@ module.exports.tests.isNameDifferent = function (test, common) {
       { name: { default: 'Malmö', eng: 'Malmo' } }
     ), 'Malmö');
 
+    t.false(isNameDifferent(
+      { name: { default: 'State of New York' }, layer: 'region' },
+      { name: { default: 'New York' } }
+    ), 'State of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York State' }, layer: 'region' },
+      { name: { default: 'New York' } }
+    ), '* State');
+
+    t.false(isNameDifferent(
+      { name: { default: 'County of New York' }, layer: 'county' },
+      { name: { default: 'New York' } }
+    ), 'County of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York County' }, layer: 'county' },
+      { name: { default: 'New York' } }
+    ), '* County');
+
+    t.false(isNameDifferent(
+      { name: { default: 'City of New York' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), 'City of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York City' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), '* City');
+
+    t.false(isNameDifferent(
+      { name: { default: 'Town of New York' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), 'Town of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York Town' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), '* Town');
+
+    t.false(isNameDifferent(
+      { name: { default: 'Township of New York' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), 'Township of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York Township' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), '* Township');
+
+    t.false(isNameDifferent(
+      { name: { default: 'City of New York' }, layer: 'localadmin' },
+      { name: { default: 'New York' } }
+    ), 'City of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York City' }, layer: 'localadmin' },
+      { name: { default: 'New York' } }
+    ), '* City');
+
+    t.false(isNameDifferent(
+      { name: { default: 'Town of New York' }, layer: 'localadmin' },
+      { name: { default: 'New York' } }
+    ), 'Town of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York Town' }, layer: 'localadmin' },
+      { name: { default: 'New York' } }
+    ), '* Town');
+
+    t.false(isNameDifferent(
+      { name: { default: 'Township of New York' }, layer: 'localadmin' },
+      { name: { default: 'New York' } }
+    ), 'Township of *');
+
+    t.false(isNameDifferent(
+      { name: { default: 'New York Township' }, layer: 'locality' },
+      { name: { default: 'New York' } }
+    ), '* Township');
+
+    t.end();
+  });
+  test('mutation tests', function (t) {
+    // mutation test, $input data should not be mutated
+    const input = { name: { default: 'New York City' }, layer: 'locality' };
+    const expected = { name: { default: 'New York' } };
+
+    // repeat previous test to ensure that the strings were actually changed
+    t.false(isNameDifferent(input, expected), '* City');
+
+    // test that input wasn't mutated in the process
+    t.equal(input.name.default, 'New York City');
+
     t.end();
   });
 };
@@ -597,6 +692,75 @@ module.exports.tests.normalizeString = function (test, common) {
     t.equal(normalizeString('Malmö'), 'malmo');
     t.equal(normalizeString('Grolmanstraße'), 'grolmanstraße');
     t.equal(normalizeString('àáâãäåấắæầằçḉèéêëếḗềḕ'), 'aaaaaaaaaeaacceeeeeeee');
+    t.end();
+  });
+};
+
+module.exports.tests.layerDependentNormalization = function (test, common) {
+  test('region', function (t) {
+    const norm = _.bind(layerDependentNormalization, null, _, 'region');
+    t.deepEqual(norm(
+      { default: ['State of Foo', 'State of Bar'], en: ['State of Baz'] }
+    ),
+      { default: ['Foo', 'Bar'], en: ['Baz'] }
+    );
+    t.deepEqual(norm(
+      { default: ['State of the Foo', 'State of the Bar'], en: ['State of the Baz'] }
+    ),
+      { default: ['State of the Foo', 'State of the Bar'], en: ['State of the Baz'] }
+    );
+    t.deepEqual(norm(
+      { default: ['Foo State', 'Bar State'], en: ['Baz State'] }
+    ),
+      { default: ['Foo', 'Bar'], en: ['Baz'] }
+    );
+    t.end();
+  });
+  test('county', function (t) {
+    const norm = _.bind(layerDependentNormalization, null, _, 'county');
+    t.deepEqual(norm(
+      { default: ['County of Foo', 'County of Bar'], en: ['County of Baz'] }
+    ),
+      { default: ['Foo', 'Bar'], en: ['Baz'] }
+    );
+    t.deepEqual(norm(
+      { default: ['County of the Foo', 'County of the Bar'], en: ['County of the Baz'] }
+    ),
+      { default: ['County of the Foo', 'County of the Bar'], en: ['County of the Baz'] }
+    );
+    t.deepEqual(norm(
+      { default: ['Foo County', 'Bar County'], en: ['Baz County'] }
+    ),
+      { default: ['Foo', 'Bar'], en: ['Baz'] }
+    );
+    t.end();
+  });
+  test('locality', function (t) {
+    const norm = _.bind(layerDependentNormalization, null, _, 'locality');
+    t.deepEqual(norm(
+      { default: ['City of Foo', 'Town of Bar'], en: ['Township of Baz'] }
+    ),
+      { default: ['Foo', 'Bar'], en: ['Baz'] }
+    );
+    t.deepEqual(norm(
+      { default: ['City of the Foo', 'Town of the Bar'], en: ['Township of the Baz'] }
+    ),
+      { default: ['City of the Foo', 'Town of the Bar'], en: ['Township of the Baz'] }
+    );
+    t.deepEqual(norm(
+      { default: ['Foo City', 'Bar Town'], en: ['Baz Township'] }
+    ),
+      { default: ['Foo', 'Bar'], en: ['Baz'] }
+    );
+    t.end();
+  });
+  test('only applied to correct layer', function (t) {
+    const norm = _.bind(layerDependentNormalization, null, _, 'venue');
+    t.deepEqual(norm(
+      { default: ['City of Los Angeles Fire Department Station'] }
+    ),
+      { default: ['City of Los Angeles Fire Department Station'] }
+    );
     t.end();
   });
 };


### PR DESCRIPTION
~~note: branched off https://github.com/pelias/api/pull/1370, [view diff](https://github.com/pelias/api/compare/dedupe-normalization...dedupe-placetype-in-name)~~

this PR adds some logic which allows strings such as `City of Philadelphia` and `Philadelphia` to match for the sake of deduplication.

the normalization function is only applied for the applicable layers, so in the case above the `City of Philadelphia` must be on the `locality` layer in order to be considered for normalization.

I've added a bunch of tests and also ensured that the original data is not mutated so the display labels will remain unaffected by the deduplication normalization.

Closes https://github.com/pelias/geonames/pull/372
Resolves https://github.com/pelias/geonames/issues/395