### PR TITLE
Upgrade to pelias-query-11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^7.0.0",
     "pelias-parser": "1.53.0",
-    "pelias-query": "^10.0.0",
+    "pelias-query": "^11.0.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -52,6 +52,8 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:postcode:boost': 20,
   'address:postcode:cutoff_frequency': 0.01,
 
+  // multi match query views require 'type' to be specified
+  'multi_match:type': 'best_fields',
   // generic multi_match cutoff_frequency
   'multi_match:cutoff_frequency': 0.01,
 

--- a/test/unit/fixture/search_pelias_parser_full_address.js
+++ b/test/unit/fixture/search_pelias_parser_full_address.js
@@ -87,6 +87,7 @@ module.exports = {
         }
       }, {
         'multi_match': {
+            'type': 'best_fields',
             'fields': [
               'parent.country^1',
               'parent.region^1',
@@ -98,8 +99,7 @@ module.exports = {
               'parent.region_a^1'
             ],
             'query': 'new york ny US',
-            'analyzer': 'peliasAdmin',
-            'cutoff_frequency': 0.01
+            'analyzer': 'peliasAdmin'
         }
       }],
       'filter': [

--- a/test/unit/fixture/search_pelias_parser_partial_address.js
+++ b/test/unit/fixture/search_pelias_parser_partial_address.js
@@ -59,6 +59,7 @@ module.exports = {
         }
       }, {
         'multi_match': {
+            'type': 'best_fields',
             'fields': [
               'parent.country^1',
               'parent.region^1',
@@ -70,8 +71,7 @@ module.exports = {
               'parent.region_a^1'
             ],
             'query': 'new york',
-            'analyzer': 'peliasAdmin',
-            'cutoff_frequency': 0.01
+            'analyzer': 'peliasAdmin'
         }
       }],
       'filter': [

--- a/test/unit/fixture/search_pelias_parser_regions_address.js
+++ b/test/unit/fixture/search_pelias_parser_regions_address.js
@@ -77,6 +77,7 @@ module.exports = {
         }
       }, {
         'multi_match': {
+            'type': 'best_fields',
             'fields': [
               'parent.country^1',
               'parent.region^1',
@@ -88,8 +89,7 @@ module.exports = {
               'parent.region_a^1'
             ],
             'query': 'manhattan ny',
-            'analyzer': 'peliasAdmin',
-            'cutoff_frequency': 0.01
+            'analyzer': 'peliasAdmin'
         }
       }],
       'filter': [


### PR DESCRIPTION
This updates the tests and fixtures to account for minor breaking changes in the `multi_match` queries, as described in https://github.com/pelias/query/pull/125.