### PR TITLE
Allow Elasticsearch host to be configured by ENV var

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -102,6 +102,15 @@ const Language = require('../service/configurations/Language');
 const Interpolation = require('../service/configurations/Interpolation');
 const Libpostal = require('../service/configurations/Libpostal');
 
+function getElasticsearchConfig(peliasConfig) {
+  const config = _.extend({}, peliasConfig.esclient);
+
+  if (process.env.ELASTICSEARCH_HOST) {
+    config.hosts = [ process.env.ELASTICSEARCH_HOST ];
+  }
+  return config;
+}
+
 /**
  * Append routes to app
  *
@@ -109,7 +118,7 @@ const Libpostal = require('../service/configurations/Libpostal');
  * @param {object} peliasConfig
  */
 function addRoutes(app, peliasConfig) {
-  const esclient = elasticsearch.Client(_.extend({}, peliasConfig.esclient));
+  const esclient = elasticsearch.Client(getElasticsearchConfig(peliasConfig));
 
   const pipConfiguration = new PointInPolygon(_.defaultTo(peliasConfig.api.services.pip, {}));
   const pipService = serviceWrapper(pipConfiguration);


### PR DESCRIPTION
We have long been pretty strict that nearly all configuration for Pelias should come through `pelias.json`, including all settings related to Elasticsearch.

While this is nice for consistency, there are times when setting configuration through `pelias.json` is not ideal.

In particular, if setting up an A/B split test, controlling parameters independently outside of `pelias.json` can make that setup much simpler.

So in this PR I propose that we allow setting the Elasticsearch host via environment variable. The value from the env var will override whatever is in `pelias.json`.

One downside I see to this PR is that it would pave the way for adding "just a few more" options to configuration via env var, such as the hostnames of other services. So it's possible we shouldn't go down that path, as I believe strongly that having a nice, structured JSON config file helps keep all the many options for Pelias organized.