### PR TITLE
Increase slop to 3 on `address_parts.street` field

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -44,7 +44,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:street:analyzer': 'peliasQuery',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 5,
-  'address:street:slop': 1,
+  'address:street:slop': 3,
   'address:street:cutoff_frequency': 0.01,
 
   'address:postcode:analyzer': 'peliasZip',

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_boundary_country_multi.js
+++ b/test/unit/fixture/search_boundary_country_multi.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_boundary_gid.js
+++ b/test/unit/fixture/search_boundary_gid.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -111,7 +111,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   },
@@ -279,7 +279,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   },

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_linguistic_focus.js
+++ b/test/unit/fixture/search_linguistic_focus.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_linguistic_focus_null_island.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_linguistic_only.js
+++ b/test/unit/fixture/search_linguistic_only.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_with_category_filtering.js
+++ b/test/unit/fixture/search_with_category_filtering.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/fixture/search_with_source_filtering.js
+++ b/test/unit/fixture/search_with_source_filtering.js
@@ -15,7 +15,7 @@ module.exports = {
                       'address_parts.street': {
                         'query': 'street value',
                         'analyzer': 'peliasQuery',
-                        'slop': 1
+                        'slop': 3
                       }
                     }
                   }

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -141,7 +141,7 @@ module.exports.tests.other_parameters = (test, common) => {
 
   });
 
-  test('address_parts.street slop defaults to 1', (t) => {
+  test('address_parts.street slop defaults to 3', (t) => {
     const logger = mock_logger();
 
     const clean = {
@@ -167,7 +167,7 @@ module.exports.tests.other_parameters = (test, common) => {
 
     const generatedQuery = generateQuery(clean, res);
 
-    t.deepEquals(generatedQuery.body.vs.var('address:street:slop').toString(), 1);
+    t.deepEquals(generatedQuery.body.vs.var('address:street:slop').toString(), 3);
     t.end();
   });
 };


### PR DESCRIPTION
This can help allow for more flexible matches when running `/v1/search` queries.