### PR TITLE
assignLabels: improve duplicate label handling

### DIFF
--- a/middleware/assignLabels.js
+++ b/middleware/assignLabels.js
@@ -15,9 +15,21 @@ function assignLabel(req, res, next, labelGenerator) {
     return next();
   }
 
+  const dedupLabel = {};
+
   res.data.forEach(function (result) {
     result.label = labelGenerator(result);
+    dedupLabel[result.label] = dedupLabel[result.label] || [];
+    dedupLabel[result.label].push(result);
   });
+
+  Object.values(dedupLabel)
+    .filter(results => results.length > 1)
+    .forEach(results => {
+      results.forEach(result => {
+        result.label = labelGenerator(result, {withOptional: true});
+      });
+    });
 
   next();
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",
     "pelias-config": "^4.0.0",
-    "pelias-labels": "^1.13.0",
+    "pelias-labels": "pelias/labels#joxit/feat/with-optional",
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^7.0.0",

--- a/test/unit/middleware/assignLabels.js
+++ b/test/unit/middleware/assignLabels.js
@@ -131,6 +131,61 @@ module.exports.tests.serialization = function(test, common) {
 
   });
 
+  test('support with optionnal', function(t) {
+    let withoutOptionCalls = 0;
+    let withOptionCalls = 0;
+    var assignLabels = proxyquire('../../../middleware/assignLabels', {
+      'pelias-labels': function(result, options) {
+        if(!options) {
+          withoutOptionCalls++;
+          return 'lab.el';
+        } else if (options.withOptional && result.id === 1) {
+          withOptionCalls++;
+          return 'lab.el, region 1';
+        } else if (options.withOptional && result.id === 2) {
+          withOptionCalls++;
+          return 'lab.el, region 2';
+        }
+      }
+    })();
+    var res = {
+      data: [{
+        id: 1,
+        name: {
+          default: ['lab.el']
+        }
+      },{
+        id: 2,
+        name: {
+          default: ['lab.el']
+        }
+      }]
+    };
+
+    var expected = {
+      data: [{
+        id: 1,
+        name: {
+          default: ['lab.el']
+        },
+        label: 'lab.el, region 1'
+      },{
+        id: 2,
+        name: {
+          default: ['lab.el']
+        },
+        label: 'lab.el, region 2'
+      }]
+    };
+
+    assignLabels({}, res, function () {
+      t.deepEqual(res, expected);
+      t.deepEqual(withOptionCalls, 2);
+      t.deepEqual(withoutOptionCalls, 2);
+      t.end();
+    });
+  });
+
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
This is the API part of pelias/labels#42, this will improve the user experience and developer experience. 

Sometimes, we can see several identical labels, this is very annoying because we can not distinguish them. This was a long time issue for us @jawg.

<img width="286" alt="Screenshot 2021-02-05 at 13 08 33" src="https://user-images.githubusercontent.com/738069/106971333-97e36080-67b3-11eb-8313-8bcc31c5d63c.png">

Our first response was, this is a integration issue, so update the name when you need to... So we implemented this in our demonstrator to say "hey, it's possible to do it on integration".

![image](https://user-images.githubusercontent.com/5153882/106968228-b2ccbb00-6748-11eb-8b81-24a5ae3e6ffd.png)

Now I realize it's awful for the developer experience... I blame myself terribly for not having thought of putting it in the API earlier... Especially since it's not complicated :sob: 

So with this PR, Bagneux will return:
```
Bagneux, Hauts-de-Seine, France
Bagneux, Deux-Sèvres, France
Bagneux, Indre, France
Bagneux, Marne, France
Bagneux, Allier, France
Bagneux, Meurthe-et-Moselle, France
Bagneux, Aisne, France
```

And Sao Paulo will return:
```
São Paulo, SP, Brazil
São Paulo, AM, Brazil
São Paulo, MT, Brazil
São Paulo, MA, Brazil
São Paulo, BA, Brazil
São Paulo, ES, Brazil
São Paulo, PA, Brazil
Se, São Paulo, Brazil
Frei Paulo, Brazil
Sao Paulo, Brazil
```

Well known localities are still unchanged, for example Paris:
```
Paris, France
Paris, TX, USA
Paris, ON, Canada
Paris, TN, USA
Swainsboro, GA, USA
Paris Township, OH, USA
Paris Township, IL, USA
Paris Township, OH, USA
Paris, ME, USA
Paris, IA, USA
```

TODO: Change package.json before merge

related: pelias/labels#41 pelias/labels#42