### PR TITLE
Add categories to the places endpoint

### DIFF
--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -2,7 +2,8 @@ const _ = require('lodash');
 const categoryTaxonomy = require('pelias-categories');
 
 const WARNINGS = {
-  empty: 'Categories parameter left blank, showing results from all categories.'
+  empty: 'Categories parameter left blank, showing results from all categories.',
+  notEmpty: 'Categories filtering not supported on this endpoint, showing results from all categories.'
 };
 
 // validate inputs, convert types and apply defaults
@@ -39,11 +40,17 @@ function _sanitize (raw, clean, categories) {
 }
 
 function _alwaysBlank (raw, clean, categories) {
+  // error & warning messages
+  const messages = { errors: [], warnings: [] };
+
   if (raw.hasOwnProperty('categories')) {
     clean.categories = [];
+    if (_.isString(raw.categories) && !_.isEmpty(raw.categories)) {
+      messages.warnings.push(WARNINGS.notEmpty);
+    }
   }
 
-  return { errors: [], warnings: [] };
+  return messages;
 }
 
 function _expected () {

--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -38,11 +38,19 @@ function _sanitize (raw, clean, categories) {
   return messages;
 }
 
+function _alwaysBlank (raw, clean, categories) {
+  if (raw.hasOwnProperty('categories')) {
+    clean.categories = [];
+  }
+
+  return { errors: [], warnings: [] };
+}
+
 function _expected () {
   return [{ name: 'categories' }];
 }
 // export function
-module.exports = () => ({
-  sanitize: _sanitize,
+module.exports = (alwaysBlank) => ({
+  sanitize: alwaysBlank ? _alwaysBlank : _sanitize,
   expected: _expected
 });

--- a/sanitizer/place.js
+++ b/sanitizer/place.js
@@ -4,6 +4,7 @@ var sanitizeAll = require('../sanitizer/sanitizeAll'),
       debug: require('../sanitizer/_debug')(),
       ids: require('../sanitizer/_ids')(),
       private: require('../sanitizer/_flag_bool')('private', false),
+      categories: require('../sanitizer/_categories')(true),
       request_language: require('../sanitizer/_request_language')()
     };
 

--- a/test/unit/sanitizer/_categories.js
+++ b/test/unit/sanitizer/_categories.js
@@ -183,6 +183,55 @@ module.exports.tests.invalid_categories = function(test, common) {
   });
 };
 
+module.exports.tests.always_blank = function(test, common) {
+  const alwaysBlankSanitizer = require( '../../../sanitizer/_categories')(true);
+  test('garbage category', function(t) {
+    var req = {
+      query: {
+        categories: 'barf'
+      },
+      clean: { }
+    };
+    var expected_messages = { errors: [], warnings: [] };
+
+    var messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+
+    t.deepEqual(messages, expected_messages, 'error with message returned');
+    t.deepEqual(req.clean.categories, [], 'should return empty array');
+    t.end();
+  });
+
+  test('all garbage categories', function(t) {
+    var req = {
+      query: {
+        categories: 'food'
+      },
+      clean: { }
+    };
+    var expected_messages = { errors: [], warnings: [] };
+
+    var messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+
+    t.deepEqual(messages, expected_messages, 'error with message returned');
+    t.deepEqual(req.clean.categories, [], 'should return empty array');
+    t.end();
+  });
+
+  test('not defined categories', function(t) {
+    var req = {
+      query: { },
+      clean: { }
+    };
+    var expected_messages = { errors: [], warnings: [] };
+
+    var messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+
+    t.deepEqual(messages, expected_messages, 'error with message returned');
+    t.deepEqual(req.clean.categories, undefined, 'categories should be undefined');
+    t.end();
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('SANITIZE _categories ' + name, testFunction);

--- a/test/unit/sanitizer/_categories.js
+++ b/test/unit/sanitizer/_categories.js
@@ -186,15 +186,17 @@ module.exports.tests.invalid_categories = function(test, common) {
 module.exports.tests.always_blank = function(test, common) {
   const alwaysBlankSanitizer = require( '../../../sanitizer/_categories')(true);
   test('garbage category', function(t) {
-    var req = {
+    const req = {
       query: {
         categories: 'barf'
       },
       clean: { }
     };
-    var expected_messages = { errors: [], warnings: [] };
+    const expected_messages = { errors: [], warnings: [
+      'Categories filtering not supported on this endpoint, showing results from all categories.'
+    ] };
 
-    var messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+    const messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
     t.deepEqual(req.clean.categories, [], 'should return empty array');
@@ -202,15 +204,49 @@ module.exports.tests.always_blank = function(test, common) {
   });
 
   test('all garbage categories', function(t) {
-    var req = {
+    const req = {
       query: {
         categories: 'food'
       },
       clean: { }
     };
-    var expected_messages = { errors: [], warnings: [] };
+    const expected_messages = { errors: [], warnings: [
+      'Categories filtering not supported on this endpoint, showing results from all categories.'
+    ] };
 
-    var messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+    const messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+
+    t.deepEqual(messages, expected_messages, 'error with message returned');
+    t.deepEqual(req.clean.categories, [], 'should return empty array');
+    t.end();
+  });
+
+  test('defined categories', function(t) {
+    const req = {
+      query: {
+        categories: undefined
+      },
+      clean: { }
+    };
+    const expected_messages = { errors: [], warnings: [] };
+
+    const messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+
+    t.deepEqual(messages, expected_messages, 'error with message returned');
+    t.deepEqual(req.clean.categories, [], 'should return empty array');
+    t.end();
+  });
+
+  test('empty categories', function(t) {
+    const req = {
+      query: {
+        categories: ''
+      },
+      clean: { }
+    };
+    const expected_messages = { errors: [], warnings: [] };
+
+    const messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
     t.deepEqual(req.clean.categories, [], 'should return empty array');
@@ -218,13 +254,13 @@ module.exports.tests.always_blank = function(test, common) {
   });
 
   test('not defined categories', function(t) {
-    var req = {
+    const req = {
       query: { },
       clean: { }
     };
-    var expected_messages = { errors: [], warnings: [] };
+    const expected_messages = { errors: [], warnings: [] };
 
-    var messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
+    const messages = alwaysBlankSanitizer.sanitize(req.query, req.clean);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
     t.deepEqual(req.clean.categories, undefined, 'categories should be undefined');


### PR DESCRIPTION
Categories are something really useful (and interesting) that's why they should also be available in the Places API.
This PR will add categories when we use the endpoint places e.g `/v1/places?categories&ids=...`

