### PR TITLE
add a "restrictIds" function to pelias for debugging

### DIFF
--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
+const restrictIds = require('./view/restrict_ids');
 
 //------------------------------
 // general-purpose search query
@@ -9,6 +10,10 @@ const addressUsingIdsQuery = new peliasQuery.layout.AddressesUsingIdsQuery();
 
 // scoring boost
 addressUsingIdsQuery.score( peliasQuery.view.focus_only_function( ) );
+// --------------------------------
+
+// debugging
+addressUsingIdsQuery.filter( restrictIds );
 // --------------------------------
 
 // non-scoring hard filters
@@ -194,6 +199,11 @@ function generateQuery( clean, res ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });
+  }
+
+  // restrictIds for debugging/explaining
+  if (clean.restrictIds) {
+    vs.var('restrictIds', clean.restrictIds);
   }
 
   return {

--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -16,7 +16,8 @@ var views = {
   phrase_first_tokens_only:   require('./view/phrase_first_tokens_only'),
   boost_exact_matches:        require('./view/boost_exact_matches'),
   max_character_count_layer_filter:   require('./view/max_character_count_layer_filter'),
-  focus_point_filter:         require('./view/focus_point_distance_filter')
+  focus_point_filter:         require('./view/focus_point_distance_filter'),
+  restrict_ids:                require('./view/restrict_ids')
 };
 
 // add abbrevations for the fields pelias/parser is able to detect.
@@ -46,6 +47,9 @@ query.score( views.ngrams_last_token_only_multi( adminFields ), 'must' );
 // admin components
 query.score( views.admin_multi_match_first( adminFields ), 'must');
 query.score( views.admin_multi_match_last( adminFields ), 'must');
+
+// debugging
+query.score( views.restrict_ids, 'must');
 
 // address components
 query.score( peliasQuery.view.address('housenumber') );
@@ -173,6 +177,11 @@ function generateQuery( clean ){
   // size
   if( clean.querySize ) {
     vs.var( 'size', clean.querySize );
+  }
+
+  // restrictIds for debugging/explaining
+  if (clean.restrictIds) {
+    vs.var('restrictIds', clean.restrictIds);
   }
 
   // run the address parser

--- a/query/search.js
+++ b/query/search.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const peliasQuery = require('pelias-query');
 const defaults = require('./search_defaults');
 const textParser = require('./text_parser');
+const restrictIds = require('./view/restrict_ids');
 
 //------------------------------
 // general-purpose search query
@@ -12,6 +13,10 @@ var fallbackQuery = new peliasQuery.layout.FallbackQuery();
 fallbackQuery.score( peliasQuery.view.focus_only_function( ) );
 fallbackQuery.score( peliasQuery.view.popularity_only_function );
 fallbackQuery.score( peliasQuery.view.population_only_function );
+// --------------------------------
+
+// debugging
+fallbackQuery.score( restrictIds, 'must');
 // --------------------------------
 
 // non-scoring hard filters
@@ -106,6 +111,11 @@ function generateQuery( clean ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });
+  }
+
+  // restrictIds for debugging/explaining
+  if (clean.restrictIds) {
+    vs.var('restrictIds', clean.restrictIds);
   }
 
   // run the address parser

--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -5,7 +5,10 @@ const textParser = require('./text_parser_pelias');
 const config = require('pelias-config').generate().api;
 
 var placeTypes = require('../helper/placeTypes');
-var views = { custom_boosts: require('./view/boost_sources_and_layers') };
+var views = { 
+  custom_boosts: require('./view/boost_sources_and_layers'),
+  restrict_ids: require('./view/restrict_ids')
+};
 
 // region_a is also an admin field which can be identified by
 // the pelias_parser. this functionality was inherited from the
@@ -19,6 +22,9 @@ var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
 query.score( peliasQuery.view.ngrams, 'must' );
+
+// debugging
+query.score( views.restrict_ids, 'must');
 
 // scoring boost
 const phrase_view = peliasQuery.view.leaf.match_phrase('main');
@@ -131,6 +137,11 @@ function generateQuery( clean ){
     vs.set({
       'boundary:gid': clean['boundary.gid']
     });
+  }
+
+  // restrictIds for debugging/explaining
+  if (clean.restrictIds) {
+    vs.var('restrictIds', clean.restrictIds);
   }
 
   // run the address parser

--- a/query/view/restrict_ids.js
+++ b/query/view/restrict_ids.js
@@ -1,0 +1,17 @@
+// Adds a doc id filter to a query
+// Used to easily understand why a specific document got the score that it did
+module.exports = function (vs) {
+  const restrictIds = vs.var('restrictIds').get();
+
+  // no valid restrictIds to use, fail now, don't render this view.
+  if (!restrictIds || restrictIds.length < 1) {
+    return null;
+  }
+
+  return {
+    ids: {
+      type: '_doc',
+      values: restrictIds,
+    },
+  };
+};

--- a/sanitizer/_debug.js
+++ b/sanitizer/_debug.js
@@ -50,11 +50,19 @@ function _setup(exposeInternalDebugTools) {
         }
       }
 
+      if (raw.restrictIds) {
+        if (exposeInternalDebugTools) {
+          clean.restrictIds = raw.restrictIds.split(',');
+        } else {
+          messages.errors.push('restrictIds not enabled, must enable exposeInternalDebugTools in pelias config');
+        }
+      }
+
       return messages;
     },
 
     expected: () => {
-      return [{ name: 'debug' }];
+      return [{ name: 'debug' }, { name: 'restrictIds' }];
     },
   };
 }

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -48,8 +48,9 @@ module.exports.tests.base_query = (test, common) => {
           AddressesUsingIdsQuery: MockQuery
         },
         view: views,
-        Vars: require('pelias-query').Vars
-      }
+        Vars: require('pelias-query').Vars,
+      },
+      './view/restrict_ids': 'restrictIds view'
     });
 
     const generatedQuery = generateQuery(clean, res);
@@ -68,6 +69,7 @@ module.exports.tests.base_query = (test, common) => {
     ]);
 
     t.deepEquals(generatedQuery.body.filter_functions, [
+      'restrictIds view',
       'boundary_country view',
       'boundary_circle view',
       'boundary_rect view',

--- a/test/unit/sanitizer/_debug.js
+++ b/test/unit/sanitizer/_debug.js
@@ -117,8 +117,36 @@ module.exports.tests.sanitize_debug = function(test, common) {
     t.end();
   });
 
+  test(`setting restrictIds should error if exposeInternalDebugTools is off`, function(t) {
+    const raw = { restrictIds: 'a:1,b:2', debug: '1' };
+    const clean = {};
+    const expected_clean = { enableDebug: true, exposeInternalDebugTools: false };
+
+    const messages = sanitizer.sanitize(raw, clean);
+
+    t.deepEquals(clean, expected_clean);
+    t.deepEqual(messages.errors, ['restrictIds not enabled, must enable exposeInternalDebugTools in pelias config'], 'no error returned');
+    t.deepEqual(messages.warnings, [], 'no warnings returned');
+    t.end();
+  });
+
+  test(`setting restrictIds should work if exposeInternalDebugTools is on`, function(t) {
+    const internalSanitizer = require('../../../sanitizer/_debug')(true);
+
+    const raw = { restrictIds: 'a:1,b:2', debug: '1' };
+    const clean = {};
+    const expected_clean = { restrictIds: ['a:1', 'b:2'], exposeInternalDebugTools: true, enableDebug: true };
+
+    const messages = internalSanitizer.sanitize(raw, clean);
+
+    t.deepEquals(clean, expected_clean);
+    t.deepEqual(messages.errors, [], 'no error returned');
+    t.deepEqual(messages.warnings, [], 'no warnings returned');
+    t.end();
+  });
+
   test('return an array of expected parameters in object form for validation', (t) => {
-    const expected = [{ name: 'debug' }];
+    const expected = [{ name: 'debug' }, { name: 'restrictIds' }];
     const validParameters = sanitizer.expected();
     t.deepEquals(validParameters, expected);
     t.end();


### PR DESCRIPTION
The purpose of this is that often I want to know "why did document A
score above document B" - pulling open the entire ES debugging response
(especially when nested in the pelias response) makes it super hard to
keep track of what document I'm looking at.

With this change, internal links are added that ask pelias to run the
same query, just restricted to that document. Such that two of these can
be opened side by side for relatively easy comparison of scoring.

This adds links that look like 
![image](https://user-images.githubusercontent.com/445616/89786017-451d3a80-dae9-11ea-92cd-bdde174220e0.png)
http://localhost:3100/v1/search?text=52%20ten%20eyck%20st%20apt%203b%20brooklyn%20ny&debug=explain&api_key=ge-1e618cf3d7bd023d&restrictIds=openstreetmap%3Astreet%3Apolyline%3A12087878

@orangejulius we talked last week about how to make it easier / more useful to see the explain output for one specific result, here's my attempt at that.

I'm open to moving the query down to pelias-query if need be.
