### PR TITLE
add github actions workflow to replace travis

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,41 @@
+name: Continuous Integration
+on: push
+jobs:
+  unit-tests:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+          - macos-10.15
+        node-version:
+          - 10.x
+          - 12.x
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Install node.js ${{ matrix.node-version }}'
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '${{ matrix.node-version }}'
+      - name: Run unit tests
+        run: |
+          npm install
+          npm run travis
+  npm-publish:
+    needs: unit-tests
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node.js 12.x
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: 12.x
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >
+          curl
+          "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh"
+          | bash -


### PR DESCRIPTION
This PR is a first attempt at replacing Travis-CI with Github Actions.
We've had loads of issues over the years with Travis so we'd like to migrate over to using Actions.

The major benefit is that the configs can be edited by anyone and the reports viewed by anyone.
It's also free for open-source projects which is nice.

I've attempted to do a 'no-op' refactor of the `.travis.yml` file although I'm open to changing anything.
The long-term plan is to live with this for a while on an active repo and once we're happy with it we can roll it out across the other repos.

cc/ @pelias/contributors 

[edit] ermahgerd it's so fast!