### PR TITLE
Fixed layer filtering for the search API

### DIFF
--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -17,6 +17,7 @@ addressUsingIdsQuery.filter( peliasQuery.view.boundary_circle );
 addressUsingIdsQuery.filter( peliasQuery.view.boundary_rect );
 addressUsingIdsQuery.filter( peliasQuery.view.sources );
 addressUsingIdsQuery.filter( peliasQuery.view.boundary_gid );
+addressUsingIdsQuery.filter( peliasQuery.view.layers );
 // --------------------------------
 
 // This query is a departure from traditional Pelias queries where textual
@@ -101,6 +102,11 @@ function generateQuery( clean, res ){
   // sources
   if( !_.isEmpty(clean.sources) ) {
     vs.var( 'sources', clean.sources);
+  }
+
+  // layers
+  if (_.isArray(clean.layers) && !_.isEmpty(clean.layers) ){
+    vs.var( 'layers', clean.layers);
   }
 
   // size

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -20,7 +20,8 @@ const views = {
   boundary_circle: 'boundary_circle view',
   boundary_rect: 'boundary_rect view',
   sources: 'sources view',
-  boundary_gid: 'boundary_gid view'
+  boundary_gid: 'boundary_gid view',
+  layers: 'layers view'
 };
 
 module.exports.tests.base_query = (test, common) => {
@@ -31,9 +32,11 @@ module.exports.tests.base_query = (test, common) => {
       parsed_text: {
         housenumber: 'housenumber value',
         postalcode: 'postcode value',
-        street: 'street value'
-      }
+        street: 'street value',
+      },
+      layers: ['venue', 'street', 'address']
     };
+
     const res = {
       data: []
     };
@@ -56,6 +59,7 @@ module.exports.tests.base_query = (test, common) => {
     t.equals(generatedQuery.body.vs.var('input:housenumber').toString(), 'housenumber value');
     t.equals(generatedQuery.body.vs.var('input:postcode').toString(), 'postcode value');
     t.equals(generatedQuery.body.vs.var('input:street').toString(), 'street value');
+    t.deepEquals(generatedQuery.body.vs.var('layers').toString(), [ 'venue', 'street', 'address' ]);
     t.notOk(generatedQuery.body.vs.isset('sources'));
     t.equals(generatedQuery.body.vs.var('size').toString(), 20);
 
@@ -68,7 +72,8 @@ module.exports.tests.base_query = (test, common) => {
       'boundary_circle view',
       'boundary_rect view',
       'sources view',
-      'boundary_gid view'
+      'boundary_gid view',
+      'layers view'
     ]);
 
     t.end();


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->
- Fixes https://github.com/pelias/api/issues/1391
---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->
- Added a hard filter for layers on the address_search_using_ids query

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
In the issue linked above I described how to reproduce.