### PR TITLE
Calculate Elasticsearch query size for autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -170,6 +170,11 @@ function generateQuery( clean ){
     vs.var('input:categories', clean.categories);
   }
 
+  // size
+  if( clean.querySize ) {
+    vs.var( 'size', clean.querySize );
+  }
+
   // run the address parser
   if( clean.parsed_text ){
     textParser( clean, vs );

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -257,6 +257,7 @@ function addRoutes(app, peliasConfig) {
     autocomplete: createRouter([
       sanitizers.autocomplete.middleware(peliasConfig.api),
       middleware.requestLanguage,
+      middleware.sizeCalculator(),
       controllers.search(peliasConfig.api, esclient, queries.autocomplete, not(hasResponseDataOrRequestErrors)),
       middleware.distance('focus.point.'),
       middleware.confidenceScore(peliasConfig.api),

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -85,7 +85,7 @@
         ]
       }
     },
-    "size": 20,
+    "size": 10,
     "track_scores": true,
     "sort": [
       "_score"


### PR DESCRIPTION
Way back in https://github.com/pelias/api/pull/1276 we added the `size` parameter to autocomplete. 

However, some of the components of this change were missing: while we could easily ensure that size values smaller than the default `10` would result in fewer than 10 results, it turns out we weren't handling the case of _higher_ sizes.

There is a simple but important middleware component that translates `size` query values into a size to send onward in the request to Elasticsearch (it should be larger than the `size` parameter to allow
for duplicate results to be pruned while still returning approximately the expected number of results).

This middleware was missing on the autocomplete endpoint, and by adding it, sizes above 10 are now more likely to return more results.

Note: returning more than 10 results is probably not a great idea from a UX standpoint, but it might be interesting for certain purposes, so it's good to allow it.