### PR TITLE
Remove duplicate `continent` entries from unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "markdown": "^0.5.0",
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",
-    "pelias-config": "^5.0.0",
+    "pelias-config": "^5.0.1",
     "pelias-labels": "^1.16.0",
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",

--- a/test/unit/helper/type_mapping.js
+++ b/test/unit/helper/type_mapping.js
@@ -52,7 +52,7 @@ module.exports.tests.interfaces = function(test, common) {
     t.deepEquals(type_mapping.layer_mapping, {
       coarse: [ 'continent', 'empire', 'country', 'dependency', 'macroregion', 'region',
         'locality', 'localadmin', 'macrocounty', 'county', 'macrohood', 'borough',
-        'neighbourhood', 'microhood', 'disputed', 'postalcode', 'continent', 'ocean', 'marinearea'
+        'neighbourhood', 'microhood', 'disputed', 'postalcode', 'ocean', 'marinearea'
       ],
       address: [ 'address' ],
       venue: [ 'venue' ],
@@ -90,7 +90,7 @@ module.exports.tests.interfaces = function(test, common) {
                  [ 'continent', 'empire', 'country', 'dependency', 'macroregion',
                    'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood',
                    'borough', 'neighbourhood', 'microhood', 'disputed', 'postalcode',
-                   'continent', 'ocean', 'marinearea']);
+                   'ocean', 'marinearea']);
     t.end();
   });
 
@@ -103,7 +103,7 @@ module.exports.tests.interfaces = function(test, common) {
       whosonfirst: [ 'continent', 'empire', 'country', 'dependency', 'macroregion',
         'region', 'locality', 'localadmin', 'macrocounty', 'county', 'macrohood',
         'borough', 'neighbourhood', 'microhood', 'disputed', 'venue', 'postalcode',
-        'continent', 'ocean', 'marinearea' ]
+        'ocean', 'marinearea' ]
     });
     t.end();
   });


### PR DESCRIPTION
This is a companion change to https://github.com/pelias/config/pull/135 that removes some duplicate `continent` layer entries from our unit tests.