### PR TITLE
constant_score subqueries should use "filter" not "query"

### DIFF
--- a/query/view/ngrams_last_token_only.js
+++ b/query/view/ngrams_last_token_only.js
@@ -29,7 +29,7 @@ module.exports = function( vs ){
   // return the view rendered using the copy
   return {
     'constant_score': {
-      'query': ngrams_strict( vsCopy )
+      'filter': ngrams_strict( vsCopy )
     }
   };
 };

--- a/query/view/ngrams_last_token_only_multi.js
+++ b/query/view/ngrams_last_token_only_multi.js
@@ -37,7 +37,7 @@ module.exports = function (adminFields){
     // return the view rendered using the copy
     return {
       'constant_score': {
-        'query': rendered
+        'filter': rendered
       }
     };
   };

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -4,7 +4,7 @@ module.exports = {
       'must': [
         {
           'constant_score': {
-            'query': {
+            'filter': {
               'match_phrase': {
                 'name.default': {
                   'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -13,7 +13,7 @@ module.exports = {
       },
       {
         'constant_score': {
-          'query': {
+          'filter': {
             'multi_match': {
               'fields': [
                 'parent.country.ngram^1',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -13,7 +13,7 @@ module.exports = {
       },
       {
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -3,7 +3,7 @@ module.exports = {
     'bool': {
       'must': [{
         'constant_score': {
-          'query': {
+          'filter': {
             'match_phrase': {
               'name.default': {
                 'analyzer': 'peliasQuery',


### PR DESCRIPTION
I ran an elasticsearch@6 build last night and a bunch of acceptance tests failed with the message:

```bash
"[parsing_exception] [constant_score] query does not support [query], with { line=1 & col=150 }"
```

This makes total sense, the `constant_score` query is non-scoring and so should accept a 'filter' context and not a 'query' context.
Since elasticsearch@6 the 'query' top-level parameter is no longer accepted.

Looking at the docs, the `filter` parameter is [compatible back as far as 2.4](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-constant-score-query.html) so I don't foresee any backwards-compatibility issues.

There are also some query types which are supported by 'query' but not by 'filter' although we only seem to be using 'match_phrase' which is supported in both contexts.