### PR TITLE
autocomplete: use should instead of must for admin matching

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -45,8 +45,8 @@ query.score( views.phrase_first_tokens_only, 'must' );
 query.score( views.ngrams_last_token_only_multi( adminFields ), 'must' );
 
 // admin components
-query.score( views.admin_multi_match_first( adminFields ), 'must');
-query.score( views.admin_multi_match_last( adminFields ), 'must');
+query.score( views.admin_multi_match_first( adminFields ), 'should');
+query.score( views.admin_multi_match_last( adminFields ), 'should');
 
 // scoring boost
 query.score( peliasQuery.view.focus( peliasQuery.view.leaf.match_all ) );

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -11,7 +11,9 @@ module.exports = {
             'boost': 1,
             'query': 'one two'
           }
-        },
+        }
+      ],
+      'should': [
         {
           'multi_match': {
             'fields': [
@@ -34,9 +36,7 @@ module.exports = {
             'analyzer': 'peliasAdmin',
             'type': 'cross_fields'
           }
-        }
-      ],
-      'should': [
+        },
         {
           'function_score': {
             'query': {

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -10,7 +10,8 @@ module.exports = {
           'type': 'phrase',
           'slop': 3
         }
-      }, {
+      }],
+      'should':[{
         'multi_match': {
           'fields': [
             'parent.country.ngram^1',
@@ -32,9 +33,7 @@ module.exports = {
           'analyzer': 'peliasAdmin',
           'type': 'cross_fields'
         }
-      }],
-      'should':[
-        {
+      },{
         'function_score': {
           'query': {
             'match_all': {}


### PR DESCRIPTION
Hi there,

## Background

Currently when we do an autocomplete including subject + admin part in a language different than English, we receive no results. The example I often use is [`Parijs, Frankrijk`](https://pelias.github.io/compare/#/v1/autocomplete?lang=nl&text=Parijs%2C+Frankrijk) in Dutch.

## First try

After the fail of https://github.com/pelias/whosonfirst/pull/492, I was looking for an alternative to get a result for [`Parijs, Frankrijk`](https://pelias.github.io/compare/#/v1/autocomplete?lang=nl&text=Parijs%2C+Frankrijk) in Dutch.

In ES, pelias documents contain this information:
- item name in many languages (e.g. `name.fr = [Paris, Ville-Lumière]`, `name.nl = Parijs`...)
- item admin hierarchy (e.g `parent.country = France`, `parent.macroregion = Île-De-France`...)

The idea here was to use two ES  queries for one autocomplete with this workflow:
1. Parse the input with `pelias-parser`
2. If the admin part is not empty
    1. Create a ES query that will return all documents where name = Frankrijk or name.nl = Frankrijk with a coarse layer 
    2. Generate a `should` clause where `parent.*_id = id`
3. Use the current autocomplete query and add the new `should` clause.

This caused side effects (-3% in acceptance tests...), so I abandoned this solution... :disappointed: 

## Second try

I moved the scoring of admin components from `must` clause to `should`. This solution probably won't solve all issues, but it's a good start.

It works just fine with `Parijs, Frankrijk` and improved some queries

```diff
275,276c275,290
<   ✘ [1] "/v1/autocomplete?text=412 Saint Patrick St, donaldsonville, la": no results returned
<   ✘ [2] "/v1/autocomplete?text=412 St Patrick St, donaldsonville, la": no results returned
---
>   ✘ [1] "/v1/autocomplete?text=412 Saint Patrick St, donaldsonville, la": score 3 out of 5
>   diff:
>     street
>       expected: Saint Patrick Street
>       actual:   Patrick St
>     locality
>       expected: Donaldsonville
>       actual:   Minden
>   ✘ [2] "/v1/autocomplete?text=412 St Patrick St, donaldsonville, la": score 3 out of 5
>   diff:
>     street
>       expected: Saint Patrick Street
>       actual:   Patrick St
>     locality
>       expected: Donaldsonville
>       actual:   Minden
386c400,402
<   ✘ [7-2] "/v1/autocomplete?lang=ru&text=8 Марта, Белоруссия": no results returned
---
>   ✘ [7-2] "/v1/autocomplete?lang=ru&text=8 Марта, Белоруссия": score 3 out of 4
>   diff:
>     priorityThresh is 1 but found at position 4
407c423,431
<   ✘ [5] "/v1/autocomplete?sources=osm&layers=street&text=dionysiou areopagitou, athens": no results returned
---
>   ✘ [5] "/v1/autocomplete?sources=osm&layers=street&text=dionysiou areopagitou, athens": score 3 out of 6
>   diff:
>     name
>       expected: Dionysiou Areopagitou
>       actual:   Dionysiou
>     street
>       expected: Dionysiou Areopagitou
>       actual:   Dionysiou
>     'Dionysiou, Greece' is not close enough: distance is 203847m but should be under 500m
```

Results for `Parijs, Frankrijk`. Since this is autocomplete, I think it's not strange to have results that don't match 100% the name :thinking: 

```
Parijs, Frankrijk
Parijs, Amsterdam, Nederland
Stad Parijs, Hulten, Nederland
Stadspalazzo Parijs, Apeldoorn, Nederland
Parijs, ON, Canada
Parijs, Zuid-Afrika
Parijs, België
Parijs, Zambia
Parijs, Lochristi, België
Goed te Parijs, Deinze, België
```

related #1296