### PR TITLE
sanitize/remove HTML elements if present in the data

### DIFF
--- a/helper/fieldValue.js
+++ b/helper/fieldValue.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const htmlSanitize = require('./htmlSanitize');
 
 function getStringValue(property) {
   // numeric value, cast to string
@@ -41,5 +42,5 @@ function getArrayValue(property) {
   return [property];
 }
 
-module.exports.getStringValue = getStringValue;
-module.exports.getArrayValue = getArrayValue;
+module.exports.getStringValue = (property) => htmlSanitize(getStringValue(property));
+module.exports.getArrayValue = (property) => htmlSanitize(getArrayValue(property));

--- a/helper/geojsonify.js
+++ b/helper/geojsonify.js
@@ -6,6 +6,7 @@ const _ = require('lodash');
 const Document = require('pelias-model').Document;
 const codec = require('pelias-model').codec;
 const field = require('./fieldValue');
+const htmlSanitize = require('./htmlSanitize');
 const decode_gid = require('./decode_gid');
 
 function geojsonifyPlaces( params, docs ){
@@ -42,13 +43,17 @@ function geojsonifyPlaces( params, docs ){
 
 function geojsonifyPlace(params, place) {
   const gid_components = decode_gid(place._id);
+  const source = htmlSanitize(place.source);
+  const source_id = htmlSanitize(gid_components.id);
+  const layer = htmlSanitize(place.layer);
+
   // setup the base doc
   const doc = {
-    id: gid_components.id,
-    gid: new Document(place.source, place.layer, gid_components.id).getGid(),
-    layer: place.layer,
-    source: place.source,
-    source_id: gid_components.id,
+    id: source_id,
+    gid: new Document(source, layer, source_id).getGid(),
+    layer,
+    source,
+    source_id,
     bounding_box: place.bounding_box,
     lat: parseFloat(place.center_point.lat),
     lng: parseFloat(place.center_point.lon),

--- a/helper/htmlSanitize.js
+++ b/helper/htmlSanitize.js
@@ -1,0 +1,27 @@
+const _ = require('lodash');
+const stripHTML = require('string-strip-html').stripHtml;
+const options = { stripTogetherWithTheirContents: ['link', 'script', 'style', 'xml'] };
+
+/**
+ * Sanitize HTML in strings by completely removing 'dangerous' elements
+ * while keeping the inner HTML of non-dangerous elements.
+ *
+ * note: Arrays and Objects of strings are supported but currently
+ * they are not sanitized *recursively*.
+ *
+ * see: https://www.npmjs.com/package/string-strip-html
+ */
+
+function htmlSanitizeValue(value) {
+  if (!_.isString(value)) { return value; }
+  return stripHTML(value, options).result;
+}
+
+function htmlSanitize(data) {
+  if (_.isString(data)) { return htmlSanitizeValue(data); }
+  if (_.isArray(data)) { return _.map(data, htmlSanitizeValue); }
+  if (_.isPlainObject(data)) { return _.mapValues(data, htmlSanitizeValue); }
+  return data;
+}
+
+module.exports = htmlSanitize;

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "retry": "^0.12.0",
     "stable": "^0.1.8",
     "stats-lite": "^2.0.4",
+    "string-strip-html": "^8.3.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {

--- a/test/unit/helper/geojsonify.js
+++ b/test/unit/helper/geojsonify.js
@@ -768,6 +768,49 @@ module.exports.tests.addendum = function(test, common) {
   });
 };
 
+// strip HTML entities from the response
+module.exports.tests.sanitizeHTML = function (test, common) {
+  test('sanitize HTML', function (t) {
+    var aliases = [{
+      '_id': '<em>example</em>:<p>example</p>:1',
+      'source': '<em>example</em>',
+      'layer': '<p>example</p>',
+      'name': {
+        'default': 'Example <script src="evil.js" /> Place'
+      },
+      'center_point': {
+        'lon': 0,
+        'lat': 0
+      }
+    }];
+
+    const expected = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        },
+        properties: {
+          id: '1',
+          gid: 'example:example:1',
+          layer: 'example',
+          source: 'example',
+          source_id: '1',
+          name: 'Example Place'
+        }
+      }],
+      bbox: [0, 0, 0, 0]
+    };
+
+    var actual = geojsonify({}, aliases);
+    t.deepEquals(actual, expected);
+    t.end();
+  });
+
+};
+
 module.exports.all = (tape, common) => {
   function test(name, testFunction) {
     return tape(`geojsonify: ${name}`, testFunction);

--- a/test/unit/helper/htmlSanitize.js
+++ b/test/unit/helper/htmlSanitize.js
@@ -1,0 +1,102 @@
+const sanitize = require('../../../helper/htmlSanitize');
+module.exports.tests = {};
+
+module.exports.tests.remove = function (test, common) {
+  test('remove: LINK tags', (t) => {
+    t.deepEquals(sanitize('AAA <link href="evil.css" /> BBB'), 'AAA BBB');
+    t.end();
+  });
+  test('remove: SCRIPT tags', (t) => {
+    t.deepEquals(sanitize('AAA <script src="evil.js" /> BBB'), 'AAA BBB');
+    t.end();
+  });
+  test('remove: STYLE tags', (t) => {
+    t.deepEquals(sanitize('AAA <style>.evil { color: red; }</style> BBB'), 'AAA BBB');
+    t.end();
+  });
+  test('remove: XML tags', (t) => {
+    t.deepEquals(sanitize('AAA <xml><evil /></xml> BBB'), 'AAA BBB');
+    t.end();
+  });
+};
+
+module.exports.tests.keep_contents = function (test, common) {
+  test('keep contents: P tags', (t) => {
+    t.deepEquals(sanitize('AAA <p>CCC</p> BBB'), 'AAA CCC BBB');
+    t.end();
+  });
+  test('keep contents: nested safe tags', (t) => {
+    t.deepEquals(sanitize('AAA <p><em>CCC</em></p> BBB'), 'AAA CCC BBB');
+    t.end();
+  });
+  test('keep contents: invalid nested safe tags (missing closing tag)', (t) => {
+    t.deepEquals(sanitize('AAA <p><em>CCC</p> BBB'), 'AAA CCC BBB');
+    t.end();
+  });
+};
+
+module.exports.tests.types = function (test, common) {
+  test('string', (t) => {
+    t.deepEquals(sanitize('AAA <link href="evil.css" /> BBB'), 'AAA BBB');
+    t.end();
+  });
+  test('string - empty', (t) => {
+    t.deepEquals(sanitize(''), '');
+    t.end();
+  });
+  test('number', (t) => {
+    t.deepEquals(sanitize(0.1), 0.1);
+    t.end();
+  });
+  test('number - empty', (t) => {
+    t.deepEquals(sanitize(NaN), NaN);
+    t.end();
+  });
+  test('array', (t) => {
+    t.deepEquals(sanitize([
+      'AAA <link href="evil.css" /> BBB',
+      'CCC <script src="evil.js" /> DDD'
+    ]), [
+      'AAA BBB',
+      'CCC DDD'
+    ]);
+    t.end();
+  });
+  test('array - empty', (t) => {
+    t.deepEquals(sanitize([]), []);
+    t.end();
+  });
+  test('object', (t) => {
+    t.deepEquals(sanitize({
+      a: 'AAA <link href="evil.css" /> BBB',
+      b: 'CCC <script src="evil.js" /> DDD'
+    }), {
+      a: 'AAA BBB',
+      b: 'CCC DDD'
+    });
+    t.end();
+  });
+  test('object - empty', (t) => {
+    t.deepEquals(sanitize({}), {});
+    t.end();
+  });
+  test('null', (t) => {
+    t.deepEquals(sanitize(null), null);
+    t.end();
+  });
+  test('undefined', (t) => {
+    t.deepEquals(sanitize(undefined), undefined);
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('[helper] htmlSanitize: ' + name, testFunction);
+  }
+
+  for (var testCase in module.exports.tests) {
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/unit/run.js
+++ b/test/unit/run.js
@@ -36,6 +36,7 @@ var tests = [
   require('./helper/decode_gid'),
   require('./helper/diffPlaces'),
   require('./helper/fieldValue'),
+  require('./helper/htmlSanitize'),
   require('./helper/geojsonify_place_details'),
   require('./helper/geojsonify'),
   require('./helper/iso3166'),


### PR DESCRIPTION
As discussed in https://github.com/pelias/model/issues/141 there is a possibility for HTML elements to be returned from the geoJSON API which could have a security impact for unaware clients.

For example, someone *could* edit OSM and set the name of a place to `Foo <script src="evil.js" /> Bar` and we would return that verbatim to the user.

Security best-practises on the front-end could mitigate the threat but they could also catch unsuspecting users unaware.

This PR sanitizes/remove HTML elements if present in the data returned from elasticsearch.

There are two options for sanitising, namely 1. completely stripping the element (for `<SCRIPT>` etc) and 2. removing the elements but keeping the content (for `<P>` etc).

I think in an ideal world we could implement this in the importers/model, that would also be cleaner since elasticsearch would never see the HTML in the first place.

However, it's much easier and much more secure to implement it in the `pelias/api` layer since we can guarantee that the JSON being returned does not contain HTML, whereas we'd have to trust the data indexed in elasticsearch to provide that guarantee if implemented in the importers.

I'm open to either approach, this was just much simpler to implement.