### PR TITLE
Remove default timeout and retry values for Pelias services

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -34,23 +34,23 @@ module.exports = Joi.object().keys({
     services: Joi.object().keys({
       pip: Joi.object().keys({
         url: Joi.string().uri({ scheme: /https?/ }).required(),
-        timeout: Joi.number().integer().optional().default(250).min(0),
-        retries: Joi.number().integer().optional().default(3).min(0),
+        timeout: Joi.number().integer().optional().min(0),
+        retries: Joi.number().integer().optional().min(0),
       }).unknown(false),
       placeholder: Joi.object().keys({
         url: Joi.string().uri({ scheme: /https?/ }).required(),
-        timeout: Joi.number().integer().optional().default(250).min(0),
-        retries: Joi.number().integer().optional().default(3).min(0),
+        timeout: Joi.number().integer().optional().min(0),
+        retries: Joi.number().integer().optional().min(0),
       }).unknown(false),
       interpolation: Joi.object().keys({
         url: Joi.string().uri({ scheme: /https?/ }).required(),
-        timeout: Joi.number().integer().optional().default(250).min(0),
-        retries: Joi.number().integer().optional().default(3).min(0),
+        timeout: Joi.number().integer().optional().min(0),
+        retries: Joi.number().integer().optional().min(0),
       }).unknown(false),
       libpostal: Joi.object().keys({
         url: Joi.string().uri({ scheme: /https?/ }).required(),
-        timeout: Joi.number().integer().optional().default(250).min(0),
-        retries: Joi.number().integer().optional().default(3).min(0),
+        timeout: Joi.number().integer().optional().min(0),
+        retries: Joi.number().integer().optional().min(0),
       }).unknown(false)
     }).unknown(false).default({}), // default api.services to an empty object
     defaultParameters: Joi.object().keys({

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -548,7 +548,7 @@ module.exports.tests.service_validation = (test, common) => {
   // these tests apply for all the individual service definitions
   const services = ['pip', 'placeholder', 'interpolation', 'libpostal'];
 
-  test('timeout and retries not specified should default to 250 and 3', (t) => {
+  test('timeout and retries not specified should default to unset', (t) => {
     services.forEach(service => {
       const config = {
         api: {
@@ -566,8 +566,8 @@ module.exports.tests.service_validation = (test, common) => {
 
       const result = schema.validate(config);
 
-      t.equals(result.value.api.services[service].timeout, 250);
-      t.equals(result.value.api.services[service].retries, 3);
+      t.equals(result.value.api.services[service].timeout, undefined);
+      t.equals(result.value.api.services[service].retries, undefined);
 
     });
 


### PR DESCRIPTION
The `pelias.json` schema validation in the API has been setting default values for the `timeout` and `retries` parameters used for network calls to each of the other Pelias services.

Years ago, in https://github.com/pelias/microservice-wrapper/pull/30, we determined that the original defaults of 250ms were too low. While rare, a heavily loaded Pelias installation can have responses from Placeholder, or even Libpostal, that take longer than 250ms.

However, the schema defaults were still using this 250ms value, which means they were effectively overriding the new, more sensible default of 1000ms in the microservice-wrapper library.

This change removes the defaults for both the `timeout` and `retries` values from the Pelias API, meaning the defaults set in the `microservice-wrapper` itself will be used.

## Further work

An additional problem with the current code is that a timeout from one of the Pelias services will result in an HTTP `400` error, which isn't correct. A 400 error indicates an error with invalid parameters or something that should be adjusted by the code making the API request. Instead a 500 error should be returned.