### PR TITLE
feat(debug): add some per-feature score debug info

### DIFF
--- a/helper/debug.js
+++ b/helper/debug.js
@@ -5,17 +5,40 @@ class Debug {
     this.name = moduleName || 'unnamed module';
   }
 
-  push(req, value){
+  getValueAndDest(req, args) {
+    if (args.length === 0) {
+      return {dest: req, value: undefined};
+    } 
+
+    if (args.length === 1) {
+      return {dest: req, value: args[0]};
+    } 
+    
+    if (args.length === 2) {
+      return {dest: args[0], value: args[1]};
+    }
+
+    throw new Error('Too many arguments to function');
+  }
+
+  // two variants
+  // - push(req, value) 
+  //    checks req.clean.enableDebug and if true, pushes values onto req.debug
+  // - push(req, dest, value) 
+  //    checks req.clean.enableDebug and if true, pushes values onto dest.debug
+  push(req, ...args){
+    const { value, dest } = this.getValueAndDest(req, args);
+    
     if (!req || _.isEmpty(req.clean) || !req.clean.enableDebug){
       return;
     }
-    req.debug = req.debug || [];
+    dest.debug = dest.debug || [];
     switch(typeof value) {
       case 'function':
-        req.debug.push({[this.name]: value()});
+        dest.debug.push({[this.name]: value()});
         break;
       default:
-        req.debug.push({[this.name]: value});
+        dest.debug.push({[this.name]: value});
     }
   }
 

--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -51,7 +51,7 @@ function geojsonifyPlace(params, place) {
     source_id: gid_components.id,
     bounding_box: place.bounding_box,
     lat: parseFloat(place.center_point.lat),
-    lng: parseFloat(place.center_point.lon)
+    lng: parseFloat(place.center_point.lon),
   };
 
   // assign name, logging a warning if it doesn't exist
@@ -78,6 +78,10 @@ function geojsonifyPlace(params, place) {
     if( Object.keys(addendum).length ){
       doc.addendum = addendum;
     }
+  }
+
+  if (place.debug) {
+    doc.debug = place.debug;
   }
 
   return doc;

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -11,6 +11,8 @@
 
 const _ = require('lodash');
 const logger = require('pelias-logger').get('api');
+const Debug = require('../helper/debug');
+const debugLog = new Debug('middleware:confidenceScoreFallback');
 
 function setup() {
   return computeScores;
@@ -196,6 +198,10 @@ function checkFallbackOccurred(req, hit) {
       rule.expectedLayers.indexOf(hit.layer) === -1
     );
   });
+
+  if (res) {
+    debugLog.push(req, hit, {'fallback rule matched': res});
+  }
 
   return !!res;
 }

--- a/test/unit/helper/debug.js
+++ b/test/unit/helper/debug.js
@@ -96,6 +96,25 @@ module.exports.tests.debug = function(test, common) {
     t.end();
   });
 
+  test('Push messages to other object if enableDebug is true', (t) => {
+    const debugLog = new Debug('debugger');
+    const req = {
+      clean: {
+        enableDebug: true
+      }
+    };
+
+    const hit = {};
+    const expected_req = [
+      {
+        debugger: 'This should be pushed'
+      },
+    ];
+    debugLog.push(req, hit, 'This should be pushed');
+    t.deepEquals(hit.debug, expected_req);
+    t.end();
+  });
+
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Hi team,

I have been trying to debug an issue in our pelias cluster where fallback is getting set on a hit we don't think it should be getting set on. It was hard for us to have any visibility into why, so I added some debugging at a per-feature level, trying to utilize as much of the existing infra as possible, to be able to debug it.

I couldn't add the ability to specify a 'dest' to begin/endTimer because debugMsg is optional there too, and it seems too magic to try to guess if a single param was a debugMsg or dest. We could do it by checking if the variable is a string (message) or object (dest), but, again, much magic.

It looks like this:

![image](https://user-images.githubusercontent.com/445616/82583876-af18ea00-9b61-11ea-977f-70732026f152.png)
