### PR TITLE
increase search query "focus:weight" from 2->3

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -31,7 +31,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'focus:offset': '0km',
   'focus:scale': '50km',
   'focus:decay': 0.5,
-  'focus:weight': 2,
+  'focus:weight': 3,
 
   'function_score:score_mode': 'avg',
   'function_score:boost_mode': 'replace',

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -46,7 +46,7 @@ module.exports = {
       'max_boost': 20,
       'functions': [
         {
-          'weight': 2,
+          'weight': 3,
           'exp': {
             'center_point': {
               'origin': {

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -57,7 +57,7 @@ module.exports = {
       'max_boost': 20,
       'functions': [
         {
-          'weight': 2,
+          'weight': 3,
           'exp': {
             'center_point': {
               'origin': {

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -46,7 +46,7 @@ module.exports = {
       'max_boost': 20,
       'functions': [
         {
-          'weight': 2,
+          'weight': 3,
           'exp': {
             'center_point': {
               'origin': {

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus.js
@@ -45,7 +45,7 @@ module.exports = {
                 'decay': 0.5
               }
             },
-            'weight': 2
+            'weight': 3
           }],
           'score_mode': 'avg',
           'boost_mode': 'replace'

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
@@ -45,7 +45,7 @@ module.exports = {
                 'decay': 0.5
               }
             },
-            'weight': 2
+            'weight': 3
           }],
           'score_mode': 'avg',
           'boost_mode': 'replace'

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
@@ -45,7 +45,7 @@ module.exports = {
                 'decay': 0.5
               }
             },
-            'weight': 2
+            'weight': 3
           }],
           'score_mode': 'avg',
           'boost_mode': 'replace'


### PR DESCRIPTION
It seems as though the autocomplete balance has changed slightly in ES6, causing `focus.point` search queries to not work as expected.

Setting "weight": 3 instead of "weight": 2 for the `function_score` query resolves this.

This issue doesn't affect `autocomplete` because it sets the `focus:weight` to 15!

I don't recall why there is such a large difference in these settings between `search` and `autocomplete` but I'd prefer to open another issue for that than include it with this work.