### PR TITLE
fix [Object] in debugUrl

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -60,12 +60,19 @@ function setup( peliasConfig, esclient, query, should_execute ){
       cmd.explain = true;
     }
 
-    const debugUrl = req.clean.exposeInternalDebugTools ?
-      `${peliasConfig.esclient.hosts[0]}/${apiConfig.indexName}/_search?` +
-        querystring.stringify({
-          source_content_type: 'application/json',
-          source: JSON.stringify(cmd.body)
-        }) : undefined;
+    let debugUrl = '';
+    if (peliasConfig.eslclient && Array.isArray(peliasConfig.eslclient.hosts) && peliasConfig.eslclient.hosts.length > 0) {
+      const firstEsHostEntry = peliasConfig.esclient.hosts[0];
+      const esHost = firstEsHostEntry.host ? 
+        `${firstEsHostEntry.protocol}://${firstEsHostEntry.host}:${firstEsHostEntry.port}` : firstEsHostEntry;
+
+       debugUrl = req.clean.exposeInternalDebugTools ?
+        `${esHost}/${apiConfig.indexName}/_search?` +
+          querystring.stringify({
+            source_content_type: 'application/json',
+            source: JSON.stringify(cmd.body)
+          }) : undefined;
+    }
 
     debugLog.push(req, {
       debugUrl,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const app = require('./app'),
 const server = app.listen( port, host, () => {
   // ask server for the actual address and port its listening on
   const listenAddress = server.address();
-  logger.info( `pelias is now running on ${listenAddress.address}:${listenAddress.port}` );
+  logger.info( `pelias is now running on http://${listenAddress.address}:${listenAddress.port}` );
 });
 
 function exitHandler() {


### PR DESCRIPTION
fixes https://github.com/pelias/compare/issues/33 - it was assuming hosts is always an array of strings. It seems like it can either be an array of strings or an array of objects

tested this with a hosts array that looks like

  "esclient": {
    "apiVersion": "7.5",
    "hosts": [{
      "protocol": "http",
      "host": "XXXX.ws.com", 
      "port": 9200
    }]
  },

and one that looks like

  "esclient": {
    "apiVersion": "7.5",
    "hosts": ["http://XZZZZ.amazonaws.com:9200"]
  },
