### PR TITLE
exposeInternalDebugTools: simplify code & cover additional hosts formats

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -1,6 +1,4 @@
 const _ = require('lodash');
-const querystring = require('querystring');
-
 const searchService = require('../service/search');
 const logger = require('pelias-logger').get('api');
 const logging = require( '../helper/logging' );
@@ -12,7 +10,7 @@ function isRequestTimeout(err) {
 }
 
 function setup( peliasConfig, esclient, query, should_execute ){
-  const apiConfig = (peliasConfig || {}).api || {};
+  const apiConfig = _.get(peliasConfig, 'api', {});
 
   function controller( req, res, next ){
     if (!should_execute(req, res)) {
@@ -56,25 +54,26 @@ function setup( peliasConfig, esclient, query, should_execute ){
       body: renderedQuery.body
     };
 
-    if (req.clean.enableElasticExplain) {
+    // support for the 'clean.enableElasticExplain' config flag
+    if (_.get(req, 'clean.enableElasticExplain') === true) {
       cmd.explain = true;
     }
 
+    // support for the 'clean.exposeInternalDebugTools' config flag
     let debugUrl;
-    if (req.clean.exposeInternalDebugTools && 
-      peliasConfig.esclient && 
-      Array.isArray(peliasConfig.esclient.hosts) && 
-      peliasConfig.esclient.hosts.length > 0) {
-      const firstEsHostEntry = peliasConfig.esclient.hosts[0];
-      const esHost = firstEsHostEntry.host ? 
-        `${firstEsHostEntry.protocol}://${firstEsHostEntry.host}:${firstEsHostEntry.port}` : firstEsHostEntry;
+    if (_.get(req, 'clean.exposeInternalDebugTools') === true) {
 
-       debugUrl = 
-        `${esHost}/${apiConfig.indexName}/_search?` +
-          querystring.stringify({
-            source_content_type: 'application/json',
-            source: JSON.stringify(cmd.body)
-          });
+      // select a random elasticsearch host to use for 'exposeInternalDebugTools' actions
+      const host = _.first(esclient.transport.connectionPool.getConnections(null, 1)).host;
+
+      // generate a URL which opens this query directly in elasticsearch
+      debugUrl = host.makeUrl({
+        path: `${apiConfig.indexName}/_search`,
+        query: {
+          source_content_type: 'application/json',
+          source: JSON.stringify(cmd.body)
+        }
+      });
     }
 
     debugLog.push(req, {


### PR DESCRIPTION
following on from https://github.com/pelias/api/pull/1465 this PR:
- cleans up the code a bit by moving the logic responsible for generating ES host URLs to the elasticsearch client lib
- covers more edge cases, such as where hosts is a `string` or where it's an `object` but one of the props (such as `port`) is not set.

I also made a couple of minor changes:
- use a cleaner syntax for `const apiConfig =`.
- use `=== true` to test that the flags are enabled and not just 'truthy', such as when the value is the string 'false'.