### PR TITLE
Update expected test value for -0

### DIFF
--- a/test/unit/helper/fieldValue.js
+++ b/test/unit/helper/fieldValue.js
@@ -26,7 +26,7 @@ module.exports.tests.getArrayValue = function(test) {
     t.deepEqual(field.getArrayValue('foo'), ['foo'], 'string');
     t.deepEqual(field.getArrayValue(['foo','bar']), ['foo','bar'], 'array');
     t.deepEqual(field.getArrayValue(['']), [''], 'array with empty string');
-    t.deepEqual(field.getArrayValue(-0), [0], 'number');
+    t.deepEqual(field.getArrayValue(-0), [-0], 'number');
     t.deepEqual(field.getArrayValue(+0), [0], 'number');
     t.deepEqual(field.getArrayValue({foo: 'bar'}), [{foo: 'bar'}], '[*]');
     t.end();


### PR DESCRIPTION
Looks like a [recent release](https://github.com/substack/tape/releases/tag/v4.12.0) of Tape made changes around how +0/-0 is handled.

It actually looks like the new behavior is more correct: `-0` now makes its way through the test, where previously it was converted to `+0`.