### PR TITLE
refactor(categories): remove pelias/categories module

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "lodash": "^4.17.4",
     "markdown": "^0.5.0",
     "morgan": "^1.8.2",
-    "pelias-categories": "^1.2.0",
     "pelias-config": "^4.0.0",
     "pelias-labels": "^1.8.0",
     "pelias-logger": "^1.2.0",

--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const categoryTaxonomy = require('pelias-categories');
+const allValidValidator = { isValidCategory: () => true };
 
 const WARNINGS = {
   empty: 'Categories parameter left blank, showing results from all categories.',
@@ -7,8 +7,8 @@ const WARNINGS = {
 };
 
 // validate inputs, convert types and apply defaults
-function _sanitize (raw, clean, categories) {
-  categories = categories || categoryTaxonomy;
+function _sanitize (raw, clean, validator) {
+  validator = validator || allValidValidator;
 
   // error & warning messages
   var messages = { errors: [], warnings: [] };
@@ -25,7 +25,7 @@ function _sanitize (raw, clean, categories) {
       return cat.toLowerCase().trim(); // lowercase inputs
     })
     .filter(cat => {
-      if (_.isString(cat) && !_.isEmpty(cat) && categories.isValidCategory(cat)) {
+      if (_.isString(cat) && !_.isEmpty(cat) && validator.isValidCategory(cat)) {
         return true;
       }
       return false;


### PR DESCRIPTION
The dependency `pelias/categories` provided no real functionality.
This PR removes the dependency and I've moved the repo [to the graveyard](https://github.com/pelias-deprecated/categories).