### PR TITLE
Nearby API: Add sort parameter

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -12,6 +12,7 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // scoring boost
 query.sort( peliasQuery.view.sort_distance );
+query.sort( peliasQuery.view.sort_popularity );
 
 // non-scoring hard filters
 query.filter( peliasQuery.view.boundary_circle );
@@ -94,6 +95,10 @@ function generateQuery( clean ){
   // categories
   if (clean.categories) {
     vs.var('input:categories', clean.categories);
+  }
+
+  if (_.isString(clean.sort)) {
+    vs.var('sort:field', clean.sort);
   }
 
   return {

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -9,6 +9,8 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'centroid:field': 'center_point',
 
+  'sort:field': 'distance',
+
   'sort:distance:order': 'asc',
   'sort:distance:distance_type': 'plane',
 

--- a/sanitizer/_sort.js
+++ b/sanitizer/_sort.js
@@ -1,0 +1,32 @@
+const _ = require('lodash');
+const DEFAULT_SORT = 'distance';
+
+const allowed_values = ['distance', 'popularity'];
+
+function _setup(){
+
+  return {
+    sanitize: function _sanitize( raw, clean ){
+
+      // error & warning messages
+      var messages = { errors: [], warnings: [] };
+
+      clean.sort = raw.sort;
+      
+      if( clean.sort && !allowed_values.includes(clean.sort) ){
+        messages.warnings.push('invalid \'sort\', using \'distance\'');
+        clean.sort = DEFAULT_SORT;
+      }
+
+      return messages;
+    },
+
+    expected: function _expected() {
+      // add size as a valid parameter
+      return [{ name: 'sort' }];
+    }
+  };
+}
+
+// export function
+module.exports = _setup;

--- a/sanitizer/nearby.js
+++ b/sanitizer/nearby.js
@@ -12,6 +12,7 @@ module.exports.middleware = (_api_pelias_config) => {
     sources_and_layers: require('../sanitizer/_sources_and_layers')(),
     geonames_deprecation: require('../sanitizer/_geonames_deprecation')(),
     size: require('../sanitizer/_size')(/* use defaults*/),
+    sort: require('../sanitizer/_sort')(),
     private: require('../sanitizer/_flag_bool')('private', false),
     geo_reverse: require('../sanitizer/_geo_reverse')(),
     boundary_country: require('../sanitizer/_boundary_country')(),


### PR DESCRIPTION
Hi, 

This is a follow up of https://github.com/pelias/pelias/issues/857.

In order to move step by step, I thought that the first one could be to add a `sort` parameter to the nearby API.

Possible values:
- `distance` (default): records are sorted by distance, from the center point.
- `popularity`: records are sorted by popularity (desc). Popular venues within the area (given the focus point and radius) are placed on top.



Motivation:
I want to be able to get popular venues within a given area.

Works well when used with the category filter: e.g: best bars around me.

Example:

`/v1/nearby?point.lat=41.40140682071436&point.lon=2.191686630249024&debug=1&categories=nightlife&sort=popularity`

Result:

```
0) Razzmatazz, Barcelona, Spain
1) L'Aliança del Poblenou, Barcelona, Spain
2) BeGood Club, Barcelona, Spain
3) Bodega Carol, Barcelona, Spain
4) El Cafè Blau, Barcelona, Spain
5) El Maderal, Barcelona, Spain
6) Atrium, Barcelona, Spain
7) Isami, Barcelona, Spain
8) Nicasso, Barcelona, Spain
9) La Tagliatella, Barcelona, Spain
```

Debug Query:
```json
{
    "query": {
    "bool": {
        "filter": [
        {
            "geo_distance": {
            "distance": "1km",
            "distance_type": "plane",
            "center_point": {
                "lat": 41.40140682071436,
                "lon": 2.191686630249024
            }
            }
        },
        {
            "terms": {
            "layer": [
                "venue",
                "address",
                "street"
            ]
            }
        },
        {
            "terms": {
            "category": [
                "nightlife"
            ]
            }
        }
        ]
    }
    },
    "size": 20,
    "track_scores": true,
    "sort": [
    "_score",
    {
        "popularity": {
        "order": "desc"
        }
    }
    ]
}
```

I will appreciate your feedback.
