### PR TITLE
chore(pelias_parser): add logging for chosen parser solution scores

### DIFF
--- a/sanitizer/_text_pelias_parser.js
+++ b/sanitizer/_text_pelias_parser.js
@@ -95,6 +95,11 @@ function parse (clean) {
   // '    VVVV NN SSSSSSS AAAAAA PPPPP      '
   let mask = solution.mask(t);
 
+  // log information about the selected solution
+  logger.info('pelias_parser_solution', {
+    score: solution.score.toFixed(2)
+  });
+
   // special handling of intersection queries
   // here we do not trust intersection parses which also contain another
   // classification, such as a house number, postcode or admin field.


### PR DESCRIPTION
When I was writing up https://github.com/pelias/parser/issues/76 today I noticed that the 'scoring' in the Pelias parser is pretty good, it's fairly indicative of when the parse was low quality and you'll see scores < `0.5` next to a lot of incorrect parses 🎉 

So this PR is pretty simple, it adds logging of the solution scores so that we can graph them and get a better idea about how it's doing in a variable production environment.

example log line:
```
info: [api] pelias_parser_solution score=0.44
```