### PR TITLE
Use Github Actions to build Docker Image

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,6 +21,18 @@ jobs:
         run: |
           npm install
           npm run travis
+  build-docker-images:
+    needs: unit-tests
+    if: github.event_name == 'push'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker images
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          curl "https://raw.githubusercontent.com/pelias/ci-tools/master/build-docker-images.sh" | bash -
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,6 +48,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: >
-          curl
+          [[ -n "$GH_SEMANTIC_RELEASE_TOKEN" && -n "$NPM_TOKEN" ]] && curl
           "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh"
           | bash -


### PR DESCRIPTION
This uses the work from https://github.com/pelias/ci-tools/pull/5 to allow building the Pelias API Docker images in Github Actions.

It might be nice for us to consolidate on a single CI provider, and this would allow a smooth transition to doing so.

A nice side effect of how Docker generates immutable images is that we don't _have_ to disable the CircleCI build right away, so for now I've chosen not to remove the `.circleci` directory in this PR. However we might want want to do that soon after we're confident in using GitHub Actions.