### PR TITLE
feat(debug): add parser demo frontend to api

### DIFF
--- a/public/apiDocWithDebug.md
+++ b/public/apiDocWithDebug.md
@@ -1,0 +1,6 @@
+## [View our documentation on GitHub](https://github.com/pelias/documentation/)
+
+## Debug Tools
+
+- [/frontend](/frontend/) - Interactive geocoding query/debug tool
+- [/frontend/parser/demo](/frontend/parser/demo) - Interactive pelias-parser debug tool

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -358,6 +358,10 @@ function addRoutes(app, peliasConfig) {
 
   if (peliasConfig.api.exposeInternalDebugTools) {
     app.use ( '/frontend',                   express.static('node_modules/pelias-compare/dist-api/'));
+    
+    app.locals.parser = { address: require('../sanitizer/_text_pelias_parser')().parser };
+    app.use ( '/parser/demo',               express.static('node_modules/pelias-parser/server/demo/') );
+    app.use ( '/parser/parse',              require('pelias-parser/server/routes/parse.js') );
   }
 }
 

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -207,7 +207,7 @@ function addRoutes(app, peliasConfig) {
   var routers = {
     index: createRouter([
       controllers.markdownToHtml(peliasConfig.api, 
-        peliasConfig.api.serveDebugFrontends ? './public/apiDocWithDebug.md' : './public/apiDoc.md'
+        peliasConfig.api.exposeInternalDebugTools ? './public/apiDocWithDebug.md' : './public/apiDoc.md'
         )
     ]),
     attribution: createRouter([
@@ -359,8 +359,8 @@ function addRoutes(app, peliasConfig) {
   app.get ( base + 'nearby',               routers.nearby );
 
   if (peliasConfig.api.exposeInternalDebugTools) {
-    app.use ( '/frontend',                   express.static('node_modules/pelias-compare/dist-api/'));
-    
+    app.use ( '/frontend',                  express.static('node_modules/pelias-compare/dist-api/'));
+
     app.locals.parser = { address: require('../sanitizer/_text_pelias_parser')().parser };
     app.use ( '/frontend/parser/demo',      express.static('node_modules/pelias-parser/server/demo/') );
     // this needs to stay here because it's where the pelias-parser demo code expects it

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -206,7 +206,9 @@ function addRoutes(app, peliasConfig) {
 
   var routers = {
     index: createRouter([
-      controllers.markdownToHtml(peliasConfig.api, './public/apiDoc.md')
+      controllers.markdownToHtml(peliasConfig.api, 
+        peliasConfig.api.serveDebugFrontends ? './public/apiDocWithDebug.md' : './public/apiDoc.md'
+        )
     ]),
     attribution: createRouter([
       controllers.markdownToHtml(peliasConfig.api, './public/attribution.md')
@@ -360,7 +362,8 @@ function addRoutes(app, peliasConfig) {
     app.use ( '/frontend',                   express.static('node_modules/pelias-compare/dist-api/'));
     
     app.locals.parser = { address: require('../sanitizer/_text_pelias_parser')().parser };
-    app.use ( '/parser/demo',               express.static('node_modules/pelias-parser/server/demo/') );
+    app.use ( '/frontend/parser/demo',      express.static('node_modules/pelias-parser/server/demo/') );
+    // this needs to stay here because it's where the pelias-parser demo code expects it
     app.use ( '/parser/parse',              require('pelias-parser/server/routes/parse.js') );
   }
 }

--- a/sanitizer/_text_pelias_parser.js
+++ b/sanitizer/_text_pelias_parser.js
@@ -241,5 +241,6 @@ function _expected () {
 // export function
 module.exports = () => ({
   sanitize: _sanitize,
-  expected: _expected
+  expected: _expected,
+  parser: parser
 });


### PR DESCRIPTION
This change hosts the parser /demo web frontend on the api server.

The reason for this is that the parser version at https://parser.demo.geocode.earth/ can be quite different from what's running in prod on a pelias api box, so it's useful to be able to play with the exact  version of the parser that's running.

I don't want a million serveXFrontend options in the code, so I'm wondering if it makes sense to deprecate serveCompareFrontend and instead change it to something like serveDebugFrontends that would encompass a range of tools?

If people like this, in a later change I can play with linking from /frontend to this, as well as adding them to the index page (if they are enabled in prod) until the team builds a better landing experience