### PR TITLE
[WIP] Reduce boost for postalcode matches

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -49,7 +49,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'address:postcode:analyzer': 'peliasZip',
   'address:postcode:field': 'address_parts.zip',
-  'address:postcode:boost': 20,
+  'address:postcode:boost': 1,
   'address:postcode:cutoff_frequency': 0.01,
 
   // generic multi_match cutoff_frequency


### PR DESCRIPTION
For many years now, we have often seen queries where incorrect results that happened to match on a postalcode were boosted above the correct match.

Considering that there is no guarantee any particular address or venue record will have a postalcode, this case is in fact fairly common.

I believe our desired outcome is that a postalcode acts only as a 'tiebreaker' between otherwise very similar results.

With that in mind, the current default boost of 20 is _far_ too high.