### PR TITLE
feat(autocomplete): Add a boost to name in multi_match

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -127,6 +127,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   // this is used to improve venue matching in cases where the we
   // are unsure if the tokens represent admin or name components.
   'admin:add_name_to_multimatch:field': 'name.default',
+  'admin:add_name_to_multimatch:boost': 1.5,
 
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -28,7 +28,7 @@ module.exports = {
                 'parent.locality_a.ngram^1',
                 'parent.region_a.ngram^1',
                 'parent.country_a.ngram^1',
-                'name.default^1'
+                'name.default^1.5'
               ],
               'query': 'three',
               'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -27,7 +27,7 @@ module.exports = {
               'parent.locality_a.ngram^1',
               'parent.region_a.ngram^1',
               'parent.country_a.ngram^1',
-              'name.default^1'
+              'name.default^1.5'
             ],
             'query': 'three',
             'analyzer': 'peliasAdmin',

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -25,7 +25,7 @@ module.exports = {
             'parent.locality_a.ngram^1',
             'parent.region_a.ngram^1',
             'parent.country_a.ngram^1',
-            'name.default^1'
+            'name.default^1.5'
           ],
           'query': 'laird',
           'analyzer': 'peliasAdmin',


### PR DESCRIPTION
This helps ensure that, all else being equal, results from the `name` field are preferred when matching across all the admin fields.

Developed along with https://github.com/pelias/api/pull/1392, this helps ensure many autocomplete queries (especially for well known cities) behave correctly.
