### PR TITLE
Special case 'union square' libpostal parse

### DIFF
--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -202,6 +202,14 @@ function patchBuggyResponses(response){
     }
   }
 
+  // union square should be venue, not neighbourhood
+  let suburb = _.get(idx, 'suburb');
+  // change suburb to house (turned into 'query' by pelias)
+  if (suburb && suburb.label === 'suburb' && suburb.value === 'union square') {
+    _.pullAt(response, suburb._pos);
+    response.push({ label: 'house', value: suburb.value });
+  }
+
   return response;
 }
 


### PR DESCRIPTION
While also a neighbourhood, most data for places called 'Union Square' are actually in the `venue` layer, so it's generally better to allow this query to hit Elasticsearch and return venues.

This change will only affect the search endpoint, and in acceptance test testing, it doesn't have any impact without other incoming PRs, like #1506.