### PR TITLE
disallow robots from crawling the API

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ if( peliasConfig.api.accessLog ){
 
 app.use( require('./middleware/headers') );
 app.use( require('./middleware/cors') );
+app.use( require('./middleware/robots') );
 app.use( require('./middleware/options') );
 app.use( require('./middleware/jsonp') );
 

--- a/middleware/robots.js
+++ b/middleware/robots.js
@@ -1,0 +1,9 @@
+// Prevent search engines from attempting to index the API
+// https://developers.google.com/search/reference/robots_meta_tag#xrobotstag
+
+function middleware(req, res, next) {
+  res.header('X-Robots-Tag', 'none');
+  next();
+}
+
+module.exports = middleware;


### PR DESCRIPTION
This is a simple security feature which disallows robots from indexing the REST API.

It appears that Google (and likely other bots) are crawling the `/` page and including it in the search index.
This is a potential security issue as a nefarious user could exploit this to find open and insecure Pelias installations in the wild.

<img width="265" alt="Screenshot 2019-11-04 at 15 36 58" src="https://user-images.githubusercontent.com/738069/68129525-01722080-ff1a-11e9-9bce-7b5c3ec662ad.png">

<img width="424" alt="Screenshot 2019-11-04 at 15 42 46" src="https://user-images.githubusercontent.com/738069/68129545-08992e80-ff1a-11e9-8a1a-f56df80d62dd.png">
