### PR TITLE
improved_timeout_handling

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -60,10 +60,17 @@ function setup( apiConfig, esclient, query, should_execute ){
       const initialTime = debugLog.beginTimer(req, `Attempt ${currentAttempt}`);
       // query elasticsearch
       searchService( esclient, cmd, function( err, docs, meta, data ){
+
+        // keep tally of hit counts - compatible with new/old versions of ES
+        let totalHits = 0;
+        if( _.has(data, 'hits.total') ) {
+          totalHits = _.isPlainObject(data.hits.total) ? data.hits.total.value : data.hits.total;
+        }
+
         const message = {
           controller: 'search',
           queryType: renderedQuery.type,
-          es_hits: _.get(data, 'hits.total'),
+          es_hits: totalHits,
           result_count: (docs || []).length,
           es_took: _.get(data, 'took', undefined),
           response_time: _.get(data, 'response_time', undefined),

--- a/middleware/sendJSON.js
+++ b/middleware/sendJSON.js
@@ -34,9 +34,7 @@ function sendJSONResponse(req, res, next) {
   const errorCodes = errors.map(function(error) {
     if (isParameterError(error)) {
       return 400;
-    } else if (isTimeoutError(error)) {
-      return 408;
-    } else if (isElasticsearchError(error)) {
+    } else if (isTimeoutError(error) || isElasticsearchError(error)) {
       return 502;
     } else {
       return 500;

--- a/service/search.js
+++ b/service/search.js
@@ -4,7 +4,9 @@
 
 **/
 
-var logger = require( 'pelias-logger' ).get( 'api' );
+const _ = require('lodash');
+const es = require('elasticsearch');
+const logger = require( 'pelias-logger' ).get( 'api' );
 
 function service( esclient, cmd, cb ){
 
@@ -21,13 +23,28 @@ function service( esclient, cmd, cb ){
       return cb( err );
     }
 
+    // in the case of query timeout the response body contains the
+    // property 'timed_out=true'.
+    // these responses contain partially processed results and so should
+    // be discarded.
+    // https://github.com/pelias/api/issues/1384
+    if( _.get(data, 'timed_out', false) === true ){
+      const err = new es.errors.RequestTimeout('request timed_out=true');
+      logger.error( `elasticsearch error ${err}` );
+      return cb( err );
+    }
+
     // map returned documents
     var docs = [];
     var meta = {
       scores: []
     };
 
-    if( data && data.hits && data.hits.total && Array.isArray(data.hits.hits)){
+    if (
+        _.has(data, 'hits') && 
+        _.get(data, 'hits.total', 0) > 0 && 
+        _.isArray(data.hits.hits)
+      ){
       docs = data.hits.hits.map( function( hit ){
 
         meta.scores.push(hit._score);

--- a/service/search.js
+++ b/service/search.js
@@ -40,12 +40,9 @@ function service( esclient, cmd, cb ){
       scores: []
     };
 
-    if (
-        _.has(data, 'hits') && 
-        _.get(data, 'hits.total', 0) > 0 && 
-        _.isArray(data.hits.hits)
-      ){
-      docs = data.hits.hits.map( function( hit ){
+    const hits = _.get(data, 'hits.hits');
+    if( _.isArray( hits ) && hits.length > 0 ){
+      docs = hits.map(hit => {
 
         meta.scores.push(hit._score);
 

--- a/test/unit/middleware/sendJSON.js
+++ b/test/unit/middleware/sendJSON.js
@@ -124,7 +124,7 @@ module.exports.tests.request_timeout = function(test, common) {
 
     res.status = function( code ){
       return { json: function( body ){
-        t.equal( code, 408, 'Request Timeout' );
+        t.equal( code, 502, 'Bad Gateway' );
         t.deepEqual( body, res.body, 'body set' );
         t.end();
       }};

--- a/test/unit/service/search.js
+++ b/test/unit/service/search.js
@@ -278,69 +278,6 @@ module.exports.tests.success_conditions = (test, common) => {
 
   });
 
-  test('esclient.search returning falsy data.hits.total should return empty docs and meta', (t) => {
-    const errorMessages = [];
-
-    const service = proxyquire('../../../service/search', {
-      'pelias-logger': {
-        get: () => {
-          return {
-            error: (msg) => {
-              errorMessages.push(msg);
-            }
-          };
-        }
-      }
-    });
-
-    const esclient = {
-      search: (cmd, callback) => {
-        t.deepEquals(cmd, 'this is the query');
-
-        const data = {
-          hits: {
-            hits: [
-              {
-                _score: 'score 1',
-                _id: 'doc id 1',
-                matched_queries: 'matched_queries 1',
-                _source: {
-                  random_key: 'value 1'
-                }
-              },
-              {
-                _score: 'score 2',
-                _id: 'doc id 2',
-                matched_queries: 'matched_queries 2',
-                _source: {
-                  random_key: 'value 2'
-                }
-              }
-            ]
-          }
-        };
-
-        callback(undefined, data);
-
-      }
-    };
-
-    const expectedDocs = [];
-    const expectedMeta = { scores: [] };
-
-    const next = (err, docs, meta) => {
-      t.equals(err, null);
-      t.deepEquals(docs, expectedDocs);
-      t.deepEquals(meta, expectedMeta);
-
-      t.equals(errorMessages.length, 0, 'no errors should have been logged');
-      t.end();
-    };
-
-    service(esclient, 'this is the query', next);
-
-  });
-
   test('esclient.search returning non-array data.hits.hits should return empty docs and meta', (t) => {
     const errorMessages = [];
 


### PR DESCRIPTION
following on from the discussion in https://github.com/pelias/api/issues/1384 this PR preemptively adds improved awareness of how elasticsearch handles timeouts.

**check for a 'timed_out=true' property in the response body**

It's possible for elasticsearch to return a `200 OK` status when in fact it's hit a timeout and is only returning a partially computed response.

I added some code to check this and return an `es.errors.RequestTimeout` error. In some ways I'm worried that this might conflate two separate signals, one for a low level socket timeout and one for a gateway (application-level) timeout. On the other hand it does what it says, and (I think?) our handling logic should really be the same regardless.

```
< HTTP/1.1 200 OK
< content-type: application/json; charset=UTF-8
< content-length: 215
<
{
  "took" : 5237,
  "timed_out" : true,
  "_shards" : {
    "total" : 12,
    "successful" : 12,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : 0,
    "max_score" : 0.0,
    "hits" : [ ]
  }
}
```

**do not return `408` responses**

There is a discussion in the [elasticsearch issues](https://github.com/elastic/elasticsearch/issues/35582) about their use of `408`, I agree with them it's not a great HTTP code to use, but that's the way it is.

Luckily for us, we have the luxury of returning a `502` here because we actually do act as a gateway, so this is a much more appropriate code as its clearer that it's a server error and not a client error.

> The HyperText Transfer Protocol (HTTP) 502 Bad Gateway server error response code indicates that the server, while acting as a gateway or proxy, received an invalid response from the upstream server.