### PR TITLE
Remove address parts scoring in autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -47,12 +47,6 @@ query.score( views.ngrams_last_token_only_multi( adminFields ), 'must' );
 query.score( views.admin_multi_match_first( adminFields ), 'must');
 query.score( views.admin_multi_match_last( adminFields ), 'must');
 
-// address components
-query.score( peliasQuery.view.address('housenumber') );
-query.score( peliasQuery.view.address('street') );
-query.score( peliasQuery.view.address('cross_street') );
-query.score( peliasQuery.view.address('postcode') );
-
 // scoring boost
 query.score( peliasQuery.view.focus( views.ngrams_strict ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -34,16 +34,6 @@ module.exports = {
       }],
       'should':[
         {
-          'match': {
-            'address_parts.street': {
-              'query': 'k road',
-              'cutoff_frequency': 0.01,
-              'boost': 1,
-              'analyzer': 'peliasQuery'
-            }
-          }
-        },
-        {
         'function_score': {
           'query': {
             'match_all': {}


### PR DESCRIPTION
This is an experimental PR that removes some sub-queries from our autocomplete queries. Specifically, all queries that target the `address_parts` fields (`housenumber`, `street`, `cross_street`, and `postalcode`) are removed.

While I'm not proposing we merge this PR as is, now, or possibly, ever, it's worth exploring the effects. After similar changes in the search endpoint (#1468) lead to much better intersection queries, its possible there are more benefits to be had.

I haven't fully tested this PR, but it shows improvements in some of our POI tests, particularly the query for [Wrigley Field](https://pelias.github.io/compare/#/v1/autocomplete?focus.point.lat=41.8855268583&focus.point.lon=-87.63152791895091&text=wrigley+field&debug=1)
![Screenshot_2020-07-13_16-58-19](https://user-images.githubusercontent.com/111716/87365056-12a01200-c52a-11ea-86d8-b12456a4713e.png)

Some _potential_ advantages of the changes in this PR could be:
- Any POI that shares all or part of its name with a street (probably many of them) will be returned higher in the results
- Because there are fewer query clauses, performance might improve: each returned document will have a simpler score calculation
- Because the `address_parts` queries use the output of the Pelias Parser, queries might be more resilient against bad parses and would also have less jitter if incomplete inputs have rapidly changing parses
- Records that do not have a name match, but _do_ match on postalcode, can no longer be scored higher than records that _do_ have a name match, but _do not_ match on postalcode (for example because the postalcode is not present in the data, a common occurrence)

Some _potential_ disadvantages of this PR:
- Address-specific analysis performed on the `address_parts.housenumber` or `address_parts.street` fields in Elasticsearch would no longer apply
- No boost will be applied to records matching a given postalcode. We know there are places where the same housenumber and street name exist in a single city, with only postalcode to differentiate

I did some _very_ initial testing of some address queries against the autocomplete endpoint, and there do not appear to be any significant changes. More testing is definitely required.