### PR TITLE
Drop support for Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 notifications:
   email: false
 node_js:
-  - 8
   - 10
   - 12
 matrix:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/pelias/api/issues"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
     "@hapi/joi": "^16.0.1",


### PR DESCRIPTION
BREAKING CHANGE: Node.js 8 is no longer supported as it will reach [end of life](https://github.com/nodejs/Release#release-schedule) at the end of 2019.


Connects https://github.com/pelias/pelias/issues/837