### PR TITLE
do not deduplicate different units at the same address

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -149,6 +149,7 @@ function isAddressDifferent(item1, item2){
   // else both have address info
   if( isPropertyDifferent(address1, address2, 'number') ){ return true; }
   if( isPropertyDifferent(address1, address2, 'street') ){ return true; }
+  if( isPropertyDifferent(address1, address2, 'unit') ){ return true; }
 
   // only compare zip if both records have it, otherwise just ignore and assume it's the same
   // since by this time we've already compared parent hierarchies
@@ -213,9 +214,9 @@ function isPropertyDifferent(item1, item2, prop ){
  * ...
  * 11: locality
  * 13: neighbourhood
- * 
+ *
  * note: Infinity is returned if layer not found in array, this is in
- * order to ensure that a high value is returned rather than the 
+ * order to ensure that a high value is returned rather than the
  * default '-1' value returned for misses when using findIndex().
  */
 function getPlaceTypeRank(item) {

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -335,6 +335,115 @@ module.exports.tests.dedupe = function(test, common) {
     t.false(isDifferent(item1, item2), 'should be the same');
     t.end();
   });
+
+  test('same address should be considered equal', function (t) {
+    var item1 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be different');
+    t.end();
+  });
+
+  test('same address and unit should be considered equal', function (t) {
+    var item1 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210',
+        'unit': 'A'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210',
+        'unit': 'A'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be different');
+    t.end();
+  });
+
+  test('same address but differing unit number should be considered different', function (t) {
+    var item1 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210',
+        'unit': 'A'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210',
+        'unit': 'B'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('same address but only one has unit number should be considered different', function (t) {
+    var item1 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210',
+        'unit': 'A'
+      }
+    };
+    var item2 = {
+      'name': {
+        'default': '1 Main St'
+      },
+      'address_parts': {
+        'number': '1',
+        'street': 'Main Street',
+        'zip': '90210'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
Multiple units at the same address are currently being deduplicated.

This can lead to situations where the response is showing much fewer results than was requested.
In particular this is not a great experience for `/v1/reverse` but also for the forward-geocoding APIs

One thing to consider before merging this:
- If the labels we generate don't include the unit number then the results will contain 10+ entries with the exact same label.

So the *pro* here is that we can show all the units in the building and the *con* is that these results will dominate results for queries near these multi-unit buildings/campuses.

I really wish there was something analogous to a `GROUP BY` in elasticsearch, but this is unfortunately not possible.

An alternative solution would be to increase the `querySize` variable from what it is now (usually double `?size`) so that more results are returned and then continue to consider these as duplicates 🤷‍♂️ 

Thoughts/Feels?