### PR TITLE
Reset boosts for street matches, region_a, and country_a to 1

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -43,7 +43,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'address:street:analyzer': 'peliasStreet',
   'address:street:field': 'address_parts.street',
-  'address:street:boost': 5,
+  'address:street:boost': 1,
   'address:street:cutoff_frequency': 0.01,
 
   'address:cross_street:analyzer': 'peliasStreet',
@@ -65,7 +65,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a.ngram',
-  'admin:country_a:boost': 4,
+  'admin:country_a:boost': 1,
   'admin:country_a:cutoff_frequency': 0.01,
 
   'admin:country:analyzer': 'peliasAdmin',
@@ -85,7 +85,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'admin:region_a:analyzer': 'peliasAdmin',
   'admin:region_a:field': 'parent.region_a.ngram',
-  'admin:region_a:boost': 4,
+  'admin:region_a:boost': 1,
   'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:macroregion:analyzer': 'peliasAdmin',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -26,8 +26,8 @@ module.exports = {
                 'parent.borough.ngram^1',
                 'parent.neighbourhood.ngram^1',
                 'parent.locality_a.ngram^1',
-                'parent.region_a.ngram^4',
-                'parent.country_a.ngram^4',
+                'parent.region_a.ngram^1',
+                'parent.country_a.ngram^1',
                 'name.default^1'
               ],
               'query': 'three',

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -25,8 +25,8 @@ module.exports = {
               'parent.borough.ngram^1',
               'parent.neighbourhood.ngram^1',
               'parent.locality_a.ngram^1',
-              'parent.region_a.ngram^4',
-              'parent.country_a.ngram^4',
+              'parent.region_a.ngram^1',
+              'parent.country_a.ngram^1',
               'name.default^1'
             ],
             'query': 'three',

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -23,8 +23,8 @@ module.exports = {
             'parent.borough.ngram^1',
             'parent.neighbourhood.ngram^1',
             'parent.locality_a.ngram^1',
-            'parent.region_a.ngram^4',
-            'parent.country_a.ngram^4',
+            'parent.region_a.ngram^1',
+            'parent.country_a.ngram^1',
             'name.default^1'
           ],
           'query': 'laird',
@@ -38,7 +38,7 @@ module.exports = {
             'address_parts.street': {
               'query': 'k road',
               'cutoff_frequency': 0.01,
-              'boost': 5,
+              'boost': 1,
               'analyzer': 'peliasStreet'
             }
           }


### PR DESCRIPTION
These boosts, while possibly helpful for longer matches, can have very significant and negative impact on shorter autocomplete queries.