### PR TITLE
Add new debugging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ The API recognizes the following properties under the top-level `api` key in you
 |`attributionURL`|no| (autodetected)|The full URL to use for the attribution link returned in all Pelias responses. Pelias will attempt to autodetect this host, but it will often be incorrect if, for example, there is a proxy between Pelias and its users. This parameter allows setting a specific URL to avoid any such issues|
 |`accessLog`|*no*||name of the format to use for access logs; may be any one of the [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
-|`serveCompareFrontend`|*no*|true|if set to true, the [pelias compare frontend](https://github.com/pelias/compare) will be served from /frontend, pointing at the local instance, to aid in on-server debugging. [example](https://pelias.github.io/compare/)
-
+|`exposeInternalDebugTools`|*no*|true|Exposes several debugging tools, such as the ability to enable Elasticsearch explain mode, that may come at a performance cost or expose sensitive infrastructure details. Not recommended if the Pelias API is open to the public.
 
 A good starting configuration file includes this section (fill in the service and Elasticsearch hosts as needed):
 

--- a/controller/search.js
+++ b/controller/search.js
@@ -53,6 +53,10 @@ function setup( apiConfig, esclient, query, should_execute ){
       body: renderedQuery.body
     };
 
+    if (req.clean.enableElasticExplain) {
+      cmd.explain = true;
+    }
+
     logger.debug( '[ES req]', cmd );
     debugLog.push(req, {ES_req: cmd});
 
@@ -126,6 +130,9 @@ function setup( apiConfig, esclient, query, should_execute ){
           }});
         }
         logger.debug('[ES response]', docs);
+        if (req.clean.enableElasticDebug) {
+          debugLog.push(req, {ES_response: {docs, meta, data}});
+        }
         next();
       });
       debugLog.stopTimer(req, initialTime);

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -213,7 +213,7 @@ function addRoutes(app, peliasConfig) {
       // try 3 different query types: address search using ids, cascading fallback, pelias parser
       controllers.search(peliasConfig.api, esclient, queries.address_search_using_ids, searchWithIdsShouldExecute),
       controllers.search(peliasConfig.api, esclient, queries.search, fallbackQueryShouldExecute),
-      sanitizers.defer_to_pelias_parser(shouldDeferToPeliasParser), //run additional sanitizers needed for pelias parser
+      sanitizers.defer_to_pelias_parser(peliasConfig.api, shouldDeferToPeliasParser), //run additional sanitizers needed for pelias parser
       controllers.search(peliasConfig.api, esclient, queries.search_pelias_parser, searchPeliasParserShouldExecute),
       middleware.trimByGranularity(),
       middleware.distance('focus.point.'),
@@ -273,7 +273,7 @@ function addRoutes(app, peliasConfig) {
       middleware.sendJSON
     ]),
     reverse: createRouter([
-      sanitizers.reverse.middleware,
+      sanitizers.reverse.middleware(peliasConfig.api),
       middleware.requestLanguage,
       middleware.sizeCalculator(2),
       controllers.search(peliasConfig.api, esclient, queries.reverse, nonCoarseReverseShouldExecute),
@@ -294,7 +294,7 @@ function addRoutes(app, peliasConfig) {
       middleware.sendJSON
     ]),
     nearby: createRouter([
-      sanitizers.nearby.middleware,
+      sanitizers.nearby.middleware(peliasConfig.api),
       middleware.requestLanguage,
       middleware.sizeCalculator(),
       controllers.search(peliasConfig.api, esclient, queries.reverse, not(hasResponseDataOrRequestErrors)),
@@ -314,7 +314,7 @@ function addRoutes(app, peliasConfig) {
       middleware.sendJSON
     ]),
     place: createRouter([
-      sanitizers.place.middleware,
+      sanitizers.place.middleware(peliasConfig.api),
       middleware.requestLanguage,
       controllers.place(peliasConfig.api, esclient),
       middleware.accuracy(),
@@ -348,7 +348,7 @@ function addRoutes(app, peliasConfig) {
   app.get ( base + 'reverse',              routers.reverse );
   app.get ( base + 'nearby',               routers.nearby );
 
-  if (peliasConfig.api.serveCompareFrontend) {
+  if (peliasConfig.api.exposeInternalDebugTools) {
     app.use ( '/frontend',                   express.static('node_modules/pelias-compare/dist-api/'));
   }
 }

--- a/sanitizer/_debug.js
+++ b/sanitizer/_debug.js
@@ -1,23 +1,61 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-function _sanitize(raw, clean){
-  const messages = {errors: [], warnings: []};
+/**
+* @param {object} exposeInternalDebugTools property of pelias config
+*/
+function _setup(exposeInternalDebugTools) {
+  return {
+    sanitize: (raw, clean) => {
+      const messages = { errors: [], warnings: [] };
 
-  if(!_.isUndefined(raw.debug) ){
-    clean.enableDebug = (typeof raw.debug === 'string') ? isTruthy(raw.debug.toLowerCase()) : isTruthy( raw.debug );
-  }
-  return messages;
+      if (_.isUndefined(raw.debug)) {
+        return messages;
+      }
+
+      clean.enableDebug = false;
+
+      if (_.isEqual(raw.debug, {})) {
+        return messages;
+      }
+
+      const debugStr = raw.debug.toString().toLowerCase();
+
+      const debugLevelMapping = {
+        'false': 0,
+        'true': 1,
+        'elastic': 2,
+        'explain': 3
+      };
+
+      const numericDebugStr = Number(debugStr);
+      
+      const debugLevel = isNaN(numericDebugStr) ? debugLevelMapping[debugStr] : numericDebugStr;
+
+      if (_.isNil(debugLevel)) {
+        messages.errors.push('Unknown debug value: ' + debugStr);
+      }
+
+      if (debugLevel >= 2 && !exposeInternalDebugTools) {
+        messages.errors.push('Debug level not enabled: ' + debugStr);
+      } else {
+        if (debugLevel >= 1) {
+          clean.enableDebug = true;
+        }
+        if (debugLevel >= 2) {
+          clean.enableElasticDebug = true;
+        }
+        if (debugLevel >= 3) {
+          clean.enableElasticExplain = true;
+        }
+      }
+
+      return messages;
+    },
+
+    expected: () => {
+      return [{ name: 'debug' }];
+    },
+  };
 }
 
-function _expected() {
-  return [{ name: 'debug' }];
-}
-
-function isTruthy(val) {
-  return _.includes( ['true', '1', 1, true], val );
-}
-
-module.exports = () => ({
-  sanitize: _sanitize,
-  expected: _expected
-});
+module.exports = _setup;

--- a/sanitizer/autocomplete.js
+++ b/sanitizer/autocomplete.js
@@ -5,7 +5,7 @@ var sanitizeAll = require('../sanitizer/sanitizeAll');
 module.exports.middleware = (_api_pelias_config) => {
   var sanitizers = {
       singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
-      debug: require('../sanitizer/_debug')(),
+      debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
       text: require('../sanitizer/_text_pelias_parser')(),
       tokenizer: require('../sanitizer/_tokenizer')(),
       size: require('../sanitizer/_size')(/* use defaults*/),

--- a/sanitizer/defer_to_pelias_parser.js
+++ b/sanitizer/defer_to_pelias_parser.js
@@ -1,14 +1,12 @@
-const sanitizeAll = require('../sanitizer/sanitizeAll'),
-    sanitizers = {
-      debug: require('../sanitizer/_debug')(),
-      text: require('../sanitizer/_text_pelias_parser')()
-    };
-
-const logger = require('pelias-logger').get('api');
-const logging = require( '../helper/logging' );
-
 // middleware
-module.exports = (should_execute) => {
+module.exports = (_api_pelias_config, should_execute) => {
+  const sanitizeAll = require('../sanitizer/sanitizeAll'),
+  sanitizers = {
+    debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
+    text: require('../sanitizer/_text_pelias_parser')()
+  };
+
+
   return function(req, res, next) {
     // if res.data already has results then don't call the _text_autocomplete sanitizer
     // this has been put into place for when the libpostal integration way of querying

--- a/sanitizer/nearby.js
+++ b/sanitizer/nearby.js
@@ -1,25 +1,26 @@
 var sanitizeAll = require('../sanitizer/sanitizeAll');
 var type_mapping = require('../helper/type_mapping');
 
-// add categories to the sanitizer list
-var sanitizers = {
-  singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
-  debug: require('../sanitizer/_debug')(),
-  layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),
-  sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
-  // depends on the layers and sources sanitizers, must be run after them
-  sources_and_layers: require('../sanitizer/_sources_and_layers')(),
-  geonames_deprecation: require('../sanitizer/_geonames_deprecation')(),
-  size: require('../sanitizer/_size')(/* use defaults*/),
-  private: require('../sanitizer/_flag_bool')('private', false),
-  geo_reverse: require('../sanitizer/_geo_reverse')(),
-  boundary_country: require('../sanitizer/_boundary_country')(),
-  categories: require('../sanitizer/_categories')(),
-  request_language: require('../sanitizer/_request_language')()
-};
+module.exports.middleware = (_api_pelias_config) => {
+  // add categories to the sanitizer list
+  var sanitizers = {
+    singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
+    debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
+    layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),
+    sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
+    // depends on the layers and sources sanitizers, must be run after them
+    sources_and_layers: require('../sanitizer/_sources_and_layers')(),
+    geonames_deprecation: require('../sanitizer/_geonames_deprecation')(),
+    size: require('../sanitizer/_size')(/* use defaults*/),
+    private: require('../sanitizer/_flag_bool')('private', false),
+    geo_reverse: require('../sanitizer/_geo_reverse')(),
+    boundary_country: require('../sanitizer/_boundary_country')(),
+    categories: require('../sanitizer/_categories')(),
+    request_language: require('../sanitizer/_request_language')()
+  };
 
-// middleware
-module.exports.middleware = function( req, res, next ){
-  sanitizeAll.runAllChecks(req, sanitizers);
-  next();
+  return function( req, res, next ){
+    sanitizeAll.runAllChecks(req, sanitizers);
+    next();
+  };
 };

--- a/sanitizer/place.js
+++ b/sanitizer/place.js
@@ -1,15 +1,16 @@
-var sanitizeAll = require('../sanitizer/sanitizeAll'),
-    sanitizers = {
-      singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
-      debug: require('../sanitizer/_debug')(),
-      ids: require('../sanitizer/_ids')(),
-      private: require('../sanitizer/_flag_bool')('private', false),
-      categories: require('../sanitizer/_categories')(true),
-      request_language: require('../sanitizer/_request_language')()
-    };
+module.exports.middleware = (_api_pelias_config) => {
+  var sanitizeAll = require('../sanitizer/sanitizeAll'),
+      sanitizers = {
+        singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
+        debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
+        ids: require('../sanitizer/_ids')(),
+        private: require('../sanitizer/_flag_bool')('private', false),
+        categories: require('../sanitizer/_categories')(true),
+        request_language: require('../sanitizer/_request_language')()
+      };
 
-// middleware
-module.exports.middleware = function(req, res, next){
-  sanitizeAll.runAllChecks(req, sanitizers);
-  next();
+  return function(req, res, next){
+    sanitizeAll.runAllChecks(req, sanitizers);
+    next();
+  };
 };

--- a/sanitizer/reverse.js
+++ b/sanitizer/reverse.js
@@ -1,23 +1,25 @@
-var type_mapping = require('../helper/type_mapping');
-var sanitizeAll = require('../sanitizer/sanitizeAll'),
-    sanitizers = {
-      singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
-      debug: require('../sanitizer/_debug')(),
-      layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),
-      sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
-      // depends on the layers and sources sanitizers, must be run after them
-      sources_and_layers: require('../sanitizer/_sources_and_layers')(),
-      geonames_deprecation: require('../sanitizer/_geonames_deprecation')(),
-      size: require('../sanitizer/_size')(/* use defaults*/),
-      private: require('../sanitizer/_flag_bool')('private', false),
-      geo_reverse: require('../sanitizer/_geo_reverse')(),
-      boundary_country: require('../sanitizer/_boundary_country')(),
-      request_language: require('../sanitizer/_request_language')(),
-      boundary_gid: require('../sanitizer/_boundary_gid')()
-    };
+module.exports.middleware = (_api_pelias_config) => {
+  var type_mapping = require('../helper/type_mapping');
+  var sanitizeAll = require('../sanitizer/sanitizeAll'),
+      sanitizers = {
+        singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
+        debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
+        layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),
+        sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
+        // depends on the layers and sources sanitizers, must be run after them
+        sources_and_layers: require('../sanitizer/_sources_and_layers')(),
+        geonames_deprecation: require('../sanitizer/_geonames_deprecation')(),
+        size: require('../sanitizer/_size')(/* use defaults*/),
+        private: require('../sanitizer/_flag_bool')('private', false),
+        geo_reverse: require('../sanitizer/_geo_reverse')(),
+        boundary_country: require('../sanitizer/_boundary_country')(),
+        request_language: require('../sanitizer/_request_language')(),
+        boundary_gid: require('../sanitizer/_boundary_gid')()
+      };
 
-// middleware
-module.exports.middleware = function( req, res, next ){
-  sanitizeAll.runAllChecks(req, sanitizers);
-  next();
+  // middleware
+  return function( req, res, next ){
+    sanitizeAll.runAllChecks(req, sanitizers);
+    next();
+  };
 };

--- a/sanitizer/search.js
+++ b/sanitizer/search.js
@@ -4,7 +4,7 @@ var sanitizeAll = require('../sanitizer/sanitizeAll');
 module.exports.middleware = (_api_pelias_config) => {
   var sanitizers = {
         singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
-        debug: require('../sanitizer/_debug')(),
+        debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
         text: require('../sanitizer/_text')(),
         size: require('../sanitizer/_size')(/* use defaults*/),
         layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),

--- a/sanitizer/structured_geocoding.js
+++ b/sanitizer/structured_geocoding.js
@@ -5,7 +5,7 @@ var sanitizeAll = require('../sanitizer/sanitizeAll');
 module.exports.middleware = (_api_pelias_config) => {
   var sanitizers = {
         singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
-        debug: require('../sanitizer/_debug')(),
+        debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
         synthesize_analysis: require('../sanitizer/_synthesize_analysis')(),
         iso2_to_iso3: require('../sanitizer/_iso2_to_iso3')(),
         city_name_standardizer: require('../sanitizer/_city_name_standardizer')(),

--- a/schema.js
+++ b/schema.js
@@ -11,7 +11,7 @@ const Joi = require('@hapi/joi');
 // optional:
 // * api.accessLog (string)
 // * api.relativeScores (boolean)
-// * api.serveCompareFrontend (boolean)
+// * api.exposeInternalDebugTools (boolean)
 // * api.localization (flipNumberAndStreetCountries is array of 3 character strings)
 module.exports = Joi.object().keys({
   api: Joi.object().required().keys({
@@ -20,7 +20,7 @@ module.exports = Joi.object().keys({
     host: Joi.string(),
     accessLog: Joi.string().allow(''),
     relativeScores: Joi.boolean(),
-    serveCompareFrontend: Joi.boolean(),
+    exposeInternalDebugTools: Joi.boolean(),
     requestRetries: Joi.number().integer().min(0),
     customBoosts: Joi.object().keys({
       layer: Joi.object(),

--- a/test/unit/sanitizer/_debug.js
+++ b/test/unit/sanitizer/_debug.js
@@ -4,7 +4,7 @@ module.exports.tests = {};
 
 module.exports.tests.sanitize_debug = function(test, common) {
   ['true', '1', 1, true, 'TRUE', 'TrUe'].forEach((value) => {
-    test('debug flag is on', function(t) {
+    test(`debug flag is on: ${value}`, function(t) {
       const raw = { debug: value };
       const clean = {};
       const expected_clean = { enableDebug: true  };
@@ -18,8 +18,66 @@ module.exports.tests.sanitize_debug = function(test, common) {
     });
   });
 
-  ['false', false, '0', 0, 'value', {}].forEach((value) => {
-    test('non-truthy values should set clean.debug to false', function(t) {
+  ['2', 2, 'elastic'].forEach((value) => {
+    test(`debug flag is on: ${value} and exposeInternalDebugTools=true`, function(t) {
+      const internalSanitizer = require('../../../sanitizer/_debug')(true);
+      const raw = { debug: value };
+      const clean = {};
+      const expected_clean = { enableDebug: true, enableElasticDebug: true };
+
+      const messages = internalSanitizer.sanitize(raw, clean);
+
+      t.deepEquals(clean, expected_clean);
+      t.deepEqual(messages.errors, [], 'no error returned');
+      t.deepEqual(messages.warnings, [], 'no warnings returned');
+      t.end();
+    });
+
+    test(`debug flag is on: ${value} and exposeInternalDebugTools unset`, function(t) {
+      const raw = { debug: value };
+      const clean = {};
+      const expected_clean = { enableDebug: false };
+
+      const messages = sanitizer.sanitize(raw, clean);
+
+      t.deepEquals(clean, expected_clean);
+      t.deepEqual(messages.errors, [`Debug level not enabled: ${value}`], 'no error returned');
+      t.deepEqual(messages.warnings, [], 'no warnings returned');
+      t.end();
+    });
+  });
+
+  ['3', 3, 'explain'].forEach((value) => {
+    test(`debug flag is on: ${value} and exposeInternalDebugTools=true`, function(t) {
+      const internalSanitizer = require('../../../sanitizer/_debug')(true);
+      const raw = { debug: value };
+      const clean = {};
+      const expected_clean = { enableDebug: true, enableElasticDebug: true, enableElasticExplain: true };
+
+      const messages = internalSanitizer.sanitize(raw, clean);
+
+      t.deepEquals(clean, expected_clean);
+      t.deepEqual(messages.errors, [], 'no error returned');
+      t.deepEqual(messages.warnings, [], 'no warnings returned');
+      t.end();
+    });
+
+    test(`debug flag is on: ${value} and exposeInternalDebugTools unset`, function(t) {
+      const raw = { debug: value };
+      const clean = {};
+      const expected_clean = { enableDebug: false };
+
+      const messages = sanitizer.sanitize(raw, clean);
+
+      t.deepEquals(clean, expected_clean);
+      t.deepEqual(messages.errors, [`Debug level not enabled: ${value}`], 'no error returned');
+      t.deepEqual(messages.warnings, [], 'no warnings returned');
+      t.end();
+    });
+  });
+
+  ['false', false, '0', 0, {}].forEach((value) => {
+    test(`non-truthy values should set clean.debug to false: ${value}`, function(t) {
       const raw = { debug: value };
       const clean = {};
       const expected_clean = { enableDebug: false  };
@@ -31,6 +89,19 @@ module.exports.tests.sanitize_debug = function(test, common) {
       t.deepEqual(messages.warnings, [], 'no warnings returned');
       t.end();
     });
+  });
+
+  test(`unknown value shold return error`, function(t) {
+    const raw = { debug: 'value' };
+    const clean = {};
+    const expected_clean = { enableDebug: false  };
+
+    const messages = sanitizer.sanitize(raw, clean);
+
+    t.deepEquals(clean, expected_clean);
+    t.deepEqual(messages.errors, ['Unknown debug value: value']);
+    t.deepEqual(messages.warnings, [], 'no warnings returned');
+    t.end();
   });
 
   test('undefined default flag should not set clean.debug', function(t) {

--- a/test/unit/sanitizer/defer_to_pelias_parser.js
+++ b/test/unit/sanitizer/defer_to_pelias_parser.js
@@ -3,6 +3,8 @@ const mock_logger = require('pelias-mock-logger');
 
 module.exports.tests = {};
 
+const dummyPeliasApiConfig = {};
+
 module.exports.tests.sanitize = (test, common) => {
   test('verify that no sanitizers were called when should_execute returns false', (t) => {
     t.plan(1);
@@ -27,7 +29,7 @@ module.exports.tests.sanitize = (test, common) => {
           }
         };
       }
-    })(() => false);
+    })(dummyPeliasApiConfig, () => false);
 
     defer_to_pelias_parser({}, {}, () => {
       t.equals(logger.getInfoMessages().length, 0);
@@ -64,7 +66,7 @@ module.exports.tests.sanitize = (test, common) => {
           }
         };
       },
-    })(() => true);
+    })(dummyPeliasApiConfig, () => true);
 
     const req = {
       path: '/v1/search',
@@ -104,7 +106,7 @@ module.exports.tests.sanitize = (test, common) => {
           }
         };
       },
-    })(() => true);
+    })(dummyPeliasApiConfig, () => true);
 
     const req = {
       path: 'not /v1/search',

--- a/test/unit/sanitizer/nearby.js
+++ b/test/unit/sanitizer/nearby.js
@@ -130,7 +130,7 @@ module.exports.tests.sanitize = function(test, common) {
     const req = {};
     const res = {};
 
-    nearby.middleware(req, res, () => {
+    nearby.middleware({})(req, res, () => {
       t.deepEquals(called_sanitizers, expected_sanitizers);
       t.end();
     });

--- a/test/unit/sanitizer/place.js
+++ b/test/unit/sanitizer/place.js
@@ -67,7 +67,7 @@ module.exports.tests.sanitize = function(test, common) {
     const req = {};
     const res = {};
 
-    place.middleware(req, res, () => {
+    place.middleware({})(req, res, () => {
       t.deepEquals(called_sanitizers, expected_sanitizers);
       t.end();
     });

--- a/test/unit/sanitizer/reverse.js
+++ b/test/unit/sanitizer/reverse.js
@@ -130,7 +130,7 @@ module.exports.tests.sanitize = function(test, common) {
     const req = {};
     const res = {};
 
-    reverse.middleware(req, res, () => {
+    reverse.middleware({})(req, res, () => {
       t.deepEquals(called_sanitizers, expected_sanitizers);
       t.end();
     });


### PR DESCRIPTION
debug=2 or debug=elastic returns raw elastic response
debug=3 or debug=explain returns raw elastic response with
explain=true in the request

The new `api.exposeInternalDebugTools` configuration property must be
set to enable these, since they may expose sensitive information about a
Pelias installation, or allow end users to run expensive explain queries
that may hurt performance.

See also:
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html

_This PR replaces #1435 after some rebasing and minor commit message cleanup_
Closes #1435 