### PR TITLE
unicode: remove "variation selector" and "zero-width joiner" symbols

### DIFF
--- a/helper/unicode.js
+++ b/helper/unicode.js
@@ -29,6 +29,7 @@ const ALTERNATE_SPACES = regenerate()
 // see: https://github.com/pelias/pelias/issues/829#issuecomment-542614645
 // ref: https://en.wikipedia.org/wiki/Combining_character
 const COMBINING_MARKS = regenerate()
+  .add(0x200D) // ZERO WIDTH JOINER (U+200D)
   .addRange(0x0300, 0x036F) // Combining Diacritical Marks (0300–036F)
   .addRange(0x1AB0, 0x1AFF) // Combining Diacritical Marks Extended (1AB0–1AFF)
   .addRange(0x1DC0, 0x1DFF) // Combining Diacritical Marks Supplement (1DC0–1DFF)

--- a/helper/unicode.js
+++ b/helper/unicode.js
@@ -33,6 +33,7 @@ const COMBINING_MARKS = regenerate()
   .addRange(0x1AB0, 0x1AFF) // Combining Diacritical Marks Extended (1AB0–1AFF)
   .addRange(0x1DC0, 0x1DFF) // Combining Diacritical Marks Supplement (1DC0–1DFF)
   .addRange(0x20D0, 0x20FF) // Combining Diacritical Marks for Symbols (20D0–20FF)
+  .addRange(0xFE00, 0xFE0F) // Variation Selectors (FE00-FE0F)
   .addRange(0xFE20, 0xFE2F) // Combining Half Marks (FE20–FE2F)
   .add(0x3099) // combining dakuten (U+3099)
   .add(0x309A) // combining handakuten (U+309A)
@@ -79,7 +80,7 @@ const MISC_UNSUPPORTED_SYMBOLS = regenerate()
   .toRegExp('g');
 
 function normalize(str) {
-  
+
   // sanity checking
   if(!_.isString(str)){ return str; }
 

--- a/test/unit/helper/unicode.js
+++ b/test/unit/helper/unicode.js
@@ -44,6 +44,7 @@ module.exports.tests.normalize = function (test) {
     t.equal(norm('💩a😎b'), 'ab', 'emoji');
     t.equal(norm('🙌🏿a🙌🏻b'), 'ab', 'emoji');
     t.equal(norm('new york ❤️usa'), 'new york usa', 'dingbat + variation selector');
+    t.equal(norm('👩‍❤️‍👩'), '', 'complex emoji ZWJ sequence (6 codepoints)');
     t.end();
   });
 };

--- a/test/unit/helper/unicode.js
+++ b/test/unit/helper/unicode.js
@@ -43,6 +43,7 @@ module.exports.tests.normalize = function (test) {
     t.equal(norm('𝄞a𝇎b'), 'ab', 'muscial symbols');
     t.equal(norm('💩a😎b'), 'ab', 'emoji');
     t.equal(norm('🙌🏿a🙌🏻b'), 'ab', 'emoji');
+    t.equal(norm('new york ❤️usa'), 'new york usa', 'dingbat + variation selector');
     t.end();
   });
 };


### PR DESCRIPTION
As mentioned in https://github.com/pelias/api/issues/1535, the [Variation Selectors](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)) unicode block can cause errors when the proceeding codepoint has been stripped but the variation selector remains.

https://apps.timwhitlock.info/unicode/inspect?s=%E2%9D%A4%EF%B8%8F

<img width="1182" alt="Screenshot 2021-06-21 at 13 49 04" src="https://user-images.githubusercontent.com/738069/122757042-44e5f200-d2eb-11eb-9dec-7da2a4e5ed58.png">

In the example above the dingbat symbol `2764` was removed but the selector `FE0F` remained, it's a non-printable character but still causes issues when JS determines the `.length` of the string.

```js
String.fromCharCode(0xFE0F).length
1
```

I'm not concerned about excluding these modifiers because they are currently only used to modify symbols which aren't relevant for geocoding. We're also already doing `NFKC` normalization which converts decomposed symbols to composed symbols where applicable, in this case there exists no single 'composed' symbol to convert this pair into.

> They are currently used to specify standardized variation sequences for mathematical symbols, emoji symbols, 'Phags-pa letters, and CJK unified ideographs corresponding to CJK compatibility ideographs.

resolves: https://github.com/pelias/api/issues/1535
closes: https://github.com/pelias/api/pull/1536