### PR TITLE
feat(debug): add deep links to ES explain per result

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -175,12 +175,12 @@ function setup( peliasConfig, esclient, query, should_execute ){
             if (req.clean.exposeInternalDebugTools && esHostUrl) {
               // add an ES explain link to each document
               docs.forEach((doc) => {
-                const esExplainUrl = `${esHostUrl}/${apiConfig.indexName}/_explain/${doc._id}?` +
+                const esExplainUrl = `${esHostUrl}/${apiConfig.indexName}/_explain/${encodeURIComponent(doc._id)}?` +
                 querystring.stringify({
                   source_content_type: 'application/json',
                   source: JSON.stringify({query: cmd.body.query})
                 });
-                const esRawDocumentUrl = `${esHostUrl}/${apiConfig.indexName}/_doc/${doc._id}?`;
+                const esRawDocumentUrl = `${esHostUrl}/${apiConfig.indexName}/_doc/${encodeURIComponent(doc._id)}?`;
 
                 doc.debug = [{esExplainUrl, esRawDocumentUrl}];
               });

--- a/controller/search.js
+++ b/controller/search.js
@@ -180,7 +180,9 @@ function setup( peliasConfig, esclient, query, should_execute ){
                   source_content_type: 'application/json',
                   source: JSON.stringify({query: cmd.body.query})
                 });
-                doc.debug = [{esExplainUrl}];
+                const esRawDocumentUrl = `${esHostUrl}/${apiConfig.indexName}/_doc/${doc._id}?`;
+
+                doc.debug = [{esExplainUrl, esRawDocumentUrl}];
               });
             }
 

--- a/controller/search.js
+++ b/controller/search.js
@@ -133,6 +133,18 @@ function setup( peliasConfig, esclient, query, should_execute ){
           // be results.  if there are no results from this ES call, don't overwrite
           // what's already there from a previous call.
           if (!_.isEmpty(docs)) {
+            if (req.clean.exposeInternalDebugTools && esHostUrl) {
+              // add an ES explain link to each document
+              docs.forEach((doc) => {
+                const esExplainUrl = `${esHostUrl}/${apiConfig.indexName}/_explain/${doc._id}?` +
+                querystring.stringify({
+                  source_content_type: 'application/json',
+                  source: JSON.stringify({query: cmd.body.query})
+                });
+                doc.debug = [{esExplainUrl}];
+              });
+            }
+
             res.data = docs;
             res.meta = meta || {};
             // store the query_type for subsequent middleware

--- a/controller/search.js
+++ b/controller/search.js
@@ -173,15 +173,24 @@ function setup( peliasConfig, esclient, query, should_execute ){
           // what's already there from a previous call.
           if (!_.isEmpty(docs)) {
             if (req.clean.exposeInternalDebugTools && esHostUrl) {
-              // add an ES explain link to each document
+              // Add an ES explain link to each document
               docs.forEach((doc) => {
+                // make a version of our query that restricts to just this doc id
+                // this makes it easier to see why this particular result got the score
+                // it did.
                 const docIdQuery = {
-                  bool: { must: 
-                    [cmd.body.query, {
-                      ids: {
-                  type: '_doc',
-                  values: [doc._id]
-                }}]}};
+                  bool: { 
+                    must: [
+                      cmd.body.query, 
+                      {
+                        ids: {
+                          type: '_doc',
+                          values: [doc._id]
+                        }
+                      }
+                    ]
+                  }
+                };
                 const esExplainUrl = `${esHostUrl}/${apiConfig.indexName}/_search?` +
                   querystring.stringify({
                     source_content_type: 'application/json',

--- a/controller/search.js
+++ b/controller/search.js
@@ -77,6 +77,7 @@ function setup( peliasConfig, esclient, query, should_execute ){
         }
       });
 
+      // Add a direct link to the ES search API with explain=true
       debugInfo.explainDebugUrl = 
         `${esHostUrl}/${apiConfig.indexName}/_search?` +
           querystring.stringify({
@@ -84,7 +85,12 @@ function setup( peliasConfig, esclient, query, should_execute ){
             source: JSON.stringify({...cmd.body, explain: true})
           });
 
-        debugInfo.analyzerLinks = [];
+        /* NOTE(blackmad): I can't decide how helpful this is. 
+          For each part of the query that's sent to elastic search, add a link that lets you see 
+          what the elastic search analysis looks like 
+          */
+
+        // generic function to walk a javascript object
         const traverse = (obj, cb, keypath) => {
           for (let k in obj) {
             if (obj[k] && typeof obj[k] === 'object') {
@@ -95,6 +101,11 @@ function setup( peliasConfig, esclient, query, should_execute ){
           }
         };
             
+        debugInfo.analyzerLinks = [];
+
+        // Traverse the command we went to elastic search
+        // For each entry that has a "query" and "analyzer" child, formulate a link
+        // to elasticsearch to see the output of that query text against that
         traverse(cmd.body, (querySection, keypath) => {
           if (querySection.query && querySection.analyzer) {
             const analysisUrl = `${esHostUrl}/${apiConfig.indexName}/_analyze?` +

--- a/controller/search.js
+++ b/controller/search.js
@@ -74,10 +74,18 @@ function setup( peliasConfig, esclient, query, should_execute ){
           source: JSON.stringify(cmd.body)
         }
       });
+
+      explainDebugUrl = 
+        `${esHostUrl}/${apiConfig.indexName}/_search?` +
+          querystring.stringify({
+            source_content_type: 'application/json',
+            source: JSON.stringify({...cmd.body, explain: true})
+          });
     }
 
     debugLog.push(req, {
       debugUrl,
+      explainDebugUrl,
       ES_req: cmd
     });
 

--- a/controller/search.js
+++ b/controller/search.js
@@ -175,11 +175,19 @@ function setup( peliasConfig, esclient, query, should_execute ){
             if (req.clean.exposeInternalDebugTools && esHostUrl) {
               // add an ES explain link to each document
               docs.forEach((doc) => {
-                const esExplainUrl = `${esHostUrl}/${apiConfig.indexName}/_explain/${encodeURIComponent(doc._id)}?` +
-                querystring.stringify({
-                  source_content_type: 'application/json',
-                  source: JSON.stringify({query: cmd.body.query})
-                });
+                const docIdQuery = {
+                  bool: { must: 
+                    [cmd.body.query, {
+                      ids: {
+                  type: '_doc',
+                  values: [doc._id]
+                }}]}};
+                const esExplainUrl = `${esHostUrl}/${apiConfig.indexName}/_search?` +
+                  querystring.stringify({
+                    source_content_type: 'application/json',
+                    source: JSON.stringify({...cmd.body, query: docIdQuery, explain: true})
+                  });
+
                 const esRawDocumentUrl = `${esHostUrl}/${apiConfig.indexName}/_doc/${encodeURIComponent(doc._id)}?`;
 
                 doc.debug = [{esExplainUrl, esRawDocumentUrl}];


### PR DESCRIPTION
adds esExplainUrl per result to better be able to understand why certain results scored the way they did without adding in all the explain output

![image](https://user-images.githubusercontent.com/445616/87170222-0bb19f00-c29f-11ea-96ce-761be5db41ff.png)

supersedes https://github.com/pelias/api/pull/1465
