### PR TITLE
Add support for custom sources in hierarchy

### DIFF
--- a/middleware/normalizeParentIds.js
+++ b/middleware/normalizeParentIds.js
@@ -32,7 +32,9 @@ function normalizeParentIds(place) {
   if (place) {
     placeTypes.forEach(function (placeType) {
       if (place[placeType] && place[placeType].length > 0 && place[placeType][0]) {
-        let source = 'whosonfirst';
+        // This is a solution for geonames hack.
+        // We can store in ES the source and defaulted to wof for backward compatibility.
+        let source = _.get(place, `${placeType}_source`, ['whosonfirst']);
 
         const placetype_ids = _.get(place, `${placeType}_gid`, [null]);
 
@@ -41,6 +43,8 @@ function normalizeParentIds(place) {
         // it's always WOF ids and hardcode to that
         if (place.source === 'geonames' && place.source_id === placetype_ids[0]) {
           source = place.source;
+        } else {
+          source = _.head(source);
         }
         
         place[`${placeType}_gid`] = [ makeNewId(source, placeType, placetype_ids[0]) ];

--- a/middleware/renamePlacenames.js
+++ b/middleware/renamePlacenames.js
@@ -36,6 +36,7 @@ function renameOneRecord(place) {
       place[prop] = place.parent[prop];
       place[prop + '_a'] = place.parent[prop + '_a'];
       place[prop + '_gid'] = place.parent[prop + '_id'];
+      place[prop + '_source'] = place.parent[prop + '_source'];
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^16.0.1",
-    "@mapbox/geojson-extent": "^0.3.1",
+    "@mapbox/geojson-extent": "^0.3.2",
     "async": "^3.0.1",
     "elasticsearch": "^16.0.0",
     "express": "^4.8.8",

--- a/test/unit/middleware/normalizeParentIds.js
+++ b/test/unit/middleware/normalizeParentIds.js
@@ -183,6 +183,63 @@ module.exports.tests.interface = function(test, common) {
     });
 
   });
+
+  test('Geonames ids do not override parent hierarchy with WOF equivalents', function(t) {
+
+    var input = {
+      data: [{
+        'parent': {
+          'country_id': [ '85633793' ],
+          'country': [ 'United States' ],
+          'country_a': [ 'USA' ],
+          'region_id': [ 'rel/161943' ],
+          'region': [ 'Mississippi' ],
+          'region_a': [ 'MS' ],
+          'region_source': [ 'osm' ]
+        },
+        'source': 'openaddresses',
+        'source_id': 'us/ms/hinds:992d7de085bf3da1',
+        'layer': 'address',
+        'country': [ 'United States' ],
+        'country_a': [ 'USA' ],
+        'country_gid': ['85633793'],
+        'region': [ 'Mississippi' ],
+        'region_a': [ 'MS' ],
+        'region_gid': [ 'rel/161943' ],
+        'region_source': [ 'osm' ]
+      }]
+    };
+
+    var expected = {
+      data: [{
+        'parent': {
+          'country_id': [ '85633793' ],
+          'country': [ 'United States' ],
+          'country_a': [ 'USA' ],
+          'region_id': [ 'rel/161943' ],
+          'region': [ 'Mississippi' ],
+          'region_a': [ 'MS' ],
+          'region_source': [ 'osm' ]
+        },
+        'source': 'openaddresses',
+        'source_id': 'us/ms/hinds:992d7de085bf3da1',
+        'layer': 'address',
+        'country': [ 'United States' ],
+        'country_gid': [ 'whosonfirst:country:85633793' ],
+        'country_a': [ 'USA' ],
+        'region': [ 'Mississippi' ],
+        'region_gid': [ 'osm:region:rel/161943' ],
+        'region_a': [ 'MS' ],
+        'region_source': [ 'osm' ]
+      }]
+    };
+
+    normalizer({}, input, function () {
+      t.deepEqual(input, expected);
+      t.end();
+    });
+
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
## Background

As you know, PIP is used as our hierarchy resolver and is compatible only with WOF. That's why we hard coded `whosonfirst` in our parent ids. But one day, spatial will supersede pip-service. 

With spatial, we will be able to use any provider :rocket:, that's why it will be essential to store the real source of our hierarchy.

## Comment

This PR is a no-op change and is fully backward compatible. It will be paired with another PR in pelias/model

Todo: 
- [x] some unit tests