### PR TITLE
Update pelias-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^7.0.0",
-    "pelias-parser": "1.38.0",
+    "pelias-parser": "1.44.0",
     "pelias-query": "^9.14.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",

--- a/test/unit/sanitizer/_text_pelias_parser.js
+++ b/test/unit/sanitizer/_text_pelias_parser.js
@@ -206,8 +206,9 @@ module.exports.tests.text_parser = function (test, common) {
   cases.push(['Calle Principal ', { subject: 'Calle Principal' }, true]);
   cases.push(['Calle Principal B', { subject: 'Calle Principal' }, true]);
   // cases.push(['Calle Principal Ba', { subject: 'Calle Principal' }, true]); // jitter issue
-  cases.push(['Calle Principal Bar', { subject: 'Calle Principal' }, true]);
-  cases.push(['Calle Principal Barc', { subject: 'Calle Principal' }, true]);
+  // cases.push(['Calle Principal Bar', { subject: 'Calle Principal' }, true]);
+  // (0.91) ➜ [ { street: 'Calle Principal Barc' } ] && (0.91) ➜ [ { street: 'Calle Principal' }, { locality: 'Barc' } ]
+  // cases.push(['Calle Principal Barc', { subject: 'Calle Principal' }, true]);
   // cases.push(['Calle Principal Barce', { subject: 'Calle Principal' }, true]); // jitter issue
   // cases.push(['Calle Principal Barcel', { subject: 'Calle Principal' }, true]); // jitter issue
   // cases.push(['Calle Principal Barcelo', { subject: 'Calle Principal' }, true]); // jitter issue


### PR DESCRIPTION
## Backgroud

Our parser rocks ! We stick the version of the perser in https://github.com/pelias/api/pull/1287/commits/c0749a0cf78a5118e6a62b1774d912d31510e67d.

But we did some good improvement since v1.38.0 such as 
- Supports for hyphen as alternative spans (pelias/parser#56)
- Add Classifier and Classification for road types (pelias/parser#65)
- Add EN toponyms for highway streets (pelias/parser#70)
- Add more place cases (pelias/parser#77)
- Add lang meta data in toponym for housenumber penalty (pelias/parser#72) 
- Fix parsing of "Empire State Building" (pelias/parser#84 **need release**)
- Add -kanal as seperable street suffix (pelias/parser#85 **need release**)
- Add support for unit type numbered (pelias/parser#87 to be merged)

## So?...

The parsing is evolving every day, and results can change and may [break CI](https://github.com/pelias/api/pull/1368)...

We definitely need to update the parser, but there are a few more questions...
- Should we reduce parser specific tests from the API ? Such as autocomplete-like test which can change at every releases.... 
- Should we duplicate tests in API and parser to monitor changes like `Calle Principal Bar` ?
- Should we stay like this and do manual updates ? :man_shrugging: 

I removed 2 tests due to parser response order
- `Calle Principal Bar`
- `Calle Principal Barc`