### PR TITLE
feat(override): allow addendum data to override imported place data

### DIFF
--- a/middleware/applyOverrides.js
+++ b/middleware/applyOverrides.js
@@ -21,7 +21,7 @@ function applyOverrides(req, res, next) {
  * Rename the fields in one record
  */
 function overrideOneRecord(place) {
-  if (place.addendum && place.addendum.override) {
+  if (_.has(place, 'addendum.override')) {
     try {
       const overrideData = codec.decode(place.addendum.override);
       place = _.merge(place, overrideData);

--- a/middleware/applyOverrides.js
+++ b/middleware/applyOverrides.js
@@ -1,0 +1,28 @@
+const _ = require('lodash');
+
+function setup() {
+  return applyOverrides;
+}
+
+function applyOverrides(req, res, next) {
+  // do nothing if no result data set
+  if (!res || !res.data) {
+    return next();
+  }
+
+  res.data = res.data.map(overrideOneRecord);
+
+  next();
+}
+
+/*
+ * Rename the fields in one record
+ */
+function overrideOneRecord(place) {
+  if (place.addendum && place.addendum.override) {
+    place = _.merge(place, place.addendum.override);
+  }
+  return place;
+}
+
+module.exports = setup;

--- a/middleware/applyOverrides.js
+++ b/middleware/applyOverrides.js
@@ -1,4 +1,6 @@
 const _ = require('lodash');
+const logger = require('pelias-logger').get('api');
+const codec = require('pelias-model').codec;
 
 function setup() {
   return applyOverrides;
@@ -20,7 +22,18 @@ function applyOverrides(req, res, next) {
  */
 function overrideOneRecord(place) {
   if (place.addendum && place.addendum.override) {
-    place = _.merge(place, place.addendum.override);
+    try {
+      const overrideData = codec.decode(place.addendum.override);
+      place = _.merge(place, overrideData);
+    } catch (err) {
+      logger.error('Invalid addendum override json string:', place.addendum);
+    }
+
+    delete place.addendum.override;
+
+    if (_.isEmpty(place.addendum)) {
+      delete place.addendum;
+    }
   }
   return place;
 }

--- a/routes/v1.js
+++ b/routes/v1.js
@@ -229,6 +229,7 @@ function addRoutes(app, peliasConfig) {
       middleware.confidenceScoreFallback(),
       middleware.interpolate(interpolationService, interpolationShouldExecute, interpolationConfiguration),
       middleware.sortResponseData(sorting, predicates.hasAdminOnlyResults),
+      middleware.applyOverrides(),
       middleware.dedupe(),
       middleware.accuracy(),
       middleware.localNamingConventions(),
@@ -251,6 +252,7 @@ function addRoutes(app, peliasConfig) {
       middleware.confidenceScore(peliasConfig.api),
       middleware.confidenceScoreFallback(),
       middleware.interpolate(interpolationService, interpolationShouldExecute, interpolationConfiguration),
+      middleware.applyOverrides(),
       middleware.dedupe(),
       middleware.accuracy(),
       middleware.localNamingConventions(),
@@ -269,6 +271,7 @@ function addRoutes(app, peliasConfig) {
       controllers.search(peliasConfig, esclient, queries.autocomplete, not(hasResponseDataOrRequestErrors)),
       middleware.distance('focus.point.'),
       middleware.confidenceScore(peliasConfig.api),
+      middleware.applyOverrides(),
       middleware.dedupe(),
       middleware.accuracy(),
       middleware.localNamingConventions(),
@@ -290,6 +293,7 @@ function addRoutes(app, peliasConfig) {
       // reverse confidence scoring depends on distance from origin
       //  so it must be calculated first
       middleware.confidenceScoreReverse(),
+      middleware.applyOverrides(),
       middleware.dedupe(),
       middleware.accuracy(),
       middleware.localNamingConventions(),
@@ -310,6 +314,7 @@ function addRoutes(app, peliasConfig) {
       // reverse confidence scoring depends on distance from origin
       //  so it must be calculated first
       middleware.confidenceScoreReverse(),
+      middleware.applyOverrides(),
       middleware.dedupe(),
       middleware.accuracy(),
       middleware.localNamingConventions(),

--- a/test/unit/middleware/applyOverrides.js
+++ b/test/unit/middleware/applyOverrides.js
@@ -1,0 +1,114 @@
+const applyOverrides = require('../../../middleware/applyOverrides')();
+const codec = require('pelias-model').codec;
+
+const proxyquire = require('proxyquire').noCallThru();
+
+module.exports.tests = {};
+
+module.exports.tests.applyOverrides = function(test, common) {
+  test('valid override data with no other addendum', function(t) {
+    const res = {
+      data: [
+        {
+            name: 'aliased name to throw out',
+            addendum: {
+                override: codec.encode({ name: 'Override Name' }),
+            }
+        }
+      ]
+    };
+
+    const expected = {
+      data: [
+        {
+          name: 'Override Name'
+        }
+      ]
+    };
+
+    applyOverrides({}, res, function () {
+      t.deepEquals(res, expected, 'valid override data');
+      t.end();
+    });
+  });
+
+  test('valid override data with other addendum data', function(t) {
+    const res = {
+      data: [
+        {
+            name: 'aliased name to throw out',
+            addendum: {
+                override: codec.encode({ name: 'Override Name' }),
+                other_data: 1234
+            }
+        }
+      ]
+    };
+
+    const expected = {
+      data: [
+        {
+          name: 'Override Name',
+          addendum: {
+              other_data: 1234
+          }
+        }
+      ]
+    };
+
+    applyOverrides({}, res, function () {
+      t.deepEquals(res, expected, 'valid override data');
+      t.end();
+    });
+  });
+
+  test('invalid override data', function(t) {
+    const res = {
+      data: [
+        {
+            name: 'aliased name to throw out',
+            addendum: {
+                override: 'garbage json'
+            }
+        }
+      ]
+    };
+
+    const expected = {
+      data: [
+        {
+          name: 'aliased name to throw out'
+        }
+      ]
+    };
+
+    const proxiedApplyOverrides = proxyquire('../../../middleware/applyOverrides', {
+        'pelias-logger': {
+          get: () => {
+            return {
+              error: (msg1, msg2) => {
+                t.equals(msg1, 'Invalid addendum override json string:');
+                t.deepEquals(msg2, { override: 'garbage json' });
+              }
+            };
+  
+          }
+        }
+      })();
+
+      proxiedApplyOverrides({}, res, function () {
+      t.deepEquals(res, expected, 'invalid override data');
+      t.end();
+    });
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('[middleware] applyOverrides: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/middleware/parseBBox.js
+++ b/test/unit/middleware/parseBBox.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire').noCallThru();
 
 module.exports.tests = {};
 
-module.exports.tests.computeDistance = function(test, common) {
+module.exports.tests.parseBBox = function(test, common) {
   test('valid bounding_box json', function(t) {
     var res = {
       data: [

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -46,6 +46,7 @@ var tests = [
   require('./helper/unicode'),
   require('./middleware/access_log'),
   require('./middleware/accuracy'),
+  require('./middleware/applyOverrides'),
   require('./middleware/assignLabels'),
   require('./middleware/confidenceScore'),
   require('./middleware/confidenceScoreFallback'),


### PR DESCRIPTION
This is part of a workaround for the issues we've seen in pelias with scoring on records that have multiple names. The issue is that elasticsearch calculates the term frequency over all the names, so a place like ["Sutter St Cafe", "The Sutter St Cafe"] is more likely to match "Sutter St" than a record with just the name ["Sutter St"]
    
This change allows us to create multiple records, one per name, but to specify in the addendum data what the canonical name (or any other data) is, so that we can generate lots of aliases for records and not worry too much about the term frequency scoring issues, such as adding "Restaurant" to every restaurant venue in our data, or aliasing "subway" and "sub way".

It's hard to say what the impact of this is - in our pelias set up we are generating aliases outside of pelias trunk, on commercial data. Without this change, creating aliases (like turning all "AA" tokens into "A A", generating compound/decompound mappings for words like coffeeshop<->coffee shop) we were seeing some regressions when only creating one record with multiple names, due to repeated tokens. With this change in approach, we are not seeing any regressions.

I would like to get this change into pelias master (rather than applying this hack at our application server level) so that I can continue performing side-by-side evaluations at the pelias api level on new indexes and accurately seeing what we are trying to show to users.
    
I am open to other approaches to this.