### PR TITLE
Add support to lang in `ngrams_last_token_only_multi`

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -4,6 +4,7 @@ const defaults = require('./autocomplete_defaults');
 const textParser = require('./text_parser_pelias');
 const config = require('pelias-config').generate();
 const placeTypes = require('../helper/placeTypes');
+const toSingleField = require('./view/helper').toSingleField;
 
 // additional views (these may be merged in to pelias/query at a later date)
 var views = {
@@ -32,7 +33,7 @@ var adminFields = placeTypes.concat(['locality_a', 'region_a', 'country_a']);
 // the name of the field to use.
 // this functionality is not enabled unless the 'input:add_name_to_multimatch'
 // variable is set to a non-empty value at query-time.
-adminFields = adminFields.concat(['add_name_to_multimatch']);
+adminFields = adminFields.concat(['add_name_to_multimatch', 'add_name_lang_to_multimatch']);
 
 //------------------------------
 // autocomplete query
@@ -185,6 +186,9 @@ function generateQuery( clean ){
   // Search in the user lang
   if(clean.lang && _.isString(clean.lang.iso6391)) {
     vs.var('lang', clean.lang.iso6391);
+
+    const field = toSingleField(vs.var('admin:add_name_lang_to_multimatch:field').get(), clean.lang.iso6391);
+    vs.var('admin:add_name_lang_to_multimatch:field', field);
   }
 
   return {

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -132,6 +132,8 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   // are unsure if the tokens represent admin or name components.
   'admin:add_name_to_multimatch:field': 'name.default',
   'admin:add_name_to_multimatch:boost': 1.5,
+  'admin:add_name_lang_to_multimatch:field': 'name.en',
+  'admin:add_name_lang_to_multimatch:boost': 1.5,
 
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',

--- a/query/view/helper.js
+++ b/query/view/helper.js
@@ -1,8 +1,12 @@
 function toMultiFields(baseField, suffix) {
+  return [baseField, toSingleField(baseField, suffix)];
+}
+
+function toSingleField(baseField, suffix) {
   // baseField looks like phrase.default or name.default; suffix looks like en, fr....
   const parts = baseField.split('.');
   parts[parts.length - 1] = suffix;
-  return [baseField, parts.join('.')];
+  return parts.join('.');
 }
 
-module.exports = { toMultiFields };
+module.exports = { toMultiFields, toSingleField };

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -28,7 +28,8 @@ module.exports = {
                 'parent.locality_a.ngram^1',
                 'parent.region_a.ngram^1',
                 'parent.country_a.ngram^1',
-                'name.default^1.5'
+                'name.default^1.5',
+                'name.en^1.5'
               ],
               'query': 'three',
               'analyzer': 'peliasQuery',

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -27,7 +27,8 @@ module.exports = {
               'parent.locality_a.ngram^1',
               'parent.region_a.ngram^1',
               'parent.country_a.ngram^1',
-              'name.default^1.5'
+              'name.default^1.5',
+              'name.en^1.5'
             ],
             'query': 'three',
             'analyzer': 'peliasAdmin',

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -25,7 +25,8 @@ module.exports = {
             'parent.locality_a.ngram^1',
             'parent.region_a.ngram^1',
             'parent.country_a.ngram^1',
-            'name.default^1.5'
+            'name.default^1.5',
+            'name.en^1.5'
           ],
           'query': 'laird',
           'analyzer': 'peliasAdmin',


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
@bboure found an issue in autocomplete multi-lang field, [Edo Tokyo Museum](https://pelias.github.io/compare/#/v1/autocomplete?layers=venue&debug=1&text=Edo+Tokyo+Museum) is not returned see https://github.com/pelias/api/issues/1296#issuecomment-703679827 

---
#### Here's what actually got changed :clap:

Since #1300 we are using two field for autocomplete search, `name.default` and `name.{lang}`.  `name.{lang}` was missing in the `ngrams_last_token_only_multi` query

---
#### Here's how others can test the changes :eyes:

[Edo Tokyo Museum](https://pelias.github.io/compare/#/v1/autocomplete?layers=venue&debug=1&text=Edo+Tokyo+Museum) should now work