### PR TITLE
Use 'hotfix' for parser performance issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^9.0.0",
-    "pelias-parser": "1.53.0",
+    "pelias-parser": "pelias/parser#remove-unit-type",
     "pelias-query": "^11.0.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",


### PR DESCRIPTION
A performance issue in the Pelias Parser where certain inputs can cause long parse times and out of memory errors was [recently reported](https://github.com/pelias/api/issues/1530).

This change implements a short term fix by disabling some functionality around unit number parsing that was contributing to the issue. From our analysis it's not so much that the unit number parsing _caused_ the issue, but it was the most recently added functionality that contributed to it.

While we develop a longer term fix, which should allow us to keep unit number parsing around, this "hotfix" will keep everything running smoothly. Unit numbers are not yet fully supported by Pelias so there _shouldn't_ be any major loss in functionality.

Fixes https://github.com/pelias/api/issues/1530
