### PR TITLE
remove npm check-types module

### DIFF
--- a/middleware/500.js
+++ b/middleware/500.js
@@ -1,8 +1,8 @@
-var check = require('check-types'),
-    logger = require( 'pelias-logger' ).get( 'api' );
+const _ = require('lodash');
+const logger = require('pelias-logger').get('api');
 
 // handle application errors
-function middleware(err, req, res, next) {
+function middleware(err, req, res) {
 
   logger.error( 'Error: `%s`. Stack trace: `%s`.', err, err.stack );
 
@@ -11,9 +11,16 @@ function middleware(err, req, res, next) {
     res.status(500);
   }
 
-  var error = ( err && err.message ) ? err.message : err;
+  // set error message
+  const error = (err && err.message) ? err.message : err;
+  let msg = 'internal server error';
+  if (_.isString(error) && !_.isEmpty(error)) {
+    msg = error;
+  }
+
+  // send response
   res.header('Cache-Control','public');
-  res.json({ error: check.nonEmptyString( error ) ? error : 'internal server error' });
+  res.json({ error: msg });
 }
 
 module.exports = middleware;

--- a/middleware/accuracy.js
+++ b/middleware/accuracy.js
@@ -3,16 +3,15 @@
  * Accuracy level should be set for each item in the results.
  * The level can be any of the following:
  *  - point
- *  - interpolated
+ *  - interpolated (not currently used)
  *  - centroid
  */
 
-var check = require('check-types');
+const _ = require('lodash');
 
-var accuracyLevelPoint = 'point';
-var accuracyLevelInterpolated = 'interpolated';
-var accuracyLevelCentroid = 'centroid';
-
+const accuracyLevelPoint = 'point';
+// const accuracyLevelInterpolated = 'interpolated';
+const accuracyLevelCentroid = 'centroid';
 
 function setup() {
   return computeAccuracy;
@@ -20,7 +19,7 @@ function setup() {
 
 function computeAccuracy(req, res, next) {
   // do nothing if no result data set
-  if (check.undefined(res) || check.undefined(res.data)) {
+  if (_.isUndefined(res) || _.isUndefined(res.data)) {
     return next();
   }
 

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -9,9 +9,8 @@
  * - fallback status (aka layer match between expected and actual)
  */
 
-var check = require('check-types');
-var logger = require('pelias-logger').get('api');
 const _ = require('lodash');
+const logger = require('pelias-logger').get('api');
 
 function setup() {
   return computeScores;
@@ -20,8 +19,8 @@ function setup() {
 function computeScores(req, res, next) {
   // do nothing if no result data set or if the query is not of the fallback variety
   // later add disambiguation to this list
-  if (check.undefined(req.clean) || check.undefined(res) ||
-      check.undefined(res.data) || check.undefined(res.meta)) {
+  if (_.isUndefined(req.clean) || _.isUndefined(res) ||
+      _.isUndefined(res.data) || _.isUndefined(res.meta)) {
     return next();
   }
 
@@ -78,7 +77,7 @@ function checkFallbackLevel(req, hit) {
       case 'street':
         return 0.8;
       case 'postalcode':
-        return 0.8;    
+        return 0.8;
       case 'localadmin':
       case 'locality':
       case 'borough':

--- a/middleware/distance.js
+++ b/middleware/distance.js
@@ -1,11 +1,9 @@
-var geolib = require('geolib');
-var check = require('check-types');
-
+const _ = require('lodash');
+const geolib = require('geolib');
 
 function setup(prefix) {
-
   return function (req, res, next) {
-    var opts = {
+    const opts = {
       prefix: prefix || 'point.'
     };
     return computeDistances(req, res, next, opts);
@@ -19,8 +17,8 @@ function computeDistances(req, res, next, opts) {
     return next();
   }
 
-  if (!(check.number(req.clean[opts.prefix + 'lat']) &&
-        check.number(req.clean[opts.prefix + 'lon']))) {
+  if (!(_.isFinite(req.clean[opts.prefix + 'lat']) &&
+        _.isFinite(req.clean[opts.prefix + 'lon']))) {
     return next();
   }
 

--- a/middleware/localNamingConventions.js
+++ b/middleware/localNamingConventions.js
@@ -1,4 +1,3 @@
-const check = require('check-types');
 const _ = require('lodash');
 const field = require('../helper/fieldValue');
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@hapi/joi": "^16.0.1",
     "@mapbox/geojson-extent": "^0.3.1",
     "async": "^3.0.1",
-    "check-types": "^10.0.0",
     "elasticsearch": "^16.0.0",
     "express": "^4.8.8",
     "geojson": "^0.5.0",

--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -1,8 +1,6 @@
+const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
-const logger = require('pelias-logger').get('api');
-const _ = require('lodash');
-const check = require('check-types');
 
 //------------------------------
 // general-purpose search query
@@ -142,8 +140,8 @@ function generateQuery( clean, res ){
   }
 
   // focus point
-  if( check.number(clean['focus.point.lat']) &&
-      check.number(clean['focus.point.lon']) ){
+  if( _.isFinite(clean['focus.point.lat']) &&
+      _.isFinite(clean['focus.point.lon']) ){
     vs.set({
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
@@ -151,10 +149,10 @@ function generateQuery( clean, res ){
   }
 
   // boundary rect
-  if( check.number(clean['boundary.rect.min_lat']) &&
-      check.number(clean['boundary.rect.max_lat']) &&
-      check.number(clean['boundary.rect.min_lon']) &&
-      check.number(clean['boundary.rect.max_lon']) ){
+  if( _.isFinite(clean['boundary.rect.min_lat']) &&
+      _.isFinite(clean['boundary.rect.max_lat']) &&
+      _.isFinite(clean['boundary.rect.min_lon']) &&
+      _.isFinite(clean['boundary.rect.max_lon']) ){
     vs.set({
       'boundary:rect:top': clean['boundary.rect.max_lat'],
       'boundary:rect:right': clean['boundary.rect.max_lon'],
@@ -164,14 +162,14 @@ function generateQuery( clean, res ){
   }
 
   // boundary circle
-  if( check.number(clean['boundary.circle.lat']) &&
-      check.number(clean['boundary.circle.lon']) ){
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
     vs.set({
       'boundary:circle:lat': clean['boundary.circle.lat'],
       'boundary:circle:lon': clean['boundary.circle.lon']
     });
 
-    if( check.number(clean['boundary.circle.radius']) ){
+    if( _.isFinite(clean['boundary.circle.radius']) ){
       vs.set({
         'boundary:circle:radius': Math.round( clean['boundary.circle.radius'] ) + 'km'
       });
@@ -179,14 +177,14 @@ function generateQuery( clean, res ){
   }
 
   // boundary country
-  if( check.nonEmptyArray(clean['boundary.country']) ){
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
       'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 
   // boundary gid
-  if ( check.string(clean['boundary.gid']) ){
+  if ( _.isString(clean['boundary.gid']) ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -1,8 +1,7 @@
+const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./autocomplete_defaults');
 const textParser = require('./text_parser_pelias');
-const check = require('check-types');
-const logger = require('pelias-logger').get('api');
 const config = require('pelias-config').generate();
 const placeTypes = require('../helper/placeTypes');
 
@@ -82,17 +81,17 @@ function generateQuery( clean ){
   const vs = new peliasQuery.Vars( defaults );
 
   // sources
-  if( check.array(clean.sources) && clean.sources.length ){
+  if( _.isArray(clean.sources) && !_.isEmpty(clean.sources) ){
     vs.var( 'sources', clean.sources );
   }
 
   // layers
-  if( check.array(clean.layers) && clean.layers.length ){
+  if (_.isArray(clean.layers) && !_.isEmpty(clean.layers) ){
     vs.var( 'layers', clean.layers);
   }
 
   // boundary country
-  if( check.nonEmptyArray(clean['boundary.country']) ){
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
       'boundary:country': clean['boundary.country'].join(' ')
     });
@@ -100,7 +99,7 @@ function generateQuery( clean ){
 
   // pass the input tokens to the views so they can choose which tokens
   // are relevant for their specific function.
-  if( check.array( clean.tokens ) ){
+  if( _.isArray( clean.tokens ) ){
     vs.var( 'input:name:tokens', clean.tokens );
     vs.var( 'input:name:tokens_complete', clean.tokens_complete );
     vs.var( 'input:name:tokens_incomplete', clean.tokens_incomplete );
@@ -114,7 +113,7 @@ function generateQuery( clean ){
   // slightly from the 'input:name:tokens' array as some tokens might have been
   // removed in the process; such as single grams which are not present in then
   // ngrams index.
-  if( check.array( clean.tokens_complete ) && check.array( clean.tokens_incomplete ) ){
+  if( _.isArray( clean.tokens_complete ) && _.isArray( clean.tokens_incomplete ) ){
     var combined = clean.tokens_complete.concat( clean.tokens_incomplete );
     if( combined.length ){
       vs.var( 'input:name', combined.join(' ') );
@@ -122,8 +121,8 @@ function generateQuery( clean ){
   }
 
   // focus point
-  if( check.number(clean['focus.point.lat']) &&
-      check.number(clean['focus.point.lon']) ){
+  if( _.isFinite(clean['focus.point.lat']) &&
+      _.isFinite(clean['focus.point.lon']) ){
     vs.set({
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
@@ -131,10 +130,10 @@ function generateQuery( clean ){
   }
 
   // boundary rect
-  if( check.number(clean['boundary.rect.min_lat']) &&
-      check.number(clean['boundary.rect.max_lat']) &&
-      check.number(clean['boundary.rect.min_lon']) &&
-      check.number(clean['boundary.rect.max_lon']) ){
+  if( _.isFinite(clean['boundary.rect.min_lat']) &&
+      _.isFinite(clean['boundary.rect.max_lat']) &&
+      _.isFinite(clean['boundary.rect.min_lon']) &&
+      _.isFinite(clean['boundary.rect.max_lon']) ){
     vs.set({
       'boundary:rect:top': clean['boundary.rect.max_lat'],
       'boundary:rect:right': clean['boundary.rect.max_lon'],
@@ -145,14 +144,14 @@ function generateQuery( clean ){
 
   // boundary circle
   // @todo: change these to the correct request variable names
-  if( check.number(clean['boundary.circle.lat']) &&
-      check.number(clean['boundary.circle.lon']) ){
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
     vs.set({
       'boundary:circle:lat': clean['boundary.circle.lat'],
       'boundary:circle:lon': clean['boundary.circle.lon']
     });
 
-    if( check.number(clean['boundary.circle.radius']) ){
+    if( _.isFinite(clean['boundary.circle.radius']) ){
       vs.set({
         'boundary:circle:radius': Math.round( clean['boundary.circle.radius'] ) + 'km'
       });
@@ -160,7 +159,7 @@ function generateQuery( clean ){
   }
 
   // boundary gid
-  if( check.string(clean['boundary.gid']) ){
+  if( _.isString(clean['boundary.gid']) ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });

--- a/query/reverse.js
+++ b/query/reverse.js
@@ -1,8 +1,6 @@
+const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./reverse_defaults');
-const check = require('check-types');
-const _ = require('lodash');
-const logger = require('pelias-logger').get('api');
 
 //------------------------------
 // reverse geocode query
@@ -35,19 +33,19 @@ function generateQuery( clean ){
   }
 
   // sources
-  if( check.array(clean.sources) && clean.sources.length ) {
+  if( _.isArray(clean.sources) && !_.isEmpty(clean.sources) ) {
     vs.var('sources', clean.sources);
   }
 
   // layers
-  if( check.array(clean.layers) && clean.layers.length ) {
+  if( _.isArray(clean.layers) && !_.isEmpty(clean.layers) ) {
     // only include non-coarse layers
     vs.var( 'layers', _.intersection(clean.layers, ['address', 'street', 'venue']));
   }
 
   // focus point to score by distance
-  if( check.number(clean['point.lat']) &&
-      check.number(clean['point.lon']) ){
+  if( _.isFinite(clean['point.lat']) &&
+      _.isFinite(clean['point.lon']) ){
     vs.set({
       'focus:point:lat': clean['point.lat'],
       'focus:point:lon': clean['point.lon']
@@ -58,20 +56,20 @@ function generateQuery( clean ){
   // note: the sanitizers will take care of the case
   // where point.lan/point.lon are provided in the
   // absense of boundary.circle.lat/boundary.circle.lon
-  if( check.number(clean['boundary.circle.lat']) &&
-      check.number(clean['boundary.circle.lon']) ){
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
 
         vs.set({
           'boundary:circle:lat': clean['boundary.circle.lat'],
           'boundary:circle:lon': clean['boundary.circle.lon']
         });
 
-        if (check.undefined(clean['boundary.circle.radius'])){
+        if (_.isUndefined(clean['boundary.circle.radius'])){
           // for coarse reverse when boundary circle radius is undefined
           vs.set({
             'boundary:circle:radius': defaults['boundary:circle:radius']
           });
-        } else if (check.number(clean['boundary.circle.radius'])){
+        } else if (_.isFinite(clean['boundary.circle.radius'])){
           // plain reverse where boundary circle is a valid number
           vs.set({
             'boundary:circle:radius': clean['boundary.circle.radius'] + 'km'
@@ -80,14 +78,14 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.nonEmptyArray(clean['boundary.country']) ){
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
       'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 
   // boundary gid
-  if ( check.string(clean['boundary.gid']) ){
+  if ( _.isString(clean['boundary.gid']) ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });

--- a/query/search.js
+++ b/query/search.js
@@ -1,8 +1,7 @@
+const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
 const textParser = require('./text_parser');
-const check = require('check-types');
-const logger = require('pelias-logger').get('api');
 
 //------------------------------
 // general-purpose search query
@@ -38,17 +37,17 @@ function generateQuery( clean ){
   vs.var( 'input:name', clean.text );
 
   // sources
-  if( check.array(clean.sources) && clean.sources.length ) {
+  if( _.isArray(clean.sources) && !_.isEmpty(clean.sources) ) {
     vs.var( 'sources', clean.sources);
   }
 
   // layers
-  if( check.array(clean.layers) && clean.layers.length ) {
+  if( _.isArray(clean.layers) && !_.isEmpty(clean.layers) ) {
     vs.var('layers', clean.layers);
   }
 
   // categories
-  if (clean.categories && clean.categories.length) {
+  if (clean.categories && !_.isEmpty(clean.categories)) {
     vs.var('input:categories', clean.categories);
   }
 
@@ -58,8 +57,8 @@ function generateQuery( clean ){
   }
 
   // focus point
-  if( check.number(clean['focus.point.lat']) &&
-      check.number(clean['focus.point.lon']) ){
+  if( _.isFinite(clean['focus.point.lat']) &&
+      _.isFinite(clean['focus.point.lon']) ){
     vs.set({
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
@@ -67,10 +66,10 @@ function generateQuery( clean ){
   }
 
   // boundary rect
-  if( check.number(clean['boundary.rect.min_lat']) &&
-      check.number(clean['boundary.rect.max_lat']) &&
-      check.number(clean['boundary.rect.min_lon']) &&
-      check.number(clean['boundary.rect.max_lon']) ){
+  if( _.isFinite(clean['boundary.rect.min_lat']) &&
+      _.isFinite(clean['boundary.rect.max_lat']) &&
+      _.isFinite(clean['boundary.rect.min_lon']) &&
+      _.isFinite(clean['boundary.rect.max_lon']) ){
     vs.set({
       'boundary:rect:top': clean['boundary.rect.max_lat'],
       'boundary:rect:right': clean['boundary.rect.max_lon'],
@@ -81,14 +80,14 @@ function generateQuery( clean ){
 
   // boundary circle
   // @todo: change these to the correct request variable names
-  if( check.number(clean['boundary.circle.lat']) &&
-      check.number(clean['boundary.circle.lon']) ){
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
     vs.set({
       'boundary:circle:lat': clean['boundary.circle.lat'],
       'boundary:circle:lon': clean['boundary.circle.lon']
     });
 
-    if( check.number(clean['boundary.circle.radius']) ){
+    if( _.isFinite(clean['boundary.circle.radius']) ){
       vs.set({
         'boundary:circle:radius': Math.round( clean['boundary.circle.radius'] ) + 'km'
       });
@@ -96,14 +95,14 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.nonEmptyArray(clean['boundary.country']) ){
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
       'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 
   // boundary gid
-  if ( check.string(clean['boundary.gid']) ){
+  if ( _.isString(clean['boundary.gid']) ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });

--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -1,8 +1,7 @@
+const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
 const textParser = require('./text_parser_pelias');
-const check = require('check-types');
-const logger = require('pelias-logger').get('api');
 const config = require('pelias-config').generate().api;
 
 var placeTypes = require('../helper/placeTypes');
@@ -63,17 +62,17 @@ function generateQuery( clean ){
   vs.var( 'match_phrase:main:input', clean.text );
 
   // sources
-  if( check.array(clean.sources) && clean.sources.length ) {
+  if( _.isArray(clean.sources) && !_.isEmpty(clean.sources) ) {
     vs.var( 'sources', clean.sources);
   }
 
   // layers
-  if( check.array(clean.layers) && clean.layers.length ) {
+  if( _.isArray(clean.layers) && !_.isEmpty(clean.layers) ) {
     vs.var( 'layers', clean.layers);
   }
 
   // categories
-  if (clean.categories && clean.categories.length) {
+  if (clean.categories && !_.isEmpty(clean.categories)) {
     vs.var('input:categories', clean.categories);
   }
 
@@ -83,8 +82,8 @@ function generateQuery( clean ){
   }
 
   // focus point
-  if( check.number(clean['focus.point.lat']) &&
-      check.number(clean['focus.point.lon']) ){
+  if( _.isFinite(clean['focus.point.lat']) &&
+      _.isFinite(clean['focus.point.lon']) ){
     vs.set({
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
@@ -92,10 +91,10 @@ function generateQuery( clean ){
   }
 
   // boundary rect
-  if( check.number(clean['boundary.rect.min_lat']) &&
-      check.number(clean['boundary.rect.max_lat']) &&
-      check.number(clean['boundary.rect.min_lon']) &&
-      check.number(clean['boundary.rect.max_lon']) ){
+  if( _.isFinite(clean['boundary.rect.min_lat']) &&
+      _.isFinite(clean['boundary.rect.max_lat']) &&
+      _.isFinite(clean['boundary.rect.min_lon']) &&
+      _.isFinite(clean['boundary.rect.max_lon']) ){
     vs.set({
       'boundary:rect:top': clean['boundary.rect.max_lat'],
       'boundary:rect:right': clean['boundary.rect.max_lon'],
@@ -106,14 +105,14 @@ function generateQuery( clean ){
 
   // boundary circle
   // @todo: change these to the correct request variable names
-  if( check.number(clean['boundary.circle.lat']) &&
-      check.number(clean['boundary.circle.lon']) ){
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
     vs.set({
       'boundary:circle:lat': clean['boundary.circle.lat'],
       'boundary:circle:lon': clean['boundary.circle.lon']
     });
 
-    if( check.number(clean['boundary.circle.radius']) ){
+    if( _.isFinite(clean['boundary.circle.radius']) ){
       vs.set({
         'boundary:circle:radius': Math.round( clean['boundary.circle.radius'] ) + 'km'
       });
@@ -121,14 +120,14 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.nonEmptyArray(clean['boundary.country']) ){
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
       'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 
   // boundary gid
-  if ( check.string(clean['boundary.gid']) ){
+  if ( _.isString(clean['boundary.gid']) ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });

--- a/query/structured_geocoding.js
+++ b/query/structured_geocoding.js
@@ -1,7 +1,7 @@
-const peliasQuery = require('pelias-query'),
-      defaults = require('./search_defaults'),
-      textParser = require('./text_parser'),
-      check = require('check-types');
+const _ = require('lodash');
+const peliasQuery = require('pelias-query');
+const defaults = require('./search_defaults');
+const textParser = require('./text_parser');
 
 //------------------------------
 // general-purpose search query
@@ -47,8 +47,8 @@ function generateQuery( clean ){
   }
 
   // focus point
-  if( check.number(clean['focus.point.lat']) &&
-      check.number(clean['focus.point.lon']) ){
+  if( _.isFinite(clean['focus.point.lat']) &&
+      _.isFinite(clean['focus.point.lon']) ){
     vs.set({
       'focus:point:lat': clean['focus.point.lat'],
       'focus:point:lon': clean['focus.point.lon']
@@ -56,10 +56,10 @@ function generateQuery( clean ){
   }
 
   // boundary rect
-  if( check.number(clean['boundary.rect.min_lat']) &&
-      check.number(clean['boundary.rect.max_lat']) &&
-      check.number(clean['boundary.rect.min_lon']) &&
-      check.number(clean['boundary.rect.max_lon']) ){
+  if( _.isFinite(clean['boundary.rect.min_lat']) &&
+      _.isFinite(clean['boundary.rect.max_lat']) &&
+      _.isFinite(clean['boundary.rect.min_lon']) &&
+      _.isFinite(clean['boundary.rect.max_lon']) ){
     vs.set({
       'boundary:rect:top': clean['boundary.rect.max_lat'],
       'boundary:rect:right': clean['boundary.rect.max_lon'],
@@ -70,14 +70,14 @@ function generateQuery( clean ){
 
   // boundary circle
   // @todo: change these to the correct request variable names
-  if( check.number(clean['boundary.circle.lat']) &&
-      check.number(clean['boundary.circle.lon']) ){
+  if( _.isFinite(clean['boundary.circle.lat']) &&
+      _.isFinite(clean['boundary.circle.lon']) ){
     vs.set({
       'boundary:circle:lat': clean['boundary.circle.lat'],
       'boundary:circle:lon': clean['boundary.circle.lon']
     });
 
-    if( check.number(clean['boundary.circle.radius']) ){
+    if( _.isFinite(clean['boundary.circle.radius']) ){
       vs.set({
         'boundary:circle:radius': Math.round( clean['boundary.circle.radius'] ) + 'km'
       });
@@ -85,14 +85,14 @@ function generateQuery( clean ){
   }
 
   // boundary country
-  if( check.nonEmptyArray(clean['boundary.country']) ){
+  if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
       'boundary:country': clean['boundary.country'].join(' ')
     });
   }
 
   // boundary gid
-  if ( check.string(clean['boundary.gid']) ){
+  if ( _.isString(clean['boundary.gid']) ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });

--- a/sanitizer/_boundary_country.js
+++ b/sanitizer/_boundary_country.js
@@ -1,4 +1,5 @@
-const check = require('check-types');
+const _ = require('lodash');
+const nonEmptyString = (v) => _.isString(v) && !_.isEmpty(v);
 const iso3166 = require('../helper/iso3166');
 
 function _sanitize(raw, clean) {
@@ -10,23 +11,23 @@ function _sanitize(raw, clean) {
 
   // param 'boundary.country' is optional and should not
   // error when simply not set by the user
-  if (check.assigned(countries)) {
+  if (!_.isNil(countries)) {
 
     // must be valid string
-    if (!check.nonEmptyString(countries)) {
+    if (!nonEmptyString(countries)) {
       messages.errors.push('boundary.country is not a string');
     } else {
       // support for multi countries
-      countries = countries.split(',').filter(check.nonEmptyString);
+      countries = countries.split(',').filter(nonEmptyString);
       const invalidIsoCodes = countries.filter(country => !containsIsoCode(country));
 
       // country list must contains at least one element
-      if (check.emptyArray(countries)) {
+      if (_.isArray(countries) && _.isEmpty(countries)) {
         messages.errors.push('boundary.country is empty');
       }
 
       // must be a valid ISO 3166 code
-      else if (check.nonEmptyArray(invalidIsoCodes)) {
+      else if (_.isArray(invalidIsoCodes) && !_.isEmpty(invalidIsoCodes)) {
         invalidIsoCodes.forEach(country => messages.errors.push(country + ' is not a valid ISO2/ISO3 country code'));
       }
 

--- a/sanitizer/_boundary_gid.js
+++ b/sanitizer/_boundary_gid.js
@@ -1,5 +1,4 @@
-var _ = require('lodash'),
-    check = require('check-types');
+const _ = require('lodash');
 
 function _sanitize(raw, clean) {
   // error & warning messages
@@ -11,8 +10,8 @@ function _sanitize(raw, clean) {
   // param 'boundary.gid' is optional and should not
   // error when simply not set by the user
   // must be valid string
-  if (check.assigned(boundary_gid)) {
-    if (!check.nonEmptyString(boundary_gid)) {
+  if (!_.isNil(boundary_gid)) {
+    if (!_.isString(boundary_gid) || _.isEmpty(boundary_gid)) {
       messages.errors.push('boundary.gid is not a string');
     }
     else {

--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -1,7 +1,7 @@
-var check = require('check-types');
-var categoryTaxonomy = require('pelias-categories');
+const _ = require('lodash');
+const categoryTaxonomy = require('pelias-categories');
 
-var WARNINGS = {
+const WARNINGS = {
   empty: 'Categories parameter left blank, showing results from all categories.'
 };
 
@@ -24,7 +24,7 @@ function _sanitize (raw, clean, categories) {
       return cat.toLowerCase().trim(); // lowercase inputs
     })
     .filter(cat => {
-      if (check.nonEmptyString(cat) && categories.isValidCategory(cat)) {
+      if (_.isString(cat) && !_.isEmpty(cat) && categories.isValidCategory(cat)) {
         return true;
       }
       return false;

--- a/sanitizer/_geo_common.js
+++ b/sanitizer/_geo_common.js
@@ -1,10 +1,9 @@
 /**
  * helper sanitizer methods for geo parameters
  */
-var groups = require('./_groups'),
-    check = require('check-types'),
-    wrap = require('./wrap'),
-    _ = require('lodash');
+const _ = require('lodash');
+const groups = require('./_groups');
+const wrap = require('./wrap');
 
 /**
  * Parse and validate rect parameter
@@ -16,13 +15,13 @@ var groups = require('./_groups'),
  */
 function sanitize_rect( key_prefix, clean, raw, bbox_is_required ) {
   // calculate full property names from the key_prefix
-  var properties = [ 'min_lat', 'max_lat', 'min_lon', 'max_lon' ].map(function(prop) {
-    return key_prefix + '.' + prop;
+  var properties = [ 'min_lat', 'max_lat', 'min_lon', 'max_lon' ].map(prop => {
+    return `${key_prefix}.${prop}`;
   });
 
   // sanitize the rect property group, this throws an exception if
   // the group is not complete
-  var bbox_present;
+  let bbox_present;
   if (bbox_is_required) {
     bbox_present = groups.required(raw, properties);
   } else {
@@ -37,14 +36,14 @@ function sanitize_rect( key_prefix, clean, raw, bbox_is_required ) {
   sanitize_bbox_bounds(raw, key_prefix);
 
   // use sanitize_coord to set values in `clean`
-  properties.forEach(function(prop) {
+  properties.forEach(prop => {
     sanitize_coord(prop, clean, raw, true);
   });
 }
 
   // validate max is greater than min for lat and lon
 function sanitize_bbox_min_max(raw, key_prefix) {
-  ['lat', 'lon'].forEach(function(dimension) {
+  ['lat', 'lon'].forEach(dimension => {
     const max = parseFloat(raw[`${key_prefix}.max_${dimension}`]);
     const min = parseFloat(raw[`${key_prefix}.min_${dimension}`]);
 
@@ -57,15 +56,15 @@ function sanitize_bbox_min_max(raw, key_prefix) {
 // validate lat/lon values are within bounds
 function sanitize_bbox_bounds(raw, key_prefix) {
   const bounds = [ { dimension: 'lat', range: 90},
-                   { dimension: 'lon', range: 180}];
+                   { dimension: 'lon', range: 180} ];
 
-  bounds.forEach(function(bound) {
+  bounds.forEach(bound => {
     const values = {
       max: parseFloat(raw[`${key_prefix}.max_${bound.dimension}`]),
       min: parseFloat(raw[`${key_prefix}.min_${bound.dimension}`])
     };
 
-    ['min', 'max'].forEach(function(prefix) {
+    ['min', 'max'].forEach(prefix => {
       if (Math.abs(values[prefix]) > bound.range) {
         const key =`${key_prefix}.${prefix}_${bound.dimension}`;
         throw new Error(`${key} value ${values[prefix]} is outside range -${bound.range},${bound.range}`);
@@ -85,7 +84,7 @@ function sanitize_bbox_bounds(raw, key_prefix) {
 function sanitize_circle( key_prefix, clean, raw, circle_is_required ) {
   // sanitize both a point and a radius if radius is present
   // otherwise just sanittize the point
-  if( check.assigned( raw[ key_prefix + '.radius' ] ) ){
+  if( !_.isNil( raw[ key_prefix + '.radius' ] ) ){
     sanitize_coord( key_prefix + '.radius', clean, raw, true );
     sanitize_point( key_prefix, clean, raw, true);
   } else {
@@ -104,8 +103,8 @@ function sanitize_circle( key_prefix, clean, raw, circle_is_required ) {
 function sanitize_point( key_prefix, clean, raw, point_is_required ) {
 
   // calculate full property names from the key_prefix
-  var properties = [ 'lat', 'lon'].map(function(prop) {
-    return key_prefix + '.' + prop;
+  var properties = [ 'lat', 'lon'].map(prop => {
+    return `${key_prefix}.${prop}`;
   });
 
   // sanitize the rect property group, this throws an exception if
@@ -123,7 +122,7 @@ function sanitize_point( key_prefix, clean, raw, point_is_required ) {
 
   // check each property individually. now that it is known a bbox is present,
   // all properties must exist, so pass the true flag for coord_is_required
-  properties.forEach(function(prop) {
+  properties.forEach(prop => {
     sanitize_coord(prop, clean, raw, true);
   });
 

--- a/sanitizer/_geo_search.js
+++ b/sanitizer/_geo_search.js
@@ -1,9 +1,9 @@
-var check = require('check-types');
-var geo_common = require ('./_geo_common');
+const _ = require('lodash');
+const geo_common = require ('./_geo_common');
 
-var LAT_LON_IS_REQUIRED = false;
-var RECT_IS_REQUIRED = false;
-var CIRCLE_IS_REQUIRED = false;
+const LAT_LON_IS_REQUIRED = false;
+const RECT_IS_REQUIRED = false;
+const CIRCLE_IS_REQUIRED = false;
 
 // validate inputs, convert types and apply defaults
 function _sanitize( raw, clean ){

--- a/sanitizer/_ids.js
+++ b/sanitizer/_ids.js
@@ -1,18 +1,18 @@
 const _ = require('lodash');
-const check = require('check-types');
+const nonEmptyString = (v) => _.isString(v) && !_.isEmpty(v);
 const type_mapping = require('../helper/type_mapping');
 const decode_gid = require('../helper/decode_gid');
 
 // validate inputs, convert types and apply defaults id generally looks like
 // 'geonames:venue:4163334' (source:layer:id) so, all three are required
 
-var lengthError = 'invalid param \'ids\': length must be >0';
+const lengthError = 'invalid param \'ids\': length must be >0';
 
-var formatError = function(input) {
+const formatError = function(input) {
   return 'id `' + input + ' is invalid: must be of the format source:layer:id for ex: \'geonames:venue:4163334\'';
 };
 
-var targetError = function(target, target_list) {
+const targetError = function(target, target_list) {
   return target + ' is invalid. It must be one of these values - [' + target_list.join(', ') + ']';
 };
 
@@ -54,7 +54,7 @@ function _sanitize( raw, clean ){
   // error & warning messages
   var messages = { errors: [], warnings: [] };
 
-  if (!check.nonEmptyString( raw.ids )) {
+  if (!nonEmptyString( raw.ids )) {
     messages.errors.push( lengthError);
     return messages;
   }
@@ -66,16 +66,16 @@ function _sanitize( raw, clean ){
   rawIds = _.uniq(rawIds);
 
   // ensure all elements are valid non-empty strings
-  if (!rawIds.every(check.nonEmptyString)) {
+  if (!rawIds.every(nonEmptyString)) {
       messages.errors.push( lengthError );
   }
 
   // cycle through raw ids and set those which are valid
-  var validIds = rawIds.map(function(rawId) {
+  var validIds = rawIds.map(rawId => {
     return sanitizeId(rawId, messages);
   });
 
-  if (validIds.every(check.object)) {
+  if (validIds.every(_.isObject)) {
     clean.ids = validIds;
   }
 

--- a/sanitizer/_single_scalar_parameters.js
+++ b/sanitizer/_single_scalar_parameters.js
@@ -1,12 +1,11 @@
-var _ = require('lodash'),
-    check = require('check-types');
+const _ = require('lodash');
 
 // validate inputs
 function _sanitize( raw, clean ){
   // error & warning messages
   var messages = { errors: [], warnings: [] };
 
-  Object.keys(raw).forEach(function(key) {
+  Object.keys(raw).forEach(key => {
     if (_.isArray(raw[key])) {
       messages.errors.push('\'' + key + '\' parameter can only have one value');
       delete raw[key];
@@ -14,7 +13,6 @@ function _sanitize( raw, clean ){
       messages.errors.push('\'' + key + '\' parameter must be a scalar');
       delete raw[key];
     }
-
   });
 
   return messages;

--- a/sanitizer/_size.js
+++ b/sanitizer/_size.js
@@ -1,16 +1,15 @@
-var check = require('check-types');
-
-var MIN_SIZE = 1,
-    MAX_SIZE = 40,
-    DEFAULT_SIZE = 10;
+const _ = require('lodash');
+const MIN_SIZE = 1;
+const MAX_SIZE = 40;
+const DEFAULT_SIZE = 10;
 
 // validate inputs, convert types and apply defaults
 function _setup( size_min, size_max, size_def ){
 
   // allow caller to inject custom min/max/default values
-  if( !check.number( size_min ) ){ size_min = MIN_SIZE; }
-  if( !check.number( size_max ) ){ size_max = MAX_SIZE; }
-  if( !check.number( size_def ) ){ size_def = DEFAULT_SIZE; }
+  if( !_.isFinite( size_min ) ){ size_min = MIN_SIZE; }
+  if( !_.isFinite( size_max ) ){ size_max = MAX_SIZE; }
+  if( !_.isFinite( size_def ) ){ size_def = DEFAULT_SIZE; }
 
   return {
     sanitize: function _sanitize( raw, clean ){

--- a/sanitizer/_targets.js
+++ b/sanitizer/_targets.js
@@ -1,5 +1,4 @@
-var _ = require('lodash'),
-    check = require('check-types');
+const _ = require('lodash');
 
 function getValidKeys(mapping) {
   return _.uniq(Object.keys(mapping)).join(',');
@@ -20,11 +19,11 @@ function _setup( paramName, targetMap ) {
       var targetsString = raw[opts.paramName];
 
       // trim whitespace
-      if( check.nonEmptyString( targetsString ) ){
+      if( _.isString( targetsString ) && !_.isEmpty( targetsString ) ){
         targetsString = targetsString.trim();
 
         // param must be a valid non-empty string
-        if( !check.nonEmptyString( targetsString ) ){
+        if( !_.isString( targetsString ) || _.isEmpty( targetsString ) ){
           messages.errors.push(
             opts.paramName + ' parameter cannot be an empty string. Valid options: ' + getValidKeys(opts.targetMap)
           );
@@ -58,12 +57,11 @@ function _setup( paramName, targetMap ) {
       }
 
       // string is empty
-      else if( check.string( targetsString ) ){
+      else if( _.isString( targetsString ) ){
         messages.errors.push(
           opts.paramName + ' parameter cannot be an empty string. Valid options: ' + getValidKeys(opts.targetMap)
         );
       }
-
 
       return messages;
     } // end of _sanitize function


### PR DESCRIPTION
something I've been wanting to do for a while....
this PR removes the `check-types` module and replaces it with `lodash`.

the `check-types` module is quite convenient for functions such as `check.nonEmptyString`, however all the same functionality is available within the `lodash` module which we have made available pretty much across all repos.

this is intended as a no-op refactor and all the tests are passing afterwards.
the two libraries have slightly different functionality and I've done my best to check the source and replace them appropriately.

note: my editor is set up to strip extra whitespace and it also highlights when `require` statements are not used, so there was some cleanup there. I've also refactored some of the code to be more modern or read more easily.

closes https://github.com/pelias/api/pull/1403