### PR TITLE
fix(nearby): empty categories filter returns no result

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -92,7 +92,7 @@ function generateQuery( clean ){
   }
 
   // categories
-  if (clean.categories) {
+  if (clean.categories && !_.isEmpty(clean.categories)) {
     vs.var('input:categories', clean.categories);
   }
 


### PR DESCRIPTION
When passing an empty `categories` parameter to the nearby endpoint, no results are returned.
The reason is that an empty array is passed as the filter:

```json
{
  "terms": {
    "category": []
  }
}
```

Expected :
All categories should be shown, and the `category` property should be returned, like in the other endpoints.