### PR TITLE
Improve performance of `max_character_count_layer_filter`

### DIFF
--- a/test/unit/query/view/max_character_count_layer_filter.js
+++ b/test/unit/query/view/max_character_count_layer_filter.js
@@ -67,12 +67,11 @@ module.exports.tests.view_within_range = function(test, common) {
     let vs = new VariableStore();
     vs.var('input:name', 'example text');
 
-    let actual = view(vs);
-    let expected = {
-      terms: {
-        layer: { $: _.difference(allLayers, ['address']) }
-      }
-    };
+    // execute the view
+    view(vs);
+
+    let expected =_.difference(allLayers, ['address']);
+    let actual = vs.var('layers').get();
 
     t.deepLooseEqual(actual, expected, 'view_within_range');
     t.end();
@@ -102,12 +101,12 @@ module.exports.tests.view_clamp_range_low = function(test, common) {
     let vs = new VariableStore();
     vs.var('input:name', 'e');
 
-    let actual = view(vs);
-    let expected = {
-      terms: {
-        layer: { $: _.difference(allLayers, ['address']) }
-      }
-    };
+    // execute the view
+    view(vs);
+
+    let expected =_.difference(allLayers, ['address']);
+    let actual = vs.var('layers').get();
+
     t.deepLooseEqual(actual, expected, 'view_clamp_range_low');
     t.end();
   });


### PR DESCRIPTION
This is a test of the performance impact of rewriting `max_character_count_layer_filter` so that it shares a single `terms`  query with the one from the `layers` parameter, rather than using its own.

After some A/B testing, it seems we can get 7% lower `p99` latency for 1 character autocomplete requests with this change. This code is not ready to be merged as is, but it was sufficient for testing out the premise before investing in the proper code changes to make it happen.

Background
==========

The `max_character_count_layer_filter` is used to exclude results from the address layer when an autocomplete query consists of less than a configured number of characters (usually set to 1, 2, or 3). This helps performance for queries that otherwise would match many millions of documents since the input is so short.

It achieves this by adding an additional `[terms](https://www.elastic.co/guide/en/elasticsearch/reference/6.8//query-dsl-terms-query.html)` query to the generated Elasticsearch query. This query enumerates _all layers_ except the address layer and tells Elasticsearch to require documents to match those layers. On its own, this is the most performant way to exclude a single layer (Elasticsearch does not support fast `not`-style queries).

However, because there is often _another_ `terms` filter that limits results to certain layers (either from the `layers` API parameter or the `address_layer_filter` sanitizer), its often the case that some of these `terms` filters are redundant.

Here's an example of the two `terms` queries created for [/v1/autocomplete?layers=locality&text=be](https://pelias.github.io/compare/#/v1/autocomplete?layers=locality&text=be&debug=1):

```json
"filter": [
  {
    "terms": {
      "layer": [
        "venue",
        "street",
        "country",
        "macroregion",
        "region",
        "county",
        "localadmin",
        "locality",
        "borough",
        "neighbourhood",
        "continent",
        "empire",
        "dependency",
        "macrocounty",
        "macrohood",
        "microhood",
        "disputed",
        "postalcode",
        "ocean",
        "marinearea"
      ]   
    }   
  },  
  {
    "terms": {
      "layer": [
        "locality"
      ]   
    }   
  }
]
```

The first `terms` query is generated by the `max_character_count_layer_filter` and  includes _all_ layers except address, while the second contains only `locality`. It should be clear that in this case the first `terms` query isn't needed at all.

Impact
================


With the changes in this PR, where only a single `terms` query is ever generated, I've seen the following reduction in p99 latencies for autocomplete queries of the following lengths:

|query length| p99 latency reduction|
| --- | ---|
| 1 | 7% |
| 2 | 3.5% |
| 3 | 3.5% |

It's also nice to shorten our Elasticsearch queries a bit, and reduce how difficult it is to read them.

How this change works
=====================

This change is not ready to merge as is: since the code previously generated a new query clause, it's written as a query view and lives in the `query` directory with our other views. It now only modifies the query variables, so it feels out of place given the new functionality.

This is probably not how we want to manage things at the end of the day, but it was a quick way to test things out.

In the long run, we probably want to move the logic in `query/view/max_character_count_layer_filter.js` to a sanitizer, so that it behaves similarly to the address layer filter in `sanitizer/_address_layer_filter.js`.

If everyone likes the idea of this change, I'll go ahead and implement it properly, since I've been deep in all of this code lately for [negative sources and layers](https://github.com/pelias/api/pull/1525).