### PR TITLE
Support aliases config in `api.targets.layers_by_source`

### DIFF
--- a/helper/TypeMapping.js
+++ b/helper/TypeMapping.js
@@ -75,6 +75,18 @@ TypeMapping.prototype.setCanonicalSources = function( sources ){
   safeReplace(this.canonical_sources, sources);
 };
 
+TypeMapping.prototype.updateLayersBySourceWithAliases = function (){
+  for (let source in this.layers_by_source) {
+    const layers = this.layers_by_source[source].reduce((acc, layer) => {
+      if (!this.layer_aliases[layer]) {
+        return acc.concat([layer]);
+      }
+      return acc.concat(this.layer_aliases[layer]);
+    }, []);
+    safeReplace(this.layers_by_source[source], _.uniq(layers));
+  }
+};
+
 // generate mappings after setters have been run
 TypeMapping.prototype.generateMappings = function(){
 
@@ -119,6 +131,8 @@ TypeMapping.prototype.loadTargets = function( targetsBlock ){
   this.setLayersBySource( targetsBlock.layers_by_source || {} );
   this.setLayerAliases( targetsBlock.layer_aliases || {} );
   this.setCanonicalSources( targetsBlock.canonical_sources || [] );
+
+  this.updateLayersBySourceWithAliases();
 
   // generate the mappings
   this.generateMappings();

--- a/test/unit/helper/TypeMapping.js
+++ b/test/unit/helper/TypeMapping.js
@@ -190,8 +190,11 @@ module.exports.tests.loadTargets = function(test) {
     });
     t.deepEqual(tm.sources, [ 'source1', 'source2' ]);
     t.deepEqual(tm.source_mapping, { source1: [ 's1', 's2' ], source2: [ 's3', 's4' ] });
-    t.deepEqual(tm.layers, [ 'layer1', 'layer3', 'layer2' ]);
-    t.deepEqual(tm.layer_mapping, { layer1: [ 'l1', 'l2' ], layer2: [ 'l3', 'l4' ], layer3: [ 'layer3' ] });
+    t.deepEqual(tm.layers, [ 'l1', 'l2', 'layer3', 'l3', 'l4' ]);
+    t.deepEqual(tm.layer_mapping, {
+      layer1: [ 'l1', 'l2' ], layer2: [ 'l3', 'l4' ], layer3: [ 'layer3' ],
+      l1: [ 'l1' ], l2: [ 'l2' ], l3: [ 'l3' ], l4: [ 'l4' ]
+    });
     t.end();
   });
 };

--- a/test/unit/helper/type_mapping.js
+++ b/test/unit/helper/type_mapping.js
@@ -114,7 +114,7 @@ module.exports.tests.interfaces = function(test, common) {
       whosonfirst: [ 'continent', 'empire', 'country', 'dependency', 'macroregion',
         'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood',
         'borough', 'neighbourhood', 'microhood', 'disputed', 'venue', 'postalcode',
-        'continent', 'ocean', 'marinearea' ]
+        'ocean', 'marinearea' ]
     });
     t.end();
   });


### PR DESCRIPTION
### Use-cases

`coarse` is a pretty cool alias, it includes all admin layers in one shoot. Following pelias/config#127, I wondered how custom targets work. Setting value on `layers_by_source` is quite annoying when you have a custom layers that are like WOF. Why don't we use `coarse` ? This is the main subject of my PR.

### Attempted Solutions

I try to add `coarse` to a custom layer, but it didn't work. The error was funny :sweat_smile: 

The targets config looks like this
```json
{
  "targets": {
    "layers_by_source": {
      "source_with_coarse": ["coarse"]
    }
  }
}
```

If I use `locality` for example (which is in the `coarse` list)

```http
GET /v1/search?sources=source_with_coarse&text=Paris&layers=locality

{
"errors": [
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the locality layer"
]
}
```
And if I use the value in the configuration:

```http
GET /v1/search?sources=source_with_coarse&text=Paris&layers=coarse

{
"errors": [
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the continent layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the empire layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the country layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the dependency layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the macroregion layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the region layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the locality layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the localadmin layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the macrocounty layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the county layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the macrohood layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the borough layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the neighbourhood layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the microhood layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the disputed layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the postalcode layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the ocean layer",
  "You have specified both the `sources` and `layers` parameters in a combination that will return no results: the test source has nothing in the marinearea layer"
]
}
```

### Proposal

I chose to update the type mapping at startup and replace aliases by the list of layers. Now all work as expected :smile: 

IMO, the safe replace is not required in my new function :man_shrugging: 