### PR TITLE
feat(debug): in /place when debug=true, expand analyzed ES document

### DIFF
--- a/middleware/expandDocument.js
+++ b/middleware/expandDocument.js
@@ -81,9 +81,13 @@ function service(apiConfig, esclient) {
 
     // Figure out all the fields that have dynamically defined ngram sub-fields.
     const ngramFields = new Set();
-    const mapping = await esclient.indices.getMapping();
+    const mapping = await esclient.indices.getMapping({index: apiConfig.indexName});
+    const hasMapping = mapping && mapping[apiConfig.indexName] && mapping[apiConfig.indexName].mappings;
+    if (!hasMapping) {
+      console.error(`Could not find mappings for index ${apiConfig.indexName} in ${JSON.stringify(mapping)}`);
+    }
+    const mappings = hasMapping ? mapping[apiConfig.indexName].mappings : {};
 
-    const mappings = mapping[apiConfig.indexName].mappings;
     traverse(mappings, (_value, keypath) => {
       // keypath will look like: properties.parent.properties.borough.fields.ngram.search_analyzer
       // and we want to extract from that "parent.borough" is a field that has ngrams on it

--- a/middleware/expandDocument.js
+++ b/middleware/expandDocument.js
@@ -1,0 +1,106 @@
+const _ = require('lodash');
+
+/**
+ * Recursive helper function for traverse()
+ */
+function traverseHelper(obj, keypath, cb) {
+  for (let k in obj) {
+    const newkeypath = keypath ? keypath + '.' + k : k;
+
+    // If obj[k] is a plain object, recurse on it
+    // otherwise, call cb on the value (which will be a string, number, array, boolean or class
+    // instance (not used here))
+    if (_.isPlainObject(obj[k])) {
+      traverseHelper(obj[k], newkeypath, cb);
+    } else {
+      cb(obj[k], newkeypath);
+    }
+  }
+}
+
+/**
+ * Given an object, recurse down the property tree and call cb(value, keypath) on the values
+ * found. keypath will be in dotted notation.
+ */
+function traverse(obj, cb) {
+  traverseHelper(obj, undefined, cb);
+}
+
+function service(apiConfig, esclient) {
+  /**
+   * Given a document, expandDocument attempts to create a human readable version of what elastic search
+   * indexes (as the result of running analyzers on the incoming document). It does this by asking
+   * ES to perform run-time analysis on every field in the document using the analyzers defined at index
+   * time.
+   *
+   * When a document is indexed by ES, it is run through a series of analzyers, that perform tasks like
+   * synonym expansion. Because these transformations are only useful for indexing, they are not saved
+   * on the indexed document. This makes it hard to reason about what is inside ES. This is a debug
+   * function to help make that easier.
+   */
+  function expandDocument(doc) {
+    const promises = [];
+    doc.debug = doc.debug || {};
+    doc.debug.expanded = {};
+
+    /**
+     * Given a dotted notation field name, and a value, send it to Elastic Search for analysis
+     * and add simplified analysis response to doc.debug.expanded.<keypath> when done
+     */
+    async function analyzeAndSetField(field, value) {
+      const isArrayOfString = _.isArray(value) && _.isString(value[0]);
+
+      // per https://www.elastic.co/guide/en/elasticsearch/reference/7.4/indices-analyze.html
+      // analyzers only run on strings or arrays of strings
+      if (!_.isString(value) && !isArrayOfString) {
+        return;
+      }
+
+      // For each field, send an RPC to elastic search to analyze it
+      // If you give ES the field name, it will match it to the analyzers specified in
+      // the schema mapping, without needing to explicitly ask for any individual analyzers
+      // 
+      // ignore failed responses, they'll get filtered out
+      const esResponse = await esclient.indices.analyze({
+        index: apiConfig.indexName,
+        body: { field, text: value },
+      }).catch(() => ({}));
+
+      // Group tokens by position and then make the output more compact
+      const tokensByPosition = _.groupBy(esResponse.tokens || [], (token) => token.position);
+      const simplifiedTokensByPosition = _.mapValues(tokensByPosition, (tokens) =>
+        tokens.map((token) => `${token.token} (${token.type})`)
+      );
+
+      // rebuild an object in doc.debug.expanded with the analysis results
+      if (simplifiedTokensByPosition) {
+        _.set(doc.debug.expanded, field, simplifiedTokensByPosition);
+      }
+    }
+
+    // Go through every field in the doc
+    traverse(doc, (value, keypath) => {
+      // look up the analyzed version of this in ES
+      promises.push(analyzeAndSetField(keypath, value));
+      // and also the dynamic .ngram version
+      promises.push(analyzeAndSetField(keypath + '.ngram', value));
+    });
+
+    // for each language on doc.name, simulate the unstored phrase.lang field
+    _.forEach(doc.name, (v, k) => {
+      promises.push(analyzeAndSetField('phrase.' + k, v));
+    });
+
+    return Promise.all(promises);
+  }
+
+  return (req, res, next) => {
+    if (req.clean.enableDebug && res.data) {
+      Promise.all(res.data.map(expandDocument)).then(() => next());
+    } else {
+      next();
+    }
+  };
+}
+
+module.exports = service;

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -325,6 +325,7 @@ function addRoutes(app, peliasConfig) {
       sanitizers.place.middleware(peliasConfig.api),
       middleware.requestLanguage,
       controllers.place(peliasConfig.api, esclient),
+      middleware.expandDocument(peliasConfig.api, esclient),
       middleware.accuracy(),
       middleware.localNamingConventions(),
       middleware.renamePlacenames(),


### PR DESCRIPTION
This change attempts to make it easier to understand what ES is doing with indexed documents.

when debug=true on a /place lookup, it runs every field in the ES document through the ES _analyze endpoint, and then reconstructs an object with the analyzed results. It's not super slow. 

I am hoping it will be helpful in understanding what our indexes are doing. Here's the street expansion for some random "1st street" in our data

![image](https://user-images.githubusercontent.com/445616/87203003-b3df5c00-c2cf-11ea-87ba-e33a6fa79092.png)

It's not spitting out the dynamic fields like phrase and ngram because ... I can't entirely figure out how to make ES spit those out