### PR TITLE
use libpostal parses for venue queries where available

### DIFF
--- a/query/search.js
+++ b/query/search.js
@@ -122,7 +122,7 @@ function generateQuery( clean ){
 }
 
 function getQuery(vs) {
-  if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithAdmin(vs)) {
+  if (hasStreet(vs) || isPostalCodeOnly(vs) || isPostalCodeWithAdmin(vs) || isVenue(vs)) {
     return {
       type: 'search_fallback',
       body: fallbackQuery.render(vs)
@@ -155,6 +155,10 @@ function determineQueryType(vs) {
 
 function hasStreet(vs) {
   return vs.isset('input:street');
+}
+
+function isVenue(vs) {
+  return determineQueryType(vs) === 'venue';
 }
 
 function isPostalCodeOnly(vs) {

--- a/test/unit/fixture/search_fallback_venue_city_country.js
+++ b/test/unit/fixture/search_fallback_venue_city_country.js
@@ -1,0 +1,196 @@
+module.exports = {
+  'query': {
+    'function_score': {
+      'query': {
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.venue',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'query value',
+                      'type': 'phrase',
+                      'fields': [
+                        'phrase.default'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'venue'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.locality',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'locality'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.localadmin',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a',
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'localadmin'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.dependency',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.dependency',
+                        'parent.dependency_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'dependency'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.country',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'country value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.country',
+                        'parent.country_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'country'
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      'max_boost': 20,
+      'functions': [
+        {
+          'field_value_factor': {
+            'modifier': 'log1p',
+            'field': 'popularity',
+            'missing': 1
+          },
+          'weight': 1
+        },
+        {
+          'field_value_factor': {
+            'modifier': 'log1p',
+            'field': 'population',
+            'missing': 1
+          },
+          'weight': 2
+        }
+      ],
+      'score_mode': 'avg',
+      'boost_mode': 'multiply'
+    }
+  },
+  'sort': [
+    '_score'
+  ],
+  'size': 20,
+  'track_scores': true
+};

--- a/test/unit/fixture/search_fallback_venue_city_state.js
+++ b/test/unit/fixture/search_fallback_venue_city_state.js
@@ -1,0 +1,196 @@
+module.exports = {
+  'query': {
+    'function_score': {
+      'query': {
+        'bool': {
+          'minimum_should_match': 1,
+          'should': [
+            {
+              'bool': {
+                '_name': 'fallback.venue',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'query value',
+                      'type': 'phrase',
+                      'fields': [
+                        'phrase.default'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a',
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'venue'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.locality',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.locality',
+                        'parent.locality_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'locality'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.localadmin',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'city value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.localadmin',
+                        'parent.localadmin_a'
+                      ]
+                    }
+                  },
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a',
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'localadmin'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.region',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.region',
+                        'parent.region_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'region'
+                  }
+                }
+              }
+            },
+            {
+              'bool': {
+                '_name': 'fallback.macroregion',
+                'must': [
+                  {
+                    'multi_match': {
+                      'query': 'state value',
+                      'type': 'phrase',
+                      'fields': [
+                        'parent.macroregion',
+                        'parent.macroregion_a'
+                      ]
+                    }
+                  }
+                ],
+                'filter': {
+                  'term': {
+                    'layer': 'macroregion'
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      'max_boost': 20,
+      'functions': [
+        {
+          'field_value_factor': {
+            'modifier': 'log1p',
+            'field': 'popularity',
+            'missing': 1
+          },
+          'weight': 1
+        },
+        {
+          'field_value_factor': {
+            'modifier': 'log1p',
+            'field': 'population',
+            'missing': 1
+          },
+          'weight': 2
+        }
+      ],
+      'score_mode': 'avg',
+      'boost_mode': 'multiply'
+    }
+  },
+  'sort': [
+    '_score'
+  ],
+  'size': 20,
+  'track_scores': true
+};

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -316,7 +316,12 @@ module.exports.tests.city_state = function(test, common) {
 
     var query = generate(clean);
 
-    t.equals(query, undefined, 'should have returned undefined');
+    var compiled = JSON.parse(JSON.stringify(query));
+    var expected = require('../fixture/search_fallback_venue_city_state');
+
+    t.deepEqual(compiled.type, 'search_fallback', 'query type set');
+    t.deepEqual(compiled.body, expected, 'search_fallback_venue_city_state');
+
     t.end();
 
   });
@@ -475,7 +480,12 @@ module.exports.tests.city_country = function(test, common) {
 
     var query = generate(clean);
 
-    t.equals(query, undefined, 'should have returned undefined');
+    var compiled = JSON.parse(JSON.stringify(query));
+    var expected = require('../fixture/search_fallback_venue_city_country');
+
+    t.deepEqual(compiled.type, 'search_fallback', 'query type set');
+    t.deepEqual(compiled.body, expected, 'search_fallback_venue_city_country');
+
     t.end();
 
   });


### PR DESCRIPTION
We're currently not using `libpostal` parses for venues, if we see a venue parse we're falling back to the native parser.
I don't remember the history of this but it seems wrong to me 🤷‍♂ 

I noticed this when looking into some bug reports, one example being "Café Pelias".
There are two things currently going wrong with this query:
- libpostal parses it correctly but the query fails with the message `No query to call ES with. Skipping`
- upon falling back to the native parser it parses it incorrectly (I'll open a separate issue for this on that repo)

So regarding the first point, I don't see why we would throw away the venue parse here from libpostal:

```js
"parsed_text": {
  "query": "Café Pelias"
}
```

The `query` label has actually been mapped from the libpostal `house` field in `controller/libpostal`, but this field indicates a venue name.

As you can see from the PR edits, we don't currently consider these venue parses for query generation and I'm not sure why, I believe that libpostal is still superior to the native parser when it comes to venue queries and has always been better than addressit was?

Thoughts?