### PR TITLE
feat(deps): Upgrade to pelias-labels-1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",
     "pelias-config": "^4.0.0",
-    "pelias-labels": "^1.13.0",
+    "pelias-labels": "^1.16.0",
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^7.0.0",


### PR DESCRIPTION
This includes improvements for:
- the default label format, adding region, including handling major cities in a region of the same name (https://github.com/pelias/labels/pull/43)
- a new label format for Singapore, handling current and future WOF data (https://github.com/pelias/labels/pull/45)