### PR TITLE
Negative sources and layers

### DIFF
--- a/middleware/geocodeJSON.js
+++ b/middleware/geocodeJSON.js
@@ -65,6 +65,12 @@ function convertToGeocodeJSON(req, res, next, opts) {
   delete res.body.geocoding.query.tokens_complete;
   delete res.body.geocoding.query.tokens_incomplete;
 
+  // remove arrays produced by negative sources and layers handling (only intended to be used internally).
+  delete res.body.geocoding.query.negative_layers;
+  delete res.body.geocoding.query.positive_layers;
+  delete res.body.geocoding.query.negative_sources;
+  delete res.body.geocoding.query.positive_sources;
+
   // OPTIONAL. Warnings and errors.
   addMessages(req, 'warnings', res.body.geocoding);
   addMessages(req, 'errors', res.body.geocoding);

--- a/sanitizer/_address_layer_filter.js
+++ b/sanitizer/_address_layer_filter.js
@@ -33,8 +33,8 @@ function _setup(tm) {
       // error & warning messages
       let messages = { errors: [], warnings: [] };
 
-      // no nothing if user has explicitely specified layers in the request
-      if (_.isArray(clean.layers) && !_.isEmpty(clean.layers)) {
+      // do nothing if user has explicitly specified positive layers in the request
+      if ( _.isArray(clean.positive_layers) && !_.isEmpty(clean.positive_layers) ) {
         return messages;
       }
 
@@ -42,7 +42,7 @@ function _setup(tm) {
       // note: this should already have superfluous characters removed
       let input = clean.text;
 
-      // no nothing if no input text specified in the request
+      // do nothing if no input text specified in the request
       if (!nonEmptyString(input)) {
         return messages;
       }
@@ -86,9 +86,15 @@ function _setup(tm) {
       // then it is safe to apply the layer filter
       if (totalWords < 2 || !hasNumeral) {
 
-        // handle the common case where neither source nor layers were specified
+        // handle the common case where neither sources nor (positive) layers were specified
         if (!_.isArray(clean.sources) || _.isEmpty(clean.sources)) {
-          clean.layers = tm.layers.filter(item => item !== 'address'); // exclude 'address'
+          // if there are no layers already set, start with the list of all of them
+          if (_.isEmpty(clean.layers)) {
+            clean.layers = tm.layers;
+          }
+
+          // filter the existing list of layers so it excludes 'address'
+          clean.layers = clean.layers.filter(item => item !== 'address');
           messages.warnings.push(ADDRESS_FILTER_WARNING);
         }
 

--- a/test/unit/sanitizer/_address_layer_filter.js
+++ b/test/unit/sanitizer/_address_layer_filter.js
@@ -6,13 +6,20 @@ const STD_MESSAGES = { errors: [], warnings: ['performance optimization: excludi
 module.exports.tests = {};
 
 module.exports.tests.sanitize = function (test, common) {
+  // a simplified type mapping with dummy values
   let tm = new TypeMapping();
   tm.setLayersBySource({ A: ['A'], B: ['B'], C: ['C'] });
   tm.generateMappings();
   let s = sanitizer(tm);
 
+  // a real type mapping with our common sources and layers
+  const real_type_mapping = new TypeMapping();
+  real_type_mapping.load();
+  const real_sanitizer = sanitizer(real_type_mapping);
+
+
   test('sanitize - do nothing if clean.layers already specified', (t) => {
-    let clean = { text: '1 example', layers: ['not empty'] };
+    let clean = { text: '1 example', layers: ['not empty'], positive_layers: ['not empty'] };
     t.deepEqual(s.sanitize(null, clean), NO_MESSAGES);
     t.deepEqual(clean.layers, ['not empty']);
     t.end();
@@ -81,6 +88,45 @@ module.exports.tests.sanitize = function (test, common) {
     let clean = { text: 'foo', sources: ['A', 'B'] };
     t.deepEqual(s.sanitize(null, clean), NO_MESSAGES);
     t.false(clean.layers);
+    t.end();
+  });
+
+  test('sanitize - do nothing when address layer explicitly specified', (t) => {
+    let clean = { text: 'foo', layers: ['address', 'venue'], positive_layers: ['address', 'venue'] };
+
+    t.deepEqual(real_sanitizer.sanitize(null, clean), NO_MESSAGES);
+    t.deepEqual(clean.layers, ['address', 'venue']);
+    t.end();
+  });
+
+  test('sanitize - do nothing when source with only addresses (OA) specified', (t) => {
+    let clean = { text: 'foo', sources: ['openaddresses']};
+
+    t.deepEqual(real_sanitizer.sanitize(null, clean), NO_MESSAGES);
+    t.equal(clean.layers, undefined);
+    t.deepEqual(clean.sources, ['openaddresses']);
+    t.end();
+  });
+
+  test('sanitize - exclude layers when source with addresses and other layers (OSM) specified', (t) => {
+    let clean = { text: 'foo', sources: ['openstreetmap']};
+
+    t.deepEqual(real_sanitizer.sanitize(null, clean), STD_MESSAGES);
+    t.deepEqual(clean.layers, ['venue', 'street'], 'layer list is reduced to exclude addresses');
+    t.deepEqual(clean.sources, ['openstreetmap']);
+    t.end();
+  });
+
+  test('sanitize - exclude addresses when negative layers other than address are specified', (t) => {
+    // select all layers except venue to simulate value of clean.layers from targets sanitizer
+    const clean_layers = real_type_mapping.getCanonicalLayers().filter(layer => layer !== 'venue').sort();
+
+    let clean = { text: 'foo', layers: clean_layers, negative_layers: ['-venue'], positive_layers: []};
+
+    const expected_layers = clean_layers.filter(layer => layer !== 'address').sort();
+
+    t.deepEqual(real_sanitizer.sanitize(null, clean), STD_MESSAGES);
+    t.deepEqual(clean.layers.sort(), expected_layers, 'layer list is reduced to exclude addresses');
     t.end();
   });
 };

--- a/test/unit/sanitizer/_sources.js
+++ b/test/unit/sanitizer/_sources.js
@@ -127,6 +127,55 @@ module.exports.tests.invalid_sources = function(test, common) {
   });
 };
 
+module.exports.tests.negative_sources = function(test, common) {
+  test('negative source only', function(t) {
+    const raw = {
+      sources: '-geonames'
+    };
+    const clean = {};
+
+    const messages = sanitizer.sanitize(raw, clean);
+
+    const expected_sources = ['openstreetmap', 'openaddresses', 'whosonfirst'];
+
+    t.deepEqual(messages.errors, [], 'no error returned');
+    t.deepEqual(clean.sources, expected_sources, 'geonames source should be removed from clean.sources');
+    t.end();
+  });
+
+  test('positive and negative sources', function(t) {
+    const raw = {
+      sources: '-geonames,osm'
+    };
+    const clean = {};
+
+    const messages = sanitizer.sanitize(raw, clean);
+
+    const expected_sources = ['openstreetmap'];
+
+    t.deepEqual(messages.errors, [], 'no error returned');
+    t.deepEqual(clean.sources, expected_sources, 'only OSM should be present in sources');
+    t.deepEqual(clean.negative_sources, ['geonames'], 'negative_sources clean property set');
+    t.deepEqual(clean.positive_sources, ['openstreetmap'], 'negative_sources clean property set');
+    t.end();
+  });
+
+  test('positive and negative sources resulting in empty list', function(t) {
+    const raw = {
+      sources: '-geonames,osm,-osm'
+    };
+    const clean = {};
+
+    const messages = sanitizer.sanitize(raw, clean);
+
+    const expected_sources = ['openstreetmap'];
+
+    t.deepEqual(messages.errors.length, 1, 'error emitted because no sources remain after positive and negative filters');
+    t.deepEqual(clean.sources, undefined, 'sources is left undefined in case of error');
+    t.end();
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('SANTIZE _sources ' + name, testFunction);


### PR DESCRIPTION
This PR adds support for "negative sources and layers": the ability to specify that certain sources or layers should be _omitted_, rather than only specifying which sources or layers should be _included_.

**Current status:** feature complete, ready for more serious testing

## How the parameters work

At its core, this PR now allows elements in the `sources` or `layers` API parameters to be prefixed by the `-` sign. This signifies that the given source/layer will be _omitted_. This is considered a "negative" source/layer, whereas the existing type of filter is "positive".

Both negative and positive filters can be specified, leading to some interesting combinations.

For example:

`/v1/search?text=berlin&layers=-venue` will search all layers except the `venue` layer

`/v1/search?text=berlin&layers=-country,coarse` will search all coarse layers _except_ `country`. `coarse` currently expands to `"continent", "empire", "country", "dependency", "macroregion", "region", "locality", "localadmin", "macrocounty", "county", "macrohood", "borough", "neighbourhood", "microhood", "disputed", "postalcode", "ocean", "marinearea"`, so it saves quite a bit of typing. It will also continue to work if we add new coarse layers

`/v1/search?text=berlin&sources=-geonames` searches all sources except geonames

## How the code works

Under the hood, the sources and layers code now checks for elements starting with `-`, and uses that to apply two filters: positive and negative, to the list of all sources/layers.

The positive list is applied _first_, and then the negative list is applied second. Because of this, queries like `/v1/search?text=berlin&layers=locality,localadmin,-locality` work fine. This one would query only for `localadmin`s.

 It _is_ possible to specify combinations that would result in nothing such as `sources=osm,-osm` or `layers=-coarse,locality`. In this case an error message is emitted and no query is performed.

### Keeping track of positive layers

There's some additional complexity that is required now that there is the internal concept of both positive and negative layers.

In particular, we have some performance optimizations that do things like remove results from the `address` layer under certain circumstances. In general, these bits of code abort if any `layers` were specified. However, we want them to function if only negative layers are specified. The internal `clean` object now stores  `positive_layers`/`positive_sources` properties that are passed around internally. These properties allow performance optimizing filters to do what they need to do.

## Work to be done
- [ ] Documentation
- [x] Additional unit tests (especially for the `sources` property)
- [ ] Additional testing for edge cases
- [x] Validation against acceptance tests
- [ ] New acceptance tests for some negative source and layer cases.
- [x] Ensure all `address` layer performance optimizations are compatible with this change
- [x] Test with various combinations of custom sources/layers
- [x] Performance testing
- [ ] ...


Connects https://github.com/pelias/pelias/issues/844