### PR TITLE
Use match_all for focus point queries

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -48,7 +48,7 @@ query.score( views.admin_multi_match_first( adminFields ), 'must');
 query.score( views.admin_multi_match_last( adminFields ), 'must');
 
 // scoring boost
-query.score( peliasQuery.view.focus( views.ngrams_strict ) );
+query.score( peliasQuery.view.focus( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.population( peliasQuery.view.leaf.match_all ) );
 query.score( views.custom_boosts( config.get('api.customBoosts') ) );

--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -24,7 +24,7 @@ query.score( peliasQuery.view.ngrams, 'must' );
 const phrase_view = peliasQuery.view.leaf.match_phrase('main');
 
 query.score( phrase_view );
-query.score( peliasQuery.view.focus( phrase_view ) );
+query.score( peliasQuery.view.focus( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.population( peliasQuery.view.leaf.match_all ) );
 

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -18,14 +18,7 @@ module.exports = {
       'should': [{
         'function_score': {
           'query': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'boost': 100,
-              'query': 'test',
-              'type': 'phrase',
-              'slop': 3
-            }
+            'match_all':  {}
           },
           'functions': [{
             'exp': {

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -18,14 +18,7 @@ module.exports = {
       'should': [{
         'function_score': {
           'query': {
-            'multi_match': {
-              'fields': ['name.default', 'name.en'],
-              'analyzer': 'peliasQuery',
-              'boost': 100,
-              'query': 'test',
-              'type': 'phrase',
-              'slop': 3
-            }
+            'match_all':  {}
           },
           'functions': [{
             'exp': {

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus.js
@@ -24,14 +24,7 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match_phrase': {
-              'phrase.default': {
-                'analyzer': 'peliasPhrase',
-                'boost': 1,
-                'slop': 2,
-                'query': 'test'
-              }
-            }
+            'match_all': {}
           },
           'functions': [{
             'exp': {

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
@@ -24,14 +24,7 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match_phrase': {
-              'phrase.default': {
-                'analyzer': 'peliasPhrase',
-                'boost': 1,
-                'slop': 2,
-                'query': 'test'
-              }
-            }
+            'match_all': {}
           },
           'functions': [{
             'exp': {

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
@@ -24,14 +24,7 @@ module.exports = {
       }, {
         'function_score': {
           'query': {
-            'match_phrase': {
-              'phrase.default': {
-                'analyzer': 'peliasPhrase',
-                'boost': 1,
-                'slop': 2,
-                'query': 'test'
-              }
-            }
+            'match_all': {}
           },
           'functions': [{
             'exp': {


### PR DESCRIPTION
We handle the `focus.point` parameter by using the [function_score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html) Elasticsearch query. `function_score` requires a function, and a query.

For historical reasons, we use a `match_phrase` query based on some of the input text for this query. However, there's really no reason to do so, we want the function score for distance from the focus point to apply to _all_ results, not just the subset of results that match the `match_phrase` query.

Usually, the subset of results that has the focus point scoring applied is almost 100% of all results, but not always, which can be very confusing.