### PR TITLE
Correctly prune uninteresting unicode chars from structured endpoint input

### DIFF
--- a/sanitizer/_synthesize_analysis.js
+++ b/sanitizer/_synthesize_analysis.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const unicode = require('../helper/unicode');
 
 const fields = {
   'venue': 'query',
@@ -24,7 +25,12 @@ function _sanitize( raw, clean ){
   // collect all the valid values into a single object
   clean.parsed_text = Object.keys(fields).reduce( (o, f) => {
     if (_.isString(raw[f]) && !_.isEmpty(_.trim(raw[f]))) {
-      o[fields[f]] = normalizeWhitespaceToSingleSpace(raw[f]);
+      let text = unicode.normalize(raw[f]);
+      text = normalizeWhitespaceToSingleSpace(text);
+
+      if (!_.isEmpty(text)) {
+        o[fields[f]] = text;
+      }
     }
 
     return o;

--- a/test/unit/sanitizer/_synthesize_analysis.js
+++ b/test/unit/sanitizer/_synthesize_analysis.js
@@ -94,6 +94,23 @@ module.exports.tests.text_parser = function(test, common) {
 
   });
 
+  test('only uninteresting unicode characters should error', function(t) {
+    const only_uninteresting_unicode = String.fromCharCode(0x001A); // ASCII 'substitute' char
+    const raw = { address: only_uninteresting_unicode };
+
+    const clean = {};
+
+    const expected_clean = { parsed_text: {} };
+
+    const messages = sanitizer().sanitize(raw, clean);
+
+    t.deepEquals(clean, expected_clean);
+    t.deepEquals(messages.errors, ['at least one of the following fields is required: ' +
+      'venue, address, neighbourhood, borough, locality, county, region, postalcode, country'], 'no errors');
+    t.deepEquals(messages.warnings, [], 'no warnings');
+    t.end();
+  });
+
   test('postalcode-only parsed_text should return error', function(t) {
     const raw = {
       postalcode: 'postalcode value'


### PR DESCRIPTION
As in https://github.com/pelias/api/pull/1373/https://github.com/pelias/api/pull/1377, it's very possible for "uninteresting" Unicode characters to sneak into inputs in the structured endpoint.

These characters can essentially be ignored, but they make simple tests like `string.length` or even `_.isEmpty(string)` return convincing values, even if the string is effectively empty.

This change adds some more simple checks for such cases in the structured endpoint, which can prevent very invalid inputs from causing 500 errors.