### PR TITLE
Enable autocomplete for postalcodes

### DIFF
--- a/sanitizer/_tokenizer.js
+++ b/sanitizer/_tokenizer.js
@@ -46,10 +46,13 @@ function _sanitize( raw, clean ){
     }
   }
 
-  // if the final character is a numeral then consider all tokens
-  // as complete in order to avoid prefix matching numerals.
-  if (/[0-9]$/.test(text) ) {
-    parserConsumedAllTokens = true;
+  // if requesting the address layer AND final character is a numeral then consider
+  // all tokens as complete in order to avoid prefix matching numerals.
+  const layers = _.get(clean, 'layers', []);
+  if (!_.isArray(layers) || _.isEmpty(layers) || layers.includes('address')) {
+    if (/[0-9]$/.test(text)) {
+      parserConsumedAllTokens = true;
+    }
   }
 
   // always set 'clean.tokens*' arrays for consistency and to avoid upstream errors.

--- a/sanitizer/autocomplete.js
+++ b/sanitizer/autocomplete.js
@@ -7,11 +7,11 @@ module.exports.middleware = (_api_pelias_config) => {
       singleScalarParameters: require('../sanitizer/_single_scalar_parameters')(),
       debug: require('../sanitizer/_debug')(_api_pelias_config.exposeInternalDebugTools),
       text: require('../sanitizer/_text_pelias_parser')(),
-      tokenizer: require('../sanitizer/_tokenizer')(),
       size: require('../sanitizer/_size')(/* use defaults*/),
       layers: require('../sanitizer/_targets')('layers', type_mapping.layer_mapping),
       sources: require('../sanitizer/_targets')('sources', type_mapping.source_mapping),
       address_layer_filter: require('../sanitizer/_address_layer_filter')(type_mapping),
+      tokenizer: require('../sanitizer/_tokenizer')(),
       // depends on the layers and sources sanitizers, must be run after them
       sources_and_layers: require('../sanitizer/_sources_and_layers')(),
       private: require('../sanitizer/_flag_bool')('private', false),

--- a/test/unit/sanitizer/_tokenizer.js
+++ b/test/unit/sanitizer/_tokenizer.js
@@ -417,7 +417,7 @@ module.exports.tests.forward_slash_delimiter = function(test, common) {
 module.exports.tests.final_token_single_gram = function(test, common) {
   test('final token single gram - numeric', function(t) {
 
-    var clean = { text: 'grolmanstrasse 1' };
+    var clean = { text: 'grolmanstrasse 1', layers: ['address'] };
     var messages = sanitizer.sanitize({}, clean);
 
     // tokens produced
@@ -551,13 +551,13 @@ module.exports.tests.numeric_final_char = function (test, common) {
   });
   test('numeric final char, multiple token', function (t) {
 
-    var clean = { text: 'stop 3', parsed_text: { subject: 'stop 3' } };
+    var clean = { text: 'stop 3', layers: ['venue'], parsed_text: { subject: 'stop 3' } };
     var messages = sanitizer.sanitize({}, clean);
 
     // tokens produced
     t.deepEquals(clean.tokens, ['stop', '3'], 'tokens produced');
-    t.deepEquals(clean.tokens_complete, ['stop', '3'], 'complete');
-    t.deepEquals(clean.tokens_incomplete, [], 'incomplete');
+    t.deepEquals(clean.tokens_complete, ['stop'], 'complete');
+    t.deepEquals(clean.tokens_incomplete, ['3'], 'incomplete');
 
     // no errors/warnings produced
     t.deepEquals(messages.errors, [], 'no errors');
@@ -595,7 +595,7 @@ module.exports.tests.subject_complete = function (test, common) {
 
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
-    return tape('sanitizeR _tokenizer: ' + name, testFunction);
+    return tape('sanitizer _tokenizer: ' + name, testFunction);
   }
 
   for( var testCase in module.exports.tests ){

--- a/test/unit/sanitizer/autocomplete.js
+++ b/test/unit/sanitizer/autocomplete.js
@@ -32,14 +32,6 @@ module.exports.tests.sanitizers = function(test, common) {
           }
         };
       },
-      '../sanitizer/_tokenizer': function () {
-        return {
-          sanitize: () => {
-            called_sanitizers.push('_tokenizer');
-            return { errors: [], warnings: [] };
-          }
-        };
-      },
       '../sanitizer/_size': function () {
         if (_.isEmpty(arguments)) {
           return {
@@ -64,11 +56,26 @@ module.exports.tests.sanitizers = function(test, common) {
           throw new Error('incorrect parameters passed to _targets');
         }
       },
-
       '../sanitizer/_sources_and_layers': function () {
         return {
           sanitize: () => {
             called_sanitizers.push('_sources_and_layers');
+            return { errors: [], warnings: [] };
+          }
+        };
+      },
+      '../sanitizer/_address_layer_filter': function () {
+        return {
+          sanitize: () => {
+            called_sanitizers.push('_address_layer_filter');
+            return { errors: [], warnings: [] };
+          }
+        };
+      },
+      '../sanitizer/_tokenizer': function () {
+        return {
+          sanitize: () => {
+            called_sanitizers.push('_tokenizer');
             return { errors: [], warnings: [] };
           }
         };
@@ -143,10 +150,11 @@ module.exports.tests.sanitizers = function(test, common) {
       '_single_scalar_parameters',
       '_debug',
       '_text_pelias_parser',
-      '_tokenizer',
       '_size',
       '_targets/layers',
       '_targets/sources',
+      '_address_layer_filter',
+      '_tokenizer',
       '_sources_and_layers',
       '_flag_bool',
       '_location_bias',


### PR DESCRIPTION
I tried to do a `/v1/autocomplete` for a partial postalcode with `?layers=postalcode` today and discovered that it doesn't return anything until the final character has been typed.

This DRAFT PR is a simple attempt at maybe fixing that

Would require more unit tests and some reasonable level of perf/recall/precision testing to get merged.