### PR TITLE
fix js type detection bug in TypeMapping

### DIFF
--- a/helper/TypeMapping.js
+++ b/helper/TypeMapping.js
@@ -91,7 +91,7 @@ TypeMapping.prototype.generateMappings = function(){
       return acc.concat(this.layers_by_source[key]);
     }.bind(this), []))
   );
-  
+
   safeReplace(
     this.layer_mapping,
     TypeMapping.addStandardTargetsToAliases(this.layers, this.layer_aliases)
@@ -112,7 +112,7 @@ TypeMapping.prototype.getCanonicalLayers = function(){
 // load values from targets block
 TypeMapping.prototype.loadTargets = function( targetsBlock ){
 
-  if( !_.isObject(targetsBlock) ){ return; }
+  if( !_.isPlainObject(targetsBlock) ){ return; }
 
   // set values from targets block
   this.setSourceAliases( targetsBlock.source_aliases || {} );
@@ -149,12 +149,21 @@ TypeMapping.prototype.load = function( done ){
 // replace the contents of an object or array
 // while maintaining the original pointer reference
 function safeReplace(reference, replacement){
-  if (_.isObject(reference) && _.isObject(replacement) ){
-    for( let attr in reference ){ delete reference[attr]; }
-    for (let attr in replacement) { reference[attr] = replacement[attr]; }
+  if (_.isPlainObject(reference) && _.isPlainObject(replacement) ){
+    for (let attr in reference) { delete reference[attr]; }
+    for (let attr in replacement) {
+      let el = replacement[attr];
+      // skip nully elements
+      if (_.isNull(el) || _.isUndefined(el) || _.isNaN(el)) { continue; }
+      reference[attr] = el;
+    }
   } else if (_.isArray(reference) && _.isArray(replacement)) {
     reference.length = 0;
-    replacement.forEach(el => reference.push(el));
+    replacement.forEach(el => {
+      // skip nully elements
+      if (_.isNull(el) || _.isUndefined(el) || _.isNaN(el)) { return; }
+      reference.push(el);
+    });
   }
 }
 

--- a/helper/TypeMapping.js
+++ b/helper/TypeMapping.js
@@ -154,14 +154,14 @@ function safeReplace(reference, replacement){
     for (let attr in replacement) {
       let el = replacement[attr];
       // skip nully elements
-      if (_.isNull(el) || _.isUndefined(el) || _.isNaN(el)) { continue; }
+      if (_.isNil(el) || _.isNaN(el)) { continue; }
       reference[attr] = el;
     }
   } else if (_.isArray(reference) && _.isArray(replacement)) {
     reference.length = 0;
     replacement.forEach(el => {
       // skip nully elements
-      if (_.isNull(el) || _.isUndefined(el) || _.isNaN(el)) { return; }
+      if (_.isNil(el) || _.isNaN(el)) { return; }
       reference.push(el);
     });
   }

--- a/query/view/focus_point_distance_filter.js
+++ b/query/view/focus_point_distance_filter.js
@@ -1,6 +1,4 @@
 const _ = require('lodash');
-
-const config = require('pelias-config');
 const type_mapping = require('../../helper/type_mapping');
 
 module.exports = function( vs ) {

--- a/test/unit/helper/TypeMapping.js
+++ b/test/unit/helper/TypeMapping.js
@@ -147,6 +147,19 @@ module.exports.tests.generateMappings = function(test) {
     t.deepEqual(ref, ['foo','faz']);
     t.end();
   });
+  test('generateMappings - layers - second call has fewer elements than first', function (t) {
+    var tm = new TypeMapping();
+    var ref = tm.layers; // save inital pointer reference
+    tm.layers_by_source = { foo: ['foo'], faz: ['faz'] };
+    tm.generateMappings();
+    t.deepEqual(ref.length, 2);
+    t.deepEqual(ref, ['foo', 'faz']);
+    tm.layers_by_source = { baz: ['baz'] };
+    tm.generateMappings();
+    t.deepEqual(ref.length, 1);
+    t.deepEqual(ref, ['baz']);
+    t.end();
+  });
   test('generateMappings - layer_mapping', function(t) {
     var tm = new TypeMapping();
     var ref = tm.layer_mapping; // save inital pointer reference


### PR DESCRIPTION
This bug was reported today via email.

Due to the use of `_.isObject()` returning true for Arrays the `TypeMapping` functionality had a bug which caused Arrays to be incorrectly cleared when using `type_mapping_discovery`, an easy fix was to use `_.isPlainObject` instead.

An example of what the Array would look like on the command-line:

```bash
reference keys [ '0', '1' ]
reference cleared [ <2 empty items> ]
```

An example of the effect of this in a query:

```js
{
  "terms": {
    "layer": [
      "venue",
      "pois",
      "locality",
      "localadmin",
      "neighbourhood",
      "macrohood",
      "region",
      "continent",
      "country",
      "macroregion",
      null,
      null,
      null,
      null,
      null,
      null,
      null,
      null,
      null,
      null
    ]
  }
}
```