### PR TITLE
Upgrade pelias-labels to 1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",
     "pelias-config": "^4.0.0",
-    "pelias-labels": "^1.8.0",
+    "pelias-labels": "^1.13.0",
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^7.0.0",


### PR DESCRIPTION
This includes improved labels for NYC as described in https://github.com/pelias/labels/pull/39