### PR TITLE
don't boost street if parse is ambiguous

### DIFF
--- a/sanitizer/_text_pelias_parser.js
+++ b/sanitizer/_text_pelias_parser.js
@@ -53,26 +53,31 @@ function _sanitize (raw, clean) {
 }
 
 function isAmbiguousStreetOrVenueParse(solutions){
-  if (!solutions) {
+  if (!solutions || solutions.length < 2) {
     return false;
   }
 
   const topTwoSolutions = _.take(solutions, 2);
   const streetOnlySolution = topTwoSolutions.find(solution => {
     return solution.pair &&
-      solution.pair.length === 1 &&
       solution.pair[0].classification.label === 'street';
   });
   const venueOnlySolution = topTwoSolutions.find(solution => {
     return solution.pair &&
-      solution.pair.length === 1 &&
       solution.pair[0].classification.label === 'venue';
   });
+
+  const restOfSolutionIsTheSame = 
+    topTwoSolutions[0].pair.length === topTwoSolutions[1].pair.length &&
+    _.every(_.zip(topTwoSolutions[0].pair.slice(1), topTwoSolutions[1].pair.slice(1)), ([p1, p2]) => 
+       p1.span.body === p2.span.body && p1.classification.label === p2.classification.label
+    );
 
   return (
     streetOnlySolution &&
     venueOnlySolution &&
-    streetOnlySolution.pair[0].span.body === venueOnlySolution.pair[0].span.body
+    streetOnlySolution.pair[0].span.body === venueOnlySolution.pair[0].span.body &&
+    restOfSolutionIsTheSame
   );
 }
 

--- a/test/unit/sanitizer/_text_pelias_parser.js
+++ b/test/unit/sanitizer/_text_pelias_parser.js
@@ -311,6 +311,14 @@ module.exports.tests.text_parser = function (test, common) {
   cases.push(['Air & Space Museum D', { subject: 'Air & Space Museum' }, true]);
   cases.push(['Air & Space Museum DC', { subject: 'Air & Space Museum' }, true]);
 
+  // ambiguous venue
+  cases.push(['mccarren park', {
+    subject: 'mccarren park',
+  }]);
+  cases.push(['wrigley field', {
+    subject: 'wrigley field',
+  }]);
+
   // admin areas
   cases.push(['N', { subject: 'N' }, true]);
   cases.push(['Ne', { subject: 'Ne' }, true]);


### PR DESCRIPTION
This is a redo of https://github.com/pelias/api/pull/1430 that's on the pelias repo rather than on mine, and fixed for place->venue rename

It fixes `mccarren park` and `wrigley field` as well as `mccarren park brooklyn` and `wrigley field chicago`

this was the original approach suggested by @missinglink for solving "wrigley field" - I don't see a great way to solve it in pelias/parser at the moment, though I'm open to suggestions.

doesn't change anything in a 1k query set.