### PR TITLE
Update CI Node.js versions and operating systems

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,6 +9,8 @@ jobs:
           - ubuntu-20.04
         node-version:
           - 12.x
+          - 14.x
+          - 16.x
     steps:
       - uses: actions/checkout@v2
       - name: 'Install node.js ${{ matrix.node-version }}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,6 @@ jobs:
         os:
           - ubuntu-20.04
         node-version:
-          - 10.x
           - 12.x
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,6 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-10.15
         node-version:
           - 10.x
           - 12.x


### PR DESCRIPTION
This makes 3 changes to our GitHub actions CI runs.

## Remove Mac OS from build matrix

When we started using GitHub Actions it seemed like the ability to test on a Mac was nice, but there are a couple downsides:

First, they often seem to take a lot longer to run than the Linux builds. For example, see [this run](https://github.com/pelias/api/actions/runs/900305928) that took 1.5 mins on Mac, but 20 seconds on Linux.
![image](https://user-images.githubusercontent.com/111716/120673604-2d33f000-c448-11eb-99e3-1a40a9aa22c2.png)

Second, builds on Mac OS cost [_10x_ per minute](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions) what a Linux build does. While this isn't directly a problem for the Pelias project, since open-source CI build minutes are _currently_ free, this could bite anyone who wants to run Pelias code in their own private repo.

Personally I don't think we get enough value out of explicitly testing on a Mac to slow things down like this, but I'm open to discussion.

## Drop Node.js 10 from build matrix

Node.js 10 reached end of life on [April 30th, 2021](https://twitter.com/nodejs/status/1388116425361874945), so we can stop testing with it.

## Add Node.js 14 and 16

These new Node.js versions seem to work fine with all Pelias code, but we've been a bit slow to add them to CI. We might as well start here :)

Eventually we can/should roll out a change like this to more Pelias repositories, but the API is a logical place to start.