### PR TITLE
fix(log): Correctly record Elasticsearch result count

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -64,7 +64,7 @@ function setup( apiConfig, esclient, query, should_execute ){
           controller: 'search',
           queryType: renderedQuery.type,
           es_hits: _.get(data, 'hits.total'),
-          result_count: _.get(res, 'data', []).length,
+          result_count: (docs || []).length,
           es_took: _.get(data, 'took', undefined),
           response_time: _.get(data, 'response_time', undefined),
           params: req.clean,


### PR DESCRIPTION
This was essentially logging how many results had already been set on the API
response under construction. So it was sometimes returning a number, but
it was actually logging based on the results of previous invocations of
the search controller. This isn't super common, so the number was
usually zero.

Fixes https://github.com/pelias/api/issues/1386
