### PR TITLE
add static serving of files in frontend/

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -363,7 +363,8 @@ function addRoutes(app, peliasConfig) {
   app.get ( base + 'nearby',               routers.nearby );
 
   if (peliasConfig.api.exposeInternalDebugTools) {
-    app.use ( '/frontend',                   express.static('node_modules/pelias-compare/dist-api/'));
+    app.use ( '/frontend',                 express.static('frontend'));
+    app.use ( '/frontend',                 express.static('node_modules/pelias-compare/dist-api/'));
   }
 }
 


### PR DESCRIPTION
The idea of this change is to make it easy for developers to add their own custom on-server debug pages to pelias. A major use cases for this in my opinion is to be able to include a page with server build information and another with index debug information. A developer can generate pages and stick them in frontend as part of their build/deploy process without needing to get their changes integrated into mainline pelias.

We discussed this change as a replacement for an earlier PR that included server build info in the build process.