### PR TITLE
Use peliasQuery analyzer for address_parts.street

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -42,12 +42,12 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:housenumber:boost': 2,
   'address:housenumber:cutoff_frequency': 0.01,
 
-  'address:street:analyzer': 'peliasStreet',
+  'address:street:analyzer': 'peliasQuery',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 1,
   'address:street:cutoff_frequency': 0.01,
 
-  'address:cross_street:analyzer': 'peliasStreet',
+  'address:cross_street:analyzer': 'peliasQuery',
   'address:cross_street:field': 'address_parts.cross_street',
   'address:cross_street:boost': 5,
   'address:cross_street:cutoff_frequency': 0.01,

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -41,7 +41,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:housenumber:boost': 2,
   'address:housenumber:cutoff_frequency': 0.01,
 
-  'address:street:analyzer': 'peliasStreet',
+  'address:street:analyzer': 'peliasQuery',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 5,
   'address:street:slop': 1,

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -39,7 +39,7 @@ module.exports = {
               'query': 'k road',
               'cutoff_frequency': 0.01,
               'boost': 1,
-              'analyzer': 'peliasStreet'
+              'analyzer': 'peliasQuery'
             }
           }
         },

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_boundary_country_multi.js
+++ b/test/unit/fixture/search_boundary_country_multi.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_boundary_gid.js
+++ b/test/unit/fixture/search_boundary_gid.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -110,7 +110,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }
@@ -278,7 +278,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_with_category_filtering.js
+++ b/test/unit/fixture/search_with_category_filtering.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }

--- a/test/unit/fixture/search_with_source_filtering.js
+++ b/test/unit/fixture/search_with_source_filtering.js
@@ -14,7 +14,7 @@ module.exports = {
                     'match_phrase': {
                       'address_parts.street': {
                         'query': 'street value',
-                        'analyzer': 'peliasStreet',
+                        'analyzer': 'peliasQuery',
                         'slop': 1
                       }
                     }


### PR DESCRIPTION
This changes the query-time analyzer for the `address_parts.street` field from `peliasStreet` to `peliasQuery`.

The latter does not generate synonyms, so it'll be much more performant and also likely produce better quality results, so win-win 🤞 