### PR TITLE
fix(dedupe): consider category in deduplication

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -39,6 +39,24 @@ function isLayerDifferent(item1, item2){
 }
 
 /**
+ * Compare the category properties if they exist.
+ * Returns false if the objects are the same, else true.
+ */
+function isCategoryDifferent(item1, item2){
+  let category1 = _.get(item1, 'category');
+  let category2 = _.get(item2, 'category');
+
+  // check if these are array objects
+  // if only one has category info, we consider them the same
+  if( !_.isArray(category1) || !_.isArray(category2) ){ return false; }
+
+  // if both categories are empty, we consider them as same
+  if( _.isEmpty(category1) || _.isEmpty(category2) ){ return false; }
+
+  return isPropertyDifferent(item1, item2, 'category');
+}
+
+/**
  * Compare the parent properties if they exist.
  * Returns false if the objects are the same, else true.
  */
@@ -168,6 +186,7 @@ function isDifferent(item1, item2, requestLanguage){
   if( isParentHierarchyDifferent( item1, item2 ) ){ return true; }
   if( isNameDifferent( item1, item2, requestLanguage ) ){ return true; }
   if( isAddressDifferent( item1, item2 ) ){ return true; }
+  if( isCategoryDifferent( item1, item2 ) ){ return true; }
   return false;
 }
 

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -27,7 +27,8 @@ module.exports.tests.dedupe = function(test, common) {
         'number': '1',
         'street': 'Main Street'
       },
-      'layer': 'address'
+      'layer': 'address',
+      'category': [ 'entertainment' ],
     };
 
     t.false(isDifferent(item1, item1), 'should be the same');
@@ -57,6 +58,47 @@ module.exports.tests.dedupe = function(test, common) {
     };
 
     t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('catch diff category', function(t) {
+    var item1 = {
+      'layer': 'same',
+      'category': [ 'transport' ]
+    };
+    var item2 = {
+      'layer': 'same',
+      'category': [ 'entertainment' ]
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('isCategoryDifferent: empty categories are duplicates', function(t) {
+    var item1 = {
+      'layer': 'same',
+      'category': [ 'transport' ]
+    };
+    var item2 = {
+      'layer': 'same',
+      'category': []
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered be different');
+    t.end();
+  });
+
+  test('isCategoryDifferent: one missing category are considered same', function(t) {
+    var item1 = {
+      'layer': 'same',
+      'category': [ 'transport' ]
+    };
+    var item2 = {
+      'layer': 'same',
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered be different');
     t.end();
   });
 


### PR DESCRIPTION
Fixes #1460 

Open for discussion: 
Based on the other comparison methods, I considered records are the same if:
- one of them is missing the category fields, or it is empty
- at least one category match in both records