### PR TITLE
Run Pelias parser-based query in more cases

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -146,10 +146,18 @@ function addRoutes(app, peliasConfig) {
     not(placeholderShouldHaveExecuted)
   );
 
-  // defer to pelias parser for analysis IF there's no response AND placeholder should not have executed
-  const shouldDeferToPeliasParser = all(
-    not(predicates.hasRequestErrors),
-    not(predicates.hasResponseData)
+  const shouldDeferToPeliasParser = any(
+    // we always want to try pelias parser based queries if there are no results
+    not(predicates.hasResponseData),
+    all(
+      // if there are only admin results, but parse contains more granular items than admin,
+      // then we want to defer to pelias parser based queries
+      predicates.hasAdminOnlyResults,
+      not(predicates.isAdminOnlyAnalysis),
+      // exception: if the 'sources' parameter is only wof, do not use pelias parser
+      // in that case Placeholder can return all the possible answers
+      not(predicates.isRequestSourcesOnlyWhosOnFirst),
+    )
   );
 
   // call search_pelias_parser query if pelias_parser was the parser

--- a/sanitizer/defer_to_pelias_parser.js
+++ b/sanitizer/defer_to_pelias_parser.js
@@ -1,4 +1,19 @@
-// middleware
+function shouldUsePeliasParse(req, res) {
+  //always use pelias parser output if old parse and queries returned no results
+  if (!res.data || res.data.length === 0) {
+    return true;
+  }
+
+  // if there's no intersection parse, the pelias parser based queries
+  // are likely not better, so don't use them
+  if (!req.clean.parsed_text.cross_street) {
+    return false;
+  }
+
+  // usually, pelias parser should be used
+  return true;
+}
+
 module.exports = (_api_pelias_config, should_execute) => {
   const sanitizeAll = require('../sanitizer/sanitizeAll'),
   sanitizers = {
@@ -6,18 +21,27 @@ module.exports = (_api_pelias_config, should_execute) => {
     text: require('../sanitizer/_text_pelias_parser')()
   };
 
-
   return function(req, res, next) {
-    // if res.data already has results then don't call the _text_autocomplete sanitizer
-    // this has been put into place for when the libpostal integration way of querying
-    // ES doesn't return anything and we want to fallback to the old logic
+    // only run the pelias parser and text sanitizer when determined by predicates
     if (!should_execute(req, res)) {
       return next();
     }
 
-    sanitizeAll.sanitize(req, sanitizers);
-    next();
+    // save the existing parse and parser name, in case we decide its best not to use
+    const existing_parse = req.clean.parsed_text;
+    const existing_parser = req.clean.parser;
 
+    // call the pelias parser and update the parse
+    sanitizeAll.sanitize(req, sanitizers);
+
+    // look at the output of Pelias Parser and previously returned results (from other parsers/queries)
+    // and determine if we should use the Pelias parser or revert to the previous parser output
+    if (!shouldUsePeliasParse(req, res)) {
+      req.clean.parsed_text = existing_parse;
+      req.clean.parser = existing_parser;
+    }
+
+    next();
   };
 
 };


### PR DESCRIPTION
Currently, there are 3 different types of queries against Elasticsearch that might be run from the `/v1/search` endpoint.

The last of these, which uses the Pelias Parser to parse the input, will only be run if there are _no_ results from either the previous queries, or from Placeholder (which is run first if any admin areas are recognized in the input by `libpostal`).

There are many cases where Placeholder will return results (such as a city), but the Pelias Parser could have recognized that other elements, especially _street intersections_ were present, and constructed an appropriate query to fetch them from Elasticssearch.

This PR changes the conditions under which the Pelias Parser and query based on it will run. There are two commits: one to expand the conditions for running the query at all, and a second to add new logic to detect a few exceptions to those new conditions, under which we _shouldn't_ run Pelias Parser based queries.

More details are in the two commit messages.