### PR TITLE
Reduce search query multi_match's neighbourhood boost

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -97,7 +97,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
   'admin:neighbourhood:field': 'parent.neighbourhood',
-  'admin:neighbourhood:boost': 1,
+  'admin:neighbourhood:boost': 0.75,
   'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'popularity:field': 'popularity',

--- a/test/unit/fixture/search_pelias_parser_full_address.js
+++ b/test/unit/fixture/search_pelias_parser_full_address.js
@@ -94,7 +94,7 @@ module.exports = {
               'parent.localadmin^1',
               'parent.locality^1',
               'parent.borough^1',
-              'parent.neighbourhood^1',
+              'parent.neighbourhood^0.75',
               'parent.region_a^1'
             ],
             'query': 'new york ny US',

--- a/test/unit/fixture/search_pelias_parser_partial_address.js
+++ b/test/unit/fixture/search_pelias_parser_partial_address.js
@@ -66,7 +66,7 @@ module.exports = {
               'parent.localadmin^1',
               'parent.locality^1',
               'parent.borough^1',
-              'parent.neighbourhood^1',
+              'parent.neighbourhood^0.75',
               'parent.region_a^1'
             ],
             'query': 'new york',

--- a/test/unit/fixture/search_pelias_parser_regions_address.js
+++ b/test/unit/fixture/search_pelias_parser_regions_address.js
@@ -84,7 +84,7 @@ module.exports = {
               'parent.localadmin^1',
               'parent.locality^1',
               'parent.borough^1',
-              'parent.neighbourhood^1',
+              'parent.neighbourhood^0.75',
               'parent.region_a^1'
             ],
             'query': 'manhattan ny',


### PR DESCRIPTION
After the venue popularity changes in https://github.com/pelias/openstreetmap/pull/531, many venue results are improved.

However, our test for finding the [Statue of Liberty](https://github.com/pelias/acceptance-tests/blob/81e15adae7a318afa228820d519115ccc0e3271c/test_cases/landmarks.json#L16-L29), which corresponds to one of our [oldest venue popularity related issues](https://github.com/pelias/pelias/issues/171), was still showing the statue as the second result, after the ferry terminal on Liberty Island.

I traced this down to scoring boosts given to the ferry terminal because it's part of the [Liberty Island](https://spelunker.whosonfirst.org/id/907131683/) neighbourhood, whereas the statue itself is not (for some reason).

In general, I don't think neighbourhoods should make this much of a difference in queries, so this PR reduces the boost given to those matches in search queries.

This doesn't break any other tests, and while we generally don't like to adjust settings for one particular test, I think this change is worth considering.

