### PR TITLE
Ignore empty tokens in query view

### DIFF
--- a/query/view/admin_multi_match_first.js
+++ b/query/view/admin_multi_match_first.js
@@ -20,7 +20,7 @@ module.exports = function (adminFields) {
     // the actual query text is simply taken from the first valid admin field
     // this assumes all the values would be the same, which is probably not true
     // TODO: handle the case where not all admin area input values are the same
-    var tokens = vs.var('input:' + valid_admin_properties[0]).get().split(/\s+/g);
+    var tokens = vs.var('input:' + valid_admin_properties[0]).get().split(/\s+/g).filter(t => t.length > 0);
 
     // no valid tokens to use, fail now, don't render this view.
     if (!tokens || tokens.length < 2) { return null; }


### PR DESCRIPTION
Empty tokens should not make it this far into the query code, but it can happen.

In that case, we should ignore empty tokens and avoid aggravating the `VariableStore` checks by attempting to store empty strings.

This fixes the 500 error described in https://github.com/pelias/api/issues/1535, but doesn't really fix the underlying problem.

From my investigation it looks like Emoji that include a [variation selector](https://emojipedia.org/variation-selector-16/) will not be completely removed by the Pelias Parser (the emoji codepoint will be removed, but not the variation selector). If possible we should address that in some follow up work.