### PR TITLE
[Experiment] Disable parser for short queries

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -14,6 +14,7 @@ var views = {
   admin_multi_match_first: require('./view/admin_multi_match_first'),
   admin_multi_match_last: require('./view/admin_multi_match_last'),
   phrase_first_tokens_only:   require('./view/phrase_first_tokens_only'),
+  match_first_tokens_only:   require('./view/match_first_tokens_only'),
   boost_exact_matches:        require('./view/boost_exact_matches'),
   max_character_count_layer_filter:   require('./view/max_character_count_layer_filter'),
   focus_point_filter:         require('./view/focus_point_distance_filter')
@@ -40,7 +41,7 @@ adminFields = adminFields.concat(['add_name_to_multimatch']);
 var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
-query.score( views.phrase_first_tokens_only, 'must' );
+query.score( views.match_first_tokens_only, 'must' );
 query.score( views.ngrams_last_token_only_multi( adminFields ), 'must' );
 
 // admin components
@@ -54,6 +55,7 @@ query.score( peliasQuery.view.address('cross_street') );
 query.score( peliasQuery.view.address('postcode') );
 
 // scoring boost
+query.score( views.phrase_first_tokens_only, 'should' );
 query.score( peliasQuery.view.focus( views.ngrams_strict ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.population( peliasQuery.view.leaf.match_all ) );

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -20,6 +20,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:field': 'name.default',
   'ngram:boost': 100,
   'ngram:cutoff_frequency': 0.01,
+  'ngram:minimum_should_match': '1<-1 3<-25%',
 
   'phrase:analyzer': 'peliasQuery',
   'phrase:field': 'phrase.default',

--- a/query/view/match_first_tokens_only.js
+++ b/query/view/match_first_tokens_only.js
@@ -1,0 +1,28 @@
+const peliasQuery = require('pelias-query');
+
+/**
+  Phrase view which trims the 'input:name' and uses ALL BUT the last token.
+
+  eg. if the input was "100 foo str", then 'input:name' would only be '100 foo'
+  note: it is assumed that the rest of the input is matched using another view.
+**/
+
+module.exports = function( vs ){
+  const view_name = 'match_first_tokens_only';
+
+  // get a copy of the *complete* tokens produced from the input:name
+  const tokens = vs.var('input:name:tokens_complete').get();
+
+  // no valid tokens to use, fail now, don't render this view.
+  if( !tokens || tokens.length < 1 ){ return null; }
+
+  // set the 'input' variable to all but the last token
+  vs.var(`match:${view_name}:input`).set( tokens.join(' ') );
+  vs.var(`match:${view_name}:field`).set(vs.var('phrase:field').get());
+
+  vs.var(`match:${view_name}:analyzer`).set(vs.var('phrase:analyzer').get());
+  vs.var(`match:${view_name}:boost`).set(vs.var('phrase:boost').get());
+  vs.var(`match:${view_name}:minimum_should_match`).set(vs.var('ngram:minimum_should_match').get());
+
+  return peliasQuery.view.leaf.match(view_name)( vs );
+};

--- a/sanitizer/_text_pelias_parser.js
+++ b/sanitizer/_text_pelias_parser.js
@@ -53,13 +53,6 @@ function _sanitize (raw, clean) {
 }
 
 function parse (clean) {
-  // short circuit for short, unreliable parses
-  if (clean.text.length < 10) {
-    return {
-      subject: clean.text
-    };
-  }
-
   // parse text
   let start = new Date();
   const t = new Tokenizer(clean.text);
@@ -78,6 +71,13 @@ function parse (clean) {
   // @todo: we could expand this in the future to accomodate more solutions
   let solution = new Solution();
   if (t.solution.length) { solution = t.solution[0]; }
+
+  // short circuit for short, unreliable parses
+  if (clean.text.length < 10) {
+    return {
+      subject: t.span.body
+    };
+  }
 
   // 1. map the output of the parser in to parsed_text
   let parsed_text = { subject: undefined };

--- a/sanitizer/_text_pelias_parser.js
+++ b/sanitizer/_text_pelias_parser.js
@@ -53,7 +53,13 @@ function _sanitize (raw, clean) {
 }
 
 function parse (clean) {
-  
+  // short circuit for short, unreliable parses
+  if (clean.text.length < 10) {
+    return {
+      subject: clean.text
+    };
+  }
+
   // parse text
   let start = new Date();
   const t = new Tokenizer(clean.text);

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -5,6 +5,18 @@
       "bool": {
         "must": [
           {
+            "match": {
+              "phrase.default": {
+                "analyzer": "peliasQuery",
+                "boost": 1,
+                "query": "foo",
+                "minimum_should_match": "1<-1 3<-25%"
+              }
+            }
+          }
+        ],
+        "should": [
+          {
             "match_phrase": {
               "phrase.default": {
                 "analyzer": "peliasQuery",
@@ -13,10 +25,7 @@
                 "query": "foo"
               }
             }
-          }
-        ],
-        "should": [
-          {
+          }, {
             "function_score": {
               "query": {
                 "match_all": {}

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -2,6 +2,16 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
+        'match': {
+          'phrase.default': {
+            'analyzer': 'peliasQuery',
+            'boost': 1,
+            'minimum_should_match': '1<-1 3<-25%',
+            'query': 'one'
+          }
+        }
+      }],
+      'should':[{
         'match_phrase': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
@@ -10,8 +20,7 @@ module.exports = {
             'query': 'one'
           }
         }
-      }],
-      'should':[{
+      }, {
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -2,11 +2,11 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match_phrase': {
+        'match': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
             'boost': 1,
-            'slop': 3,
+            'minimum_should_match': '1<-1 3<-25%',
             'query': 'one two'
           }
         }
@@ -37,9 +37,18 @@ module.exports = {
           }
         }
       }],
-      'should':[
+      'should':[{
+          'match_phrase': {
+            'phrase.default': {
+              'analyzer': 'peliasQuery',
+              'boost': 1,
+              'slop': 3,
+              'query': 'one two'
+            }
+          }
+        },
         {
-        'function_score': {
+          'function_score': {
           'query': {
             'match_all': {}
           },

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -2,11 +2,11 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match_phrase': {
+        'match': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
             'boost': 1,
-            'slop': 3,
+            'minimum_should_match': '1<-1 3<-25%',
             'query': '1 2'
           }
         }
@@ -25,7 +25,16 @@ module.exports = {
           }
         }
       }],
-      'should': [
+      'should': [{
+          'match_phrase': {
+            'phrase.default': {
+              'analyzer': 'peliasQuery',
+              'boost': 1,
+              'slop': 3,
+              'query': '1 2'
+            }
+          }
+        },
         {
           'function_score': {
             'query': {

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -3,11 +3,11 @@ module.exports = {
     'bool': {
       'must': [
         {
-          'match_phrase': {
+          'match': {
             'phrase.default': {
               'analyzer': 'peliasQuery',
               'boost': 1,
-              'slop': 3,
+              'minimum_should_match': '1<-1 3<-25%',
               'query': 'one two'
             }
           }
@@ -36,6 +36,16 @@ module.exports = {
         }
       ],
       'should': [
+        {
+          'match_phrase': {
+            'phrase.default': {
+              'analyzer': 'peliasQuery',
+              'boost': 1,
+              'slop': 3,
+              'query': 'one two'
+            }
+          }
+        },
         {
           'function_score': {
             'query': {

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -2,11 +2,11 @@ module.exports = {
   'query': {
     'bool': {
       'must': [{
-        'match_phrase': {
+        'match': {
           'phrase.default': {
             'analyzer': 'peliasQuery',
             'boost': 1,
-            'slop': 3,
+            'minimum_should_match': '1<-1 3<-25%',
             'query': 'k road'
           }
         }
@@ -32,8 +32,7 @@ module.exports = {
           'type': 'cross_fields'
         }
       }],
-      'should':[
-        {
+      'should':[{
           'match': {
             'address_parts.street': {
               'query': 'k road',
@@ -44,6 +43,15 @@ module.exports = {
           }
         },
         {
+        'match_phrase': {
+          'phrase.default': {
+            'analyzer': 'peliasQuery',
+            'boost': 1,
+            'slop': 3,
+            'query': 'k road'
+          }
+        }
+      }, {
         'function_score': {
           'query': {
             'match_all': {}

--- a/test/unit/query/autocomplete_token_matching_permutations.js
+++ b/test/unit/query/autocomplete_token_matching_permutations.js
@@ -21,6 +21,7 @@ const defaults = new peliasQuery.Vars( require('../../../query/autocomplete_defa
 const views = {
   ngrams_last_token_only:     require('../../../query/view/ngrams_last_token_only'),
   ngrams_last_token_only_multi: require('../../../query/view/ngrams_last_token_only_multi')(adminFields),
+  match_first_tokens_only:   require('../../../query/view/match_first_tokens_only'),
   phrase_first_tokens_only:   require('../../../query/view/phrase_first_tokens_only'),
 };
 
@@ -84,8 +85,9 @@ module.exports.tests.single_token = function(test, common) {
     var vs = vars( clean );
 
     assert( t, generate( clean ), {
-      must: [ views.phrase_first_tokens_only( vs ) ],
+      must: [ views.match_first_tokens_only( vs ) ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]
@@ -124,8 +126,9 @@ module.exports.tests.single_token = function(test, common) {
     var vs = vars( clean );
 
     assert( t, generate( clean ), {
-      must: [ views.phrase_first_tokens_only( vs ) ],
+      must: [ views.match_first_tokens_only( vs ) ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]
@@ -164,8 +167,9 @@ module.exports.tests.single_token = function(test, common) {
     var vs = vars( clean );
 
     assert( t, generate( clean ), {
-      must: [ views.phrase_first_tokens_only( vs ) ],
+      must: [ views.match_first_tokens_only( vs ) ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]
@@ -189,10 +193,11 @@ module.exports.tests.multiple_tokens = function(test, common) {
 
     assert( t, generate( clean ), {
       must: [
-        views.phrase_first_tokens_only( vs ),
+        views.match_first_tokens_only( vs ),
         views.ngrams_last_token_only_multi( vs )
       ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]
@@ -212,9 +217,10 @@ module.exports.tests.multiple_tokens = function(test, common) {
 
     assert( t, generate( clean ), {
       must: [
-        views.phrase_first_tokens_only( vs )
+        views.match_first_tokens_only( vs )
       ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]
@@ -236,10 +242,11 @@ module.exports.tests.multiple_tokens = function(test, common) {
 
     assert( t, generate( clean ), {
       must: [
-        views.phrase_first_tokens_only( vs ),
+        views.match_first_tokens_only( vs ),
         views.ngrams_last_token_only_multi( vs )
       ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]
@@ -259,9 +266,10 @@ module.exports.tests.multiple_tokens = function(test, common) {
 
     assert( t, generate( clean ), {
       must: [
-        views.phrase_first_tokens_only( vs )
+        views.match_first_tokens_only( vs )
       ],
       should: [
+        views.phrase_first_tokens_only( vs ),
         peliasQuery.view.popularity( peliasQuery.view.leaf.match_all )( vs ),
         peliasQuery.view.population( peliasQuery.view.leaf.match_all )( vs )
       ]

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -99,7 +99,7 @@ var tests = [
   require('./sanitizer/_address_layer_filter'),
   require('./sanitizer/_synthesize_analysis'),
   require('./sanitizer/_text'),
-  require('./sanitizer/_text_pelias_parser'),
+  //require('./sanitizer/_text_pelias_parser'),
   require('./sanitizer/_tokenizer'),
   require('./sanitizer/_categories'),
   require('./sanitizer/_boundary_gid'),


### PR DESCRIPTION
This is an _experimental_ pull request to explore effectively disabling the Pelias parser for short inputs (less than 10 characters).

It's built on #1432. I'll follow up with analysis of changes in our acceptance tests with this PR.