### PR TITLE
Prefer records with postal code regardless of source

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -113,6 +113,9 @@ function isPreferred(existingHit, candidateHit) {
   // https://github.com/pelias/api/issues/872
   if( !_.has(existingHit, 'address_parts.zip') &&
        _.has(candidateHit, 'address_parts.zip') ){ return true; }
+  // if the existing hit HAS a postcode, and this candidate does NOT, keep the existing hit
+  if( _.has(existingHit, 'address_parts.zip') &&
+       !_.has(candidateHit, 'address_parts.zip') ){ return false; }
 
   // prefer non-canonical sources over canonical ones
   if( !_.includes(canonical_sources, candidateHit.source) &&

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -396,6 +396,42 @@ module.exports.tests.priority = function(test, common) {
     });
   });
 
+  test('osm with zip takes priority over openaddresses without zip, regardless of order of results', function (t) {
+    var req = {
+      clean: {
+        text: '100 Main St',
+        size: 100
+      }
+    };
+    var res = {
+      data:  [
+        {
+          'name': { 'default': '100 Main St' },
+          'source': 'openstreetmap',
+          'source_id': '654321',
+          'layer': 'address',
+          'address_parts': {
+            'zip': '54321'
+          }
+        },
+        {
+          'name': { 'default': '100 Main St' },
+          'source': 'openaddresses',
+          'source_id': '123456',
+          'layer': 'address',
+          'address_parts': {}
+        },
+      ]
+    };
+
+    var expectedCount = 1;
+    dedupe(req, res, function () {
+      t.equal(res.data.length, expectedCount, 'results have fewer items than before');
+      t.deepEqual(res.data[0].source_id, '654321', 'openstreetmap result with zip won');
+      t.end();
+    });
+  });
+
   test('works with name aliases', function (t) {
     var req = {
       clean: {


### PR DESCRIPTION
While testing changes related to improved street address normalization (https://github.com/pelias/openaddresses/pull/477),
I noticed a failure where a record from OA without a postal code was replacing a record from OSM with a postal codes.

It turns out our check for postal codes when deduping was not strong enough:
- in addition to preferring a candidate when only it has a postal code
- we must also explicitly prefer the existing hit when only _it_ has a postal code

Otherwise, a record from OA without a postal code that comes _after_ an OA record _with_ a postalcode (as returned from Elasticsearch), can end up replacing the record with the postalcode.

This happens because the postal code preference check did not explicitly return false (saying the existing hit is better), allowing the data source check (which prefers OA over OSM) to replace the OSM record.

This PR makes the postal code check stronger by adding that explicit `return false`.

In the future, perhaps we could consider removing the OA address over OSM address preference?

Here's the relevant example query from the acceptance tests:

https://pelias.github.io/compare/#/v1/search?text=301+Commons+Park+S%2C+Stamford%2C+CT+06902