### PR TITLE
[dedup] Remove accents in `normalizeString`

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const placeTypes = require('./placeTypes');
 const canonicalLayers = require('../helper/type_mapping').getCanonicalLayers();
 const field = require('../helper/fieldValue');
+const removeAccents = require('remove-accents');
 
 // only consider these layers as synonymous for deduplication purposes.
 // when performing inter-layer deduping, layers coming earlier in this list take
@@ -227,7 +228,7 @@ function getPlaceTypeRank(item) {
  * lowercase characters and remove some punctuation
  */
 function normalizeString(str){
-  return str.toLowerCase().split(/[ ,-]+/).join(' ');
+  return removeAccents(str.toLowerCase().split(/[ ,-]+/).join(' '));
 }
 
 module.exports.isDifferent = isDifferent;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",
+    "remove-accents": "^0.4.2",
     "require-all": "^3.0.0",
     "retry": "^0.12.0",
     "stable": "^0.1.8",

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -129,6 +129,38 @@ module.exports.tests.dedupe = function(test, common) {
       t.end();
     });
   });
+
+  test('dedup with accents', function (t) {
+    var req = {
+      clean: {
+        text: 'Forêt du Gâvre',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': 'Forêt du Gâvre' },
+          'source': 'osm',
+          'source_id': 'node/1692538115',
+          'layer': 'venue'
+        },
+        {
+          'name': { 'default': 'Foret du Gavre' },
+          'source': 'geonames',
+          'source_id': '3016473',
+          'layer': 'venue'
+        }
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].source, 'osm', 'osm result won');
+      t.end();
+    });
+  });
 };
 
 


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
When I'm searching [`Forêt du Gâvre`](https://pelias.github.io/compare/#/v1/search?text=For%C3%AAt+du+G%C3%A2vre), `Forêt du Gâvre` is present twice, the first one with correct accents `0)` and the second with a missing accent `5)`.

```
0) Forêt du Gâvre, Le Gâvre, France
1) Forêt Domaniale du Gâvre, Le Gâvre, France
2) Maison de la Forêt, Le Gâvre, France
3) Camping de la Forêt, Le Gâvre, France
4) La forêt aux livres, Le Gâvre, France
5) Forêt du Gavre, Le Gâvre, France
6) Petite-Forêt, France
7) L'Auberge de la Forêt, Le Gâvre, France
8) Rue de la Forêt, Le Gâvre, France
9) L'Orée de la Foret, Le Gâvre, France
``` 

---
#### Here's what actually got changed :clap:

With this PR, only the first Forêt du Gâvre is present.

```
Forêt du Gâvre, Le Gâvre, France
Forêt domaniale du Gâvre, Le Gâvre, France
Maison de la Forêt, Le Gâvre, France
Camping de la Forêt, Le Gâvre, France
La forêt aux livres, Le Gâvre, France
L'Auberge de la Forêt, Le Gâvre, France
Rue de la Forêt, Le Gâvre, France
L'Orée de la Foret, Le Gâvre, France
Lotissement l'Orée de la Forêt, Le Gâvre, France
Petite-Forêt, France
```
