### PR TITLE
Intersection parsing and scoring improvements

### DIFF
--- a/query/text_parser_pelias.js
+++ b/query/text_parser_pelias.js
@@ -27,7 +27,9 @@ function addParsedVariablesToQueryVariables(clean, vs) {
   }
 
   // street name
-  if (!_.isEmpty(clean.parsed_text.street)) {
+  if (!_.isEmpty(clean.parsed_text.street) && _.isEmpty(clean.parsed_text.cross_street)) {
+    // do not query the `street` field if this is an intersection parse
+    // otherwise the order of the intersection in the data will determine what results come first
     vs.var('input:street', clean.parsed_text.street);
   }
 
@@ -37,7 +39,9 @@ function addParsedVariablesToQueryVariables(clean, vs) {
   }
 
   // postcode
-  if (!_.isEmpty(clean.parsed_text.postcode)) {
+  if (!_.isEmpty(clean.parsed_text.postcode) && _.isEmpty(clean.parsed_text.cross_street)) {
+    // do not score on `postcode` field if this is an intersection parse
+    // intersections cannot have postcodes, so this unfairly boosts non-intersection results that match the postcode
     vs.var('input:postcode', clean.parsed_text.postcode);
   }
 

--- a/sanitizer/_text_pelias_parser.js
+++ b/sanitizer/_text_pelias_parser.js
@@ -95,19 +95,6 @@ function parse (clean) {
   // '    VVVV NN SSSSSSS AAAAAA PPPPP      '
   let mask = solution.mask(t);
 
-  // special handling of intersection queries
-  // here we do not trust intersection parses which also contain another
-  // classification, such as a house number, postcode or admin field.
-  // this is to avoid errors for queries such as:
-  // eg 'air & space museum, washington, dc'
-  if (parsed_text.street && parsed_text.cross_street) {
-    if (Object.keys(parsed_text).length > 3) {
-      delete parsed_text.street;
-      delete parsed_text.cross_street;
-      mask = mask.replace(/S/g, ' ');
-    }
-  }
-
   // the entire input text as seen by the parser with any postcode classification(s) removed
   let body = t.span.body.split('')
     .map((c, i) => (mask[i] !== 'P') ? c : ' ')


### PR DESCRIPTION
This PR includes two changes that improve parsing and scoring for queries involving intersections:

## Remove special case handling of intersection + admin parses

Prior to [pelias-parser-1.53.0](https://github.com/pelias/api/pull/1463), parsing intersections with an administrative area (as might generally be sent to the search endpoint) was problematic, and we had some special-case logic to remove such parses. They now generally work well, so we can remove that code.

## Avoid querying on `street` or `postcode` fields with intersection parses

The first of these fields will only be populated with the _first_ of the two street names in the intersection parse. Likewise, the corresponding field in documents in Elasticsearch will be populated with whichever street comes first in the data. So, essentially its a coin flip (50-50 chance) as to whether or not the query and the intersection data match up. If they don't, then other results such as streets, addresses, or intersections that _do_ match the street field, but aren't the correct result, will come first.

Similarly, since intersection records in Pelias will not have a postalcode, we no longer score on postal code matches for intersection parses. Without this change, results that match a given postalcode but are not otherwise correct may be returned first.