### PR TITLE
fix(labels): handle rare case where name is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",
     "pelias-config": "^5.0.1",
-    "pelias-labels": "^1.16.0",
+    "pelias-labels": "^1.16.1",
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.7.0",
     "pelias-model": "^9.0.0",


### PR DESCRIPTION
This happens only for Geonames records (and as far as we can tell, only for the country of the Philippines), so will rarely if ever be seen (it would require using the `sources=geonames` parameter, which we do not recommend).

This fix is included by bumping pelias-labels from 1.16.0 to 1.16.1