### PR TITLE
 use parsed_text.housenumber across pelias/api codebase

### DIFF
--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -9,7 +9,7 @@ var field_mapping = {
   island:         'island',
   category:       'category',
   house:          'query',
-  house_number:   'number',
+  house_number:   'housenumber',
   road:           'street',
   suburb:         'neighbourhood',
   city_district:  'borough',

--- a/controller/predicates/isAdminOnlyAnalysis.js
+++ b/controller/predicates/isAdminOnlyAnalysis.js
@@ -10,7 +10,7 @@ module.exports = (request, response) => {
   }
 
   // return true only if all non-admin properties of parsed_text are empty
-  const is_admin_only_analysis = ['unit', 'number', 'street', 'query', 'category', 'postalcode'].every((prop) => {
+  const is_admin_only_analysis = ['unit', 'housenumber', 'street', 'query', 'category', 'postalcode'].every((prop) => {
     return _.isEmpty(request.clean.parsed_text[prop]);
   });
 

--- a/controller/structured_libpostal.js
+++ b/controller/structured_libpostal.js
@@ -46,10 +46,10 @@ function setup(libpostalService, should_execute) {
         // and assign to street
         // eg - '1090 N Charlotte St' becomes number=1090 and street=N Charlotte St
         if (house_number_field) {
-          req.clean.parsed_text.number = house_number_field.value;
+          req.clean.parsed_text.housenumber = house_number_field.value;
 
           // remove the first instance of the number and trim whitespace
-          req.clean.parsed_text.street = _.trim(_.replace(req.clean.parsed_text.address, req.clean.parsed_text.number, ''));
+          req.clean.parsed_text.street = _.trim(_.replace(req.clean.parsed_text.address, req.clean.parsed_text.housenumber, ''));
 
           // If libpostal have parsed unit then add it for search
           const unit_field = findField(response, 'unit');

--- a/middleware/confidenceScore.js
+++ b/middleware/confidenceScore.js
@@ -154,7 +154,7 @@ function checkName(text, parsed_text, hit) {
  * @returns {number}
  */
 function checkQueryType(text, hit) {
-  if (!_.isNil(text) && !_.isNil(text.number) &&
+  if (!_.isNil(text) && !_.isNil(text.housenumber) &&
       (_.isUndefined(hit.address_parts) ||
       (!_.isNil(hit.address_parts) && _.isUndefined(hit.address_parts.number)))) {
     return 0;
@@ -200,7 +200,7 @@ function propMatch(textProp, hitProp, expectEnriched) {
  * against the results
  *
  * @param {object} text
- * @param {string|number} [text.number]
+ * @param {string|number} [text.housenumber]
  * @param {string} [text.street]
  * @param {string} [text.postalcode]
  * @param {string} [text.state]
@@ -218,8 +218,8 @@ function checkAddress(text, hit) {
   var checkCount = 5;
   var res = 0;
 
-  if (!_.isNil(text) && !_.isNil(text.number) && !_.isNil(text.street)) {
-    res += propMatch(text.number, (hit.address_parts ? hit.address_parts.number : null), false);
+  if (!_.isNil(text) && !_.isNil(text.housenumber) && !_.isNil(text.street)) {
+    res += propMatch(text.housenumber, (hit.address_parts ? hit.address_parts.number : null), false);
     res += propMatch(text.street, (hit.address_parts ? hit.address_parts.street : null), false);
     res += propMatch(text.postalcode, (hit.address_parts ? hit.address_parts.zip: null), true);
     res += propMatch(text.state, ((hit.parent && hit.parent.region_a) ? hit.parent.region_a[0] : null), true);

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -129,54 +129,54 @@ const fallbackRules = [
   {
     name: 'address',
     notSet: ['query'],
-    set: ['number', 'street'],
+    set: ['housenumber', 'street'],
     expectedLayers: ['address']
   },
   {
     name: 'street',
-    notSet: ['query', 'number'],
+    notSet: ['query', 'housenumber'],
     set: ['street'],
     expectedLayers: ['street']
   },
   {
     name: 'postalcode',
-    notSet: ['query', 'number', 'street'],
+    notSet: ['query', 'housenumber', 'street'],
     set: ['postalcode'],
     expectedLayers: ['postalcode']
   },
   {
     name: 'neighbourhood',
-    notSet: ['query', 'number', 'street', 'postalcode'],
+    notSet: ['query', 'housenumber', 'street', 'postalcode'],
     set: ['neighbourhood'],
     expectedLayers: ['neighbourhood']
   },
   {
     name: 'borough',
-    notSet: ['query', 'number', 'street', 'postalcode', 'neighbourhood'],
+    notSet: ['query', 'housenumber', 'street', 'postalcode', 'neighbourhood'],
     set: ['borough'],
     expectedLayers: ['borough']
   },
   {
     name: 'city',
-    notSet: ['query', 'number', 'street', 'postalcode', 'neighbourhood', 'borough'],
+    notSet: ['query', 'housenumber', 'street', 'postalcode', 'neighbourhood', 'borough'],
     set: ['city'],
     expectedLayers: ['borough', 'locality', 'localadmin']
   },
   {
     name: 'county',
-    notSet: ['query', 'number', 'street', 'postalcode', 'neighbourhood', 'borough', 'city'],
+    notSet: ['query', 'housenumber', 'street', 'postalcode', 'neighbourhood', 'borough', 'city'],
     set: ['county'],
     expectedLayers: ['county']
   },
   {
     name: 'state',
-    notSet: ['query', 'number', 'street', 'postalcode', 'neighbourhood', 'borough', 'city', 'county'],
+    notSet: ['query', 'housenumber', 'street', 'postalcode', 'neighbourhood', 'borough', 'city', 'county'],
     set: ['state'],
     expectedLayers: ['region']
   },
   {
     name: 'country',
-    notSet: ['query', 'number', 'street', 'postalcode', 'neighbourhood', 'borough', 'city', 'county', 'state'],
+    notSet: ['query', 'housenumber', 'street', 'postalcode', 'neighbourhood', 'borough', 'city', 'county', 'state'],
     set: ['country'],
     expectedLayers: ['country']
   }

--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -108,8 +108,8 @@ function generateQuery( clean, res ){
     vs.var( 'size', clean.querySize );
   }
 
-  if( ! _.isEmpty(clean.parsed_text.number) ){
-    vs.var( 'input:housenumber', clean.parsed_text.number );
+  if( ! _.isEmpty(clean.parsed_text.housenumber) ){
+    vs.var( 'input:housenumber', clean.parsed_text.housenumber );
   }
 
   if( ! _.isEmpty(clean.parsed_text.unit) ){

--- a/query/text_parser.js
+++ b/query/text_parser.js
@@ -20,8 +20,8 @@ function addParsedVariablesToQueryVariables( parsed_text, vs ){
   }
 
   // house number
-  if( ! _.isEmpty(parsed_text.number) ){
-    vs.var( 'input:housenumber', parsed_text.number );
+  if( ! _.isEmpty(parsed_text.housenumber) ){
+    vs.var( 'input:housenumber', parsed_text.housenumber );
   }
 
   // street name

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -174,7 +174,7 @@ function addRoutes(app, peliasConfig) {
   const interpolationShouldExecute = all(
     not(predicates.hasRequestErrors),
     isInterpolationEnabled,
-    predicates.hasParsedTextProperties.all('number', 'street'),
+    predicates.hasParsedTextProperties.all('housenumber', 'street'),
     predicates.hasResultsAtLayers('street')
   );
 

--- a/sanitizer/_address_layer_filter.js
+++ b/sanitizer/_address_layer_filter.js
@@ -53,7 +53,7 @@ function _setup(tm) {
       // be subject to change.
       if (_.isObject(clean.parsed_text) && !_.isEmpty(clean.parsed_text)) {
 
-        var isStreetAddress = clean.parsed_text.hasOwnProperty('number') && clean.parsed_text.hasOwnProperty('street');
+        var isStreetAddress = clean.parsed_text.hasOwnProperty('housenumber') && clean.parsed_text.hasOwnProperty('street');
 
         // use $subject where available (pelias parser)
         if (_.has(clean, 'parsed_text.subject')) {
@@ -62,7 +62,7 @@ function _setup(tm) {
 
         // if 'pelias_parser' or 'libpostal' identified input as a street address
         else if (isStreetAddress) {
-          input = clean.parsed_text.number + ' ' + clean.parsed_text.street;
+          input = clean.parsed_text.housenumber + ' ' + clean.parsed_text.street;
         }
 
         // else if the 'naive parser' was used, input is equal to 'name'

--- a/sanitizer/_geonames_warnings.js
+++ b/sanitizer/_geonames_warnings.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 
-const non_admin_fields = ['number', 'street', 'query', 'category'];
+const non_admin_fields = ['housenumber', 'street', 'query', 'category'];
 
 function hasAnyNonAdminFields(parsed_text) {
   return !_.isEmpty(

--- a/service/configurations/Interpolation.js
+++ b/service/configurations/Interpolation.js
@@ -12,7 +12,7 @@ class Interpolation extends ServiceConfiguration {
 
   getParameters(req, hit) {
     let params = {
-      number: req.clean.parsed_text.number,
+      number: req.clean.parsed_text.housenumber,
       street: hit.address_parts.street || req.clean.parsed_text.street,
       lat: hit.center_point.lat,
       lon: hit.center_point.lon

--- a/test/ciao/search/address_parsing.coffee
+++ b/test/ciao/search/address_parsing.coffee
@@ -33,7 +33,7 @@ json.geocoding.query['text'].should.eql '30 w 26th st, ny'
 json.geocoding.query['size'].should.eql 10
 
 #? address parsing
-json.geocoding.query.parsed_text['number'].should.eql '30'
+json.geocoding.query.parsed_text['housenumber'].should.eql '30'
 json.geocoding.query.parsed_text['street'].should.eql 'w 26th st'
 json.geocoding.query.parsed_text['state'].should.eql 'ny'
 

--- a/test/unit/controller/libpostal.js
+++ b/test/unit/controller/libpostal.js
@@ -242,7 +242,7 @@ module.exports.tests.success_conditions = (test, common) => {
             island: 'island value',
             category: 'category value',
             query: 'house value',
-            number: 'house_number value',
+            housenumber: 'house_number value',
             street: 'road value',
             neighbourhood: 'suburb value',
             borough: 'city_district value',
@@ -343,7 +343,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           text: 'original query',
           parser: 'libpostal',
           parsed_text: {
-            number: '4004',
+            housenumber: '4004',
             street: 'nw beaverton-hillsdale',
             city: 'portland'
           }
@@ -483,7 +483,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           parser: 'libpostal',
           parsed_text: {
             unit: '11',
-            number: '1015',
+            housenumber: '1015',
             street: 'nudgee road',
             neighbourhood: 'banyo',
             postalcode: '4014',
@@ -543,7 +543,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           parser: 'libpostal',
           parsed_text: {
             unit: '2+3',
-            number: '32',
+            housenumber: '32',
             street: 'dixon street',
             neighbourhood: 'strathpine',
             postalcode: '4500',
@@ -603,7 +603,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           parser: 'libpostal',
           parsed_text: {
             unit: 'unit 3',
-            number: '30',
+            housenumber: '30',
             street: 'dan rees street',
             neighbourhood: 'wallsend',
             postalcode: '2287',
@@ -667,7 +667,7 @@ module.exports.tests.bug_fixes = (test, common) => {
           parser: 'libpostal',
           parsed_text: {
             unit: '99',
-            number: '11/1015',
+            housenumber: '11/1015',
             street: 'nudgee road',
             neighbourhood: 'banyo',
             postalcode: '4014',

--- a/test/unit/controller/predicates/isAdminOnlyAnalysis.js
+++ b/test/unit/controller/predicates/isAdminOnlyAnalysis.js
@@ -45,7 +45,7 @@ module.exports.tests.false_conditions = (test, common) => {
   });
 
   test('parsed_text with non-admin properties should return false', (t) => {
-    ['unit', 'number', 'street', 'query', 'category', 'postalcode'].forEach((property) => {
+    ['unit', 'housenumber', 'street', 'query', 'category', 'postalcode'].forEach((property) => {
       const req = {
         clean: {
           parsed_text: {

--- a/test/unit/controller/structured_libpostal.js
+++ b/test/unit/controller/structured_libpostal.js
@@ -199,7 +199,7 @@ module.exports.tests.success_conditions = (test, common) => {
       t.deepEquals(req, {
         clean: {
           parsed_text: {
-            number: 'house_number value',
+            housenumber: 'house_number value',
             street: 'other value  street value'
           }
         },
@@ -239,7 +239,7 @@ module.exports.tests.success_conditions = (test, common) => {
       t.deepEquals(req, {
         clean: {
           parsed_text: {
-            number: 'postcode value',
+            housenumber: 'postcode value',
             street: 'other value  street value'
           }
         },
@@ -327,7 +327,7 @@ module.exports.tests.success_conditions = (test, common) => {
         clean: {
           parsed_text: {
             street: 'the street',
-            number: '22',
+            housenumber: '22',
             unit: '1 th'
           }
         },
@@ -414,7 +414,7 @@ module.exports.tests.success_conditions = (test, common) => {
   //           island: 'island value',
   //           category: 'category value',
   //           query: 'house value',
-  //           number: 'house_number value',
+  //           housenumber: 'house_number value',
   //           street: 'road value',
   //           neighbourhood: 'suburb value',
   //           borough: 'city_district value',

--- a/test/unit/middleware/confidenceScore.js
+++ b/test/unit/middleware/confidenceScore.js
@@ -103,7 +103,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           state: 'NM'
         }
@@ -139,7 +139,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           state: 'NM'
         }
@@ -175,7 +175,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           state: 'NM'
         }
@@ -207,7 +207,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: 'example',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'example',
           state: 'EG'
         }

--- a/test/unit/middleware/confidenceScoreFallback.js
+++ b/test/unit/middleware/confidenceScoreFallback.js
@@ -104,7 +104,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           city: 'City',
           state: 'NM'
@@ -142,7 +142,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           city: 'City',
           state: 'NM'
@@ -180,7 +180,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           city: 'City',
           state: 'NM'
@@ -321,7 +321,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           state: 'NM'
         }
@@ -356,7 +356,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           state: 'NM'
         }
@@ -391,7 +391,7 @@ module.exports.tests.confidenceScore = function(test, common) {
       clean: {
         text: '123 Main St, City, NM, USA',
         parsed_text: {
-          number: 123,
+          housenumber: 123,
           street: 'Main St',
           state: 'NM',
           country: 'USA'
@@ -524,7 +524,7 @@ module.exports.tests.confidenceScore = function(test, common) {
             clean: {
                 text: '123 Main St, City, NM, USA, 1234',
                 parsed_text: {
-                    number: 123,
+                    housenumber: 123,
                     street: 'Main St',
                     state: 'NM',
                     country: 'USA',

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -29,7 +29,7 @@ module.exports.tests.base_query = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         postalcode: 'postcode value',
         street: 'street value'
       }
@@ -82,7 +82,7 @@ module.exports.tests.other_parameters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       querySize: 'querySize value'
@@ -114,7 +114,7 @@ module.exports.tests.other_parameters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       sources: ['source 1', 'source 2']
@@ -146,7 +146,7 @@ module.exports.tests.other_parameters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       }
     };
@@ -178,7 +178,7 @@ module.exports.tests.granularity_bands = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       }
     };
@@ -300,7 +300,7 @@ module.exports.tests.granularity_bands = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       }
     };
@@ -345,7 +345,7 @@ module.exports.tests.granularity_bands = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       }
     };
@@ -400,7 +400,7 @@ module.exports.tests.boundary_filters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       'boundary.country': ['boundary.country', 'value']
@@ -432,7 +432,7 @@ module.exports.tests.boundary_filters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       'focus.point.lat': 12.121212,
@@ -466,7 +466,7 @@ module.exports.tests.boundary_filters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       'boundary.rect.min_lat': 12.121212,
@@ -504,7 +504,7 @@ module.exports.tests.boundary_filters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       'boundary.circle.lat': 12.121212,
@@ -539,7 +539,7 @@ module.exports.tests.boundary_filters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       'boundary.circle.lat': 12.121212,
@@ -575,7 +575,7 @@ module.exports.tests.boundary_filters = (test, common) => {
 
     const clean = {
       parsed_text: {
-        number: 'housenumber value',
+        housenumber: 'housenumber value',
         street: 'street value'
       },
       'boundary.gid': '123'

--- a/test/unit/query/search.js
+++ b/test/unit/query/search.js
@@ -124,7 +124,7 @@ module.exports.tests.query = function(test, common) {
       parsed_text: {
         query: 'query value',
         category: 'category value',
-        number: 'number value',
+        housenumber: 'number value',
         street: 'street value',
         neighbourhood: 'neighbourhood value',
         borough: 'borough value',
@@ -342,7 +342,7 @@ module.exports.tests.city_state = function(test, common) {
       parsed_text: {
         city: 'city value',
         state: 'state value',
-        number: 'number value'
+        housenumber: 'number value'
       }
     };
 
@@ -501,7 +501,7 @@ module.exports.tests.city_country = function(test, common) {
       parsed_text: {
         city: 'city value',
         country: 'country value',
-        number: 'number value'
+        housenumber: 'number value'
       }
     };
 

--- a/test/unit/query/text_parser.js
+++ b/test/unit/query/text_parser.js
@@ -37,7 +37,7 @@ module.exports.tests.query = function(test, common) {
     var parsed_text = {
       query: 'query value',
       category: 'category value',
-      number: 'number value',
+      housenumber: 'number value',
       street: 'street value',
       address: 'address value',
       neighbourhood: 'neighbourhood value',
@@ -91,7 +91,7 @@ module.exports.tests.housenumber_special_cases = function(test, common) {
   test('numeric query with street but without number should not change anything', function(t) {
     var parsed_text = {
       query: '17',
-      number: 'housenumber value',
+      housenumber: 'housenumber value',
       street: 'street value'
       // no number or street
     };
@@ -109,7 +109,7 @@ module.exports.tests.housenumber_special_cases = function(test, common) {
   test('numeric query with number but without street should not change anything', function(t) {
     var parsed_text = {
       query: '17',
-      number: 'number value'
+      housenumber: 'number value'
       // no number or street
     };
     var vs = new VariableStore();
@@ -162,7 +162,7 @@ module.exports.tests.empty_values = function(test, common) {
     var parsed_text = {
       query: '',
       category: '',
-      number: '',
+      housenumber: '',
       street: '',
       address: '',
       neighbourhood: '',

--- a/test/unit/sanitizer/_address_layer_filter.js
+++ b/test/unit/sanitizer/_address_layer_filter.js
@@ -121,14 +121,14 @@ module.exports.tests.parsed_text = function (test, common) {
   });
 
   test('pelias_parser/libpostal - do not apply filter for numeric addresses', (t) => {
-    let clean = { text: 'A', parsed_text: { number: '1', street: 'Main St' } };
+    let clean = { text: 'A', parsed_text: { housenumber: '1', street: 'Main St' } };
     t.deepEqual(s.sanitize(null, clean), NO_MESSAGES);
     t.false(clean.layers);
     t.end();
   });
 
   test('pelias_parser/libpostal - apply filter for non-numeric addresses', (t) => {
-    let clean = { text: 'A', parsed_text: { number: 'Foo', street: 'Main St' } };
+    let clean = { text: 'A', parsed_text: { housenumber: 'Foo', street: 'Main St' } };
     t.deepEqual(s.sanitize(null, clean), STD_MESSAGES);
     t.deepEqual(clean.layers, ['A', 'B', 'C']);
     t.end();

--- a/test/unit/sanitizer/_geonames_warnings.js
+++ b/test/unit/sanitizer/_geonames_warnings.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 
 const sanitizer = require('../../../sanitizer/_geonames_warnings')();
 
-const nonAdminProperties = ['number', 'street', 'query', 'category'];
+const nonAdminProperties = ['housenumber', 'street', 'query', 'category'];
 const adminProperties = ['neighbourhood', 'borough', 'city', 'county', 'state', 'postalcode', 'country'];
 
 module.exports.tests = {};

--- a/test/unit/service/configurations/Interpolation.js
+++ b/test/unit/service/configurations/Interpolation.js
@@ -54,7 +54,7 @@ module.exports.tests.all = (test, common) => {
     const req = {
       clean: {
         parsed_text: {
-          number: 'parsed number value',
+          housenumber: 'parsed number value',
           street: 'parsed street value'
         }
       }
@@ -90,7 +90,7 @@ module.exports.tests.all = (test, common) => {
     const req = {
       clean: {
         parsed_text: {
-          number: 'parsed number value',
+          housenumber: 'parsed number value',
           street: 'parsed street value'
         }
       }


### PR DESCRIPTION
I think this a bug in pelias where it is sometimes calling an exact match a fallback result because it was looking for the wrong field in parsed_text.

the "Street" fallback rule was applying in some cases when it shouldn't have been. I believe this is because it was looking in parsed_text for a field called "number" which is now called "housenumber"