### PR TITLE
added postcode match boost for autocomplete

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -17,7 +17,8 @@ var views = {
   phrase_first_tokens_only:   require('./view/phrase_first_tokens_only'),
   boost_exact_matches:        require('./view/boost_exact_matches'),
   max_character_count_layer_filter:   require('./view/max_character_count_layer_filter'),
-  focus_point_filter:         require('./view/focus_point_distance_filter')
+  focus_point_filter:         require('./view/focus_point_distance_filter'),
+  boost_postcode_match: require('./view/boost_postcode_match')
 };
 
 // add abbrevations for the fields pelias/parser is able to detect.
@@ -49,6 +50,7 @@ query.score( views.admin_multi_match_first( adminFields ), 'must');
 query.score( views.admin_multi_match_last( adminFields ), 'must');
 
 // scoring boost
+query.score( views.boost_postcode_match( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.focus( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.popularity( peliasQuery.view.leaf.match_all ) );
 query.score( peliasQuery.view.population( peliasQuery.view.leaf.match_all ) );

--- a/query/view/boost_postcode_match.js
+++ b/query/view/boost_postcode_match.js
@@ -1,0 +1,33 @@
+module.exports = function (subview) {
+  return function (vs) {
+
+    // query section reduces the number of records which
+    // the decay function is applied to.
+    // we simply re-use the another view for the function query.
+    if (!subview) {
+      return null;
+    } // subview validation failed
+
+    // validate required params
+    if (!vs.isset('input:postcode') ||
+        !vs.isset('address:postcode:analyzer') ||
+        !vs.isset('address:postcode:field') ||
+        !vs.isset('address:postcode:boost')) {
+      return null;
+    }
+
+    return {
+      constant_score: {
+        filter: {
+          match_phrase: {
+            [ vs.var('address:postcode:field') ]: {
+              query   : vs.var('input:postcode'),
+                analyzer: vs.var('address:postcode:analyzer')
+              }
+            }
+          },
+        boost : vs.var('address:postcode:boost')
+      }
+    };
+  };
+};


### PR DESCRIPTION
While preparing a pelias deployment for production usage, I faced some weird behavior:

`search` handles queries like `kreisstraße 12, 25795` very well:
```json
{
    "geocoding": {
        "version": "0.2",
        "attribution": "http://10.50.30.2:4000/attribution",
        "query": {
            "text": "kreisstraße 12, 25795",
            "size": 3,
            "private": false,
            "lang": {
                "name": "German",
                "iso6391": "de",
                "iso6393": "deu",
                "via": "header",
                "defaulted": false
            },
            "querySize": 20,
            "parser": "libpostal",
            "parsed_text": {
                "street": "kreisstraße",
                "housenumber": "12",
                "postalcode": "25795"
            }
        },
        "warnings": [
            "Invalid Parameter: api_key"
        ],
        "engine": {
            "name": "Pelias",
            "author": "Mapzen",
            "version": "1.0"
        },
        "timestamp": 1625860907041
    },
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    9.077043,
                    54.231885
                ]
            },
            "properties": {
                "id": "Z1A4Xnm",
                "gid": "cw:address:Z1A4Xnm",
                "layer": "address",
                "source": "cw",
                "source_id": "Z1A4Xnm",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "25795",
                "confidence": 1,
                "match_type": "exact",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Schleswig-Holstein",
                "region_gid": "whosonfirst:region:85682517",
                "region_a": "SH",
                "county": "Kreis Dithmarschen",
                "county_gid": "whosonfirst:county:102064119",
                "county_a": "DT",
                "localadmin": "Kirchspielslandgemeinde Heider Umland",
                "localadmin_gid": "whosonfirst:localadmin:1377683411",
                "locality": "Weddingstedt",
                "locality_gid": "whosonfirst:locality:101805125",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Weddingstedt, SH, Deutschland",
                "index": 0
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.956732,
                    53.349553
                ]
            },
            "properties": {
                "id": "node/1592206882",
                "gid": "openstreetmap:address:node/1592206882",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/1592206882",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "26345",
                "confidence": 1,
                "match_type": "exact",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Niedersachsen",
                "region_gid": "whosonfirst:region:85682555",
                "region_a": "NI",
                "county": "Landkreis Friesland",
                "county_gid": "whosonfirst:county:102064051",
                "localadmin": "Bockhorn",
                "localadmin_gid": "whosonfirst:localadmin:1377688673",
                "locality": "Bockhorn",
                "locality_gid": "whosonfirst:locality:101806527",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Bockhorn, NI, Deutschland",
                "index": 1
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    8.438347,
                    51.349948
                ]
            },
            "properties": {
                "id": "node/1052209269",
                "gid": "openstreetmap:address:node/1052209269",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/1052209269",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "59939",
                "confidence": 1,
                "match_type": "exact",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Nordrhein-Westfalen",
                "region_gid": "whosonfirst:region:85682513",
                "region_a": "NW",
                "macrocounty": "Arnsberg",
                "macrocounty_gid": "whosonfirst:macrocounty:404227579",
                "county": "Hochsauerlandkreis",
                "county_gid": "whosonfirst:county:102063783",
                "county_a": "HC",
                "localadmin": "Olsberg",
                "localadmin_gid": "whosonfirst:localadmin:1377692267",
                "locality": "Olsberg",
                "locality_gid": "whosonfirst:locality:101839497",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Olsberg, NW, Deutschland",
                "index": 2
            }
        }
    ],
    "bbox": [
        7.956732,
        51.349948,
        9.077043,
        54.231885
    ]
}
````

<details>
  <summary>Search ES query</summary>

  ```json
{
    "query": {
        "function_score": {
            "query": {
                "bool": {
                    "minimum_should_match": 1,
                    "should": [
                        {
                            "bool": {
                                "_name": "fallback.street",
                                "must": [
                                    {
                                        "match_phrase": {
                                            "address_parts.street": {
                                                "query": "kreisstraße",
                                                "slop": 4,
                                                "analyzer": "peliasQuery"
                                            }
                                        }
                                    }
                                ],
                                "filter": {
                                    "term": {
                                        "layer": "street"
                                    }
                                },
                                "boost": 5
                            }
                        },
                        {
                            "bool": {
                                "_name": "fallback.address",
                                "must": [
                                    {
                                        "match_phrase": {
                                            "address_parts.zip": {
                                                "query": "25795"
                                            }
                                        }
                                    },
                                    {
                                        "match_phrase": {
                                            "address_parts.number": {
                                                "query": "12"
                                            }
                                        }
                                    },
                                    {
                                        "match_phrase": {
                                            "address_parts.street": {
                                                "query": "kreisstraße",
                                                "slop": 4,
                                                "analyzer": "peliasQuery"
                                            }
                                        }
                                    }
                                ],
                                "filter": {
                                    "term": {
                                        "layer": "address"
                                    }
                                },
                                "boost": 10
                            }
                        },
                        {
                            "bool": {
                                "_name": "fallback.address",
                                "must": [
                                    {
                                        "match_phrase": {
                                            "address_parts.number": {
                                                "query": "12"
                                            }
                                        }
                                    },
                                    {
                                        "match_phrase": {
                                            "address_parts.street": {
                                                "query": "kreisstraße",
                                                "slop": 4,
                                                "analyzer": "peliasQuery"
                                            }
                                        }
                                    }
                                ],
                                "filter": {
                                    "term": {
                                        "layer": "address"
                                    }
                                },
                                "boost": 10
                            }
                        }
                    ],
                    "filter": {
                        "bool": {
                            "must": []
                        }
                    }
                }
            },
            "functions": []
        }
    },
    "size": 20,
    "track_scores": true
}
  ```

</details>

And `autocomplete` doesn't (also with `size` of 10 or more, it's not even in the list):
```json
{
    "geocoding": {
        "version": "0.2",
        "attribution": "http://10.50.30.2:4000/attribution",
        "query": {
            "text": "kreisstraße 12, 25795",
            "parser": "pelias",
            "parsed_text": {
                "subject": "12 kreisstraße",
                "street": "kreisstraße",
                "housenumber": "12",
                "postcode": "25795"
            },
            "size": 3,
            "private": false,
            "lang": {
                "name": "German",
                "iso6391": "de",
                "iso6393": "deu",
                "via": "header",
                "defaulted": false
            },
            "querySize": 20
        },
        "warnings": [
            "Invalid Parameter: api_key"
        ],
        "engine": {
            "name": "Pelias",
            "author": "Mapzen",
            "version": "1.0"
        },
        "timestamp": 1625860964588
    },
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.956732,
                    53.349553
                ]
            },
            "properties": {
                "id": "node/1592206882",
                "gid": "openstreetmap:address:node/1592206882",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/1592206882",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "26345",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Niedersachsen",
                "region_gid": "whosonfirst:region:85682555",
                "region_a": "NI",
                "county": "Landkreis Friesland",
                "county_gid": "whosonfirst:county:102064051",
                "localadmin": "Bockhorn",
                "localadmin_gid": "whosonfirst:localadmin:1377688673",
                "locality": "Bockhorn",
                "locality_gid": "whosonfirst:locality:101806527",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Bockhorn, NI, Deutschland",
                "index": 0
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    8.438347,
                    51.349948
                ]
            },
            "properties": {
                "id": "node/1052209269",
                "gid": "openstreetmap:address:node/1052209269",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/1052209269",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "59939",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Nordrhein-Westfalen",
                "region_gid": "whosonfirst:region:85682513",
                "region_a": "NW",
                "macrocounty": "Arnsberg",
                "macrocounty_gid": "whosonfirst:macrocounty:404227579",
                "county": "Hochsauerlandkreis",
                "county_gid": "whosonfirst:county:102063783",
                "county_a": "HC",
                "localadmin": "Olsberg",
                "localadmin_gid": "whosonfirst:localadmin:1377692267",
                "locality": "Olsberg",
                "locality_gid": "whosonfirst:locality:101839497",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Olsberg, NW, Deutschland",
                "index": 1
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.798891,
                    47.583317
                ]
            },
            "properties": {
                "id": "node/307204052",
                "gid": "openstreetmap:address:node/307204052",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/307204052",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "79618",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Baden-Württemberg",
                "region_gid": "whosonfirst:region:85682567",
                "region_a": "BW",
                "macrocounty": "Freiburg",
                "macrocounty_gid": "whosonfirst:macrocounty:404227543",
                "county": "Lörrach",
                "county_gid": "whosonfirst:county:102063211",
                "county_a": "LR",
                "localadmin": "Rheinfelden (Baden)",
                "localadmin_gid": "whosonfirst:localadmin:1377685769",
                "locality": "Rheinfelden (Baden)",
                "locality_gid": "whosonfirst:locality:101765249",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Rheinfelden (Baden), BW, Deutschland",
                "addendum": {
                    "osm": {
                        "operator": "Deutsche Telekom AG"
                    }
                },
                "index": 2
            }
        }
    ],
    "bbox": [
        7.798891,
        47.583317,
        8.438347,
        53.349553
    ]
}
```

<details>
  <summary>Autocomplete ES query</summary>

```json
{
    "query": {
        "bool": {
            "must": [
                {
                    "multi_match": {
                        "type": "phrase",
                        "query": "12",
                        "fields": [
                            "phrase.default",
                            "phrase.de"
                        ],
                        "analyzer": "peliasQuery",
                        "boost": 1,
                        "slop": 3
                    }
                },
                {
                    "constant_score": {
                        "filter": {
                            "multi_match": {
                                "type": "phrase",
                                "query": "kreisstraße",
                                "fields": [
                                    "name.default",
                                    "name.de"
                                ],
                                "analyzer": "peliasQuery",
                                "boost": 100,
                                "slop": 3
                            }
                        }
                    }
                }
            ],
            "should": [
                {
                    "function_score": {
                        "query": {
                            "match_all": {}
                        },
                        "max_boost": 20,
                        "functions": [
                            {
                                "field_value_factor": {
                                    "modifier": "log1p",
                                    "field": "popularity",
                                    "missing": 1
                                },
                                "weight": 1
                            }
                        ],
                        "score_mode": "first",
                        "boost_mode": "replace"
                    }
                },
                {
                    "function_score": {
                        "query": {
                            "match_all": {}
                        },
                        "max_boost": 20,
                        "functions": [
                            {
                                "field_value_factor": {
                                    "modifier": "log1p",
                                    "field": "population",
                                    "missing": 1
                                },
                                "weight": 3
                            }
                        ],
                        "score_mode": "first",
                        "boost_mode": "replace"
                    }
                }
            ]
        }
    },
    "size": 20,
    "track_scores": true,
    "sort": [
        "_score"
    ]
}
```

</details>

To understand why, I dived into the code and saw that `postcode` was [already mentioned to get acknowledged](https://github.com/pelias/api/blob/master/query/autocomplete_defaults.js#L55), but, for me, it looked like there is something missing. So I extended a scoring for the case the a parsed postcode could be matched by ES:

```json
{
    "geocoding": {
        "version": "0.2",
        "attribution": "http://localhost:3100/attribution",
        "query": {
            "text": "kreisstraße 12, 25795",
            "parser": "pelias",
            "parsed_text": {
                "subject": "12 kreisstraße",
                "street": "kreisstraße",
                "housenumber": "12",
                "postcode": "25795"
            },
            "size": 3,
            "private": false,
            "lang": {
                "name": "German",
                "iso6391": "de",
                "iso6393": "deu",
                "via": "header",
                "defaulted": false
            },
            "querySize": 20
        },
        "warnings": [
            "Invalid Parameter: api_key"
        ],
        "engine": {
            "name": "Pelias",
            "author": "Mapzen",
            "version": "1.0"
        },
        "timestamp": 1625861259553
    },
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    9.077043,
                    54.231885
                ]
            },
            "properties": {
                "id": "Z1A4Xnm",
                "gid": "cw:address:Z1A4Xnm",
                "layer": "address",
                "source": "cw",
                "source_id": "Z1A4Xnm",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "25795",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Schleswig-Holstein",
                "region_gid": "whosonfirst:region:85682517",
                "region_a": "SH",
                "county": "Kreis Dithmarschen",
                "county_gid": "whosonfirst:county:102064119",
                "county_a": "DT",
                "localadmin": "Kirchspielslandgemeinde Heider Umland",
                "localadmin_gid": "whosonfirst:localadmin:1377683411",
                "locality": "Weddingstedt",
                "locality_gid": "whosonfirst:locality:101805125",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Weddingstedt, SH, Deutschland",
                "index": 0
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    7.956732,
                    53.349553
                ]
            },
            "properties": {
                "id": "node/1592206882",
                "gid": "openstreetmap:address:node/1592206882",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/1592206882",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "26345",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Niedersachsen",
                "region_gid": "whosonfirst:region:85682555",
                "region_a": "NI",
                "county": "Landkreis Friesland",
                "county_gid": "whosonfirst:county:102064051",
                "localadmin": "Bockhorn",
                "localadmin_gid": "whosonfirst:localadmin:1377688673",
                "locality": "Bockhorn",
                "locality_gid": "whosonfirst:locality:101806527",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Bockhorn, NI, Deutschland",
                "index": 1
            }
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    8.438347,
                    51.349948
                ]
            },
            "properties": {
                "id": "node/1052209269",
                "gid": "openstreetmap:address:node/1052209269",
                "layer": "address",
                "source": "openstreetmap",
                "source_id": "node/1052209269",
                "name": "Kreisstraße 12",
                "housenumber": "12",
                "street": "Kreisstraße",
                "postalcode": "59939",
                "accuracy": "point",
                "country": "Deutschland",
                "country_gid": "whosonfirst:country:85633111",
                "country_a": "DEU",
                "region": "Nordrhein-Westfalen",
                "region_gid": "whosonfirst:region:85682513",
                "region_a": "NW",
                "macrocounty": "Arnsberg",
                "macrocounty_gid": "whosonfirst:macrocounty:404227579",
                "county": "Hochsauerlandkreis",
                "county_gid": "whosonfirst:county:102063783",
                "county_a": "HC",
                "localadmin": "Olsberg",
                "localadmin_gid": "whosonfirst:localadmin:1377692267",
                "locality": "Olsberg",
                "locality_gid": "whosonfirst:locality:101839497",
                "continent": "Europa",
                "continent_gid": "whosonfirst:continent:102191581",
                "label": "Kreisstraße 12, Olsberg, NW, Deutschland",
                "index": 2
            }
        }
    ],
    "bbox": [
        7.956732,
        51.349948,
        9.077043,
        54.231885
    ]
}
```

<details>
  <summary>New autocomplete ES query when postcode could be parsed</summary>

```json
{
    "query": {
        "bool": {
            "must": [
                {
                    "multi_match": {
                        "type": "phrase",
                        "query": "12",
                        "fields": [
                            "phrase.default",
                            "phrase.de"
                        ],
                        "analyzer": "peliasQuery",
                        "boost": 1,
                        "slop": 3
                    }
                },
                {
                    "constant_score": {
                        "filter": {
                            "multi_match": {
                                "type": "phrase",
                                "query": "kreisstraße",
                                "fields": [
                                    "name.default",
                                    "name.de"
                                ],
                                "analyzer": "peliasQuery",
                                "boost": 100,
                                "slop": 3
                            }
                        }
                    }
                }
            ],
            "should": [
                {
                    "constant_score": {
                        "filter": {
                            "match_phrase": {
                                "address_parts.zip": {
                                    "query": "25795",
                                    "analyzer": "peliasZip"
                                }
                            }
                        },
                        "boost": 2000
                    }
                },
                {
                    "function_score": {
                        "query": {
                            "match_all": {}
                        },
                        "max_boost": 20,
                        "functions": [
                            {
                                "field_value_factor": {
                                    "modifier": "log1p",
                                    "field": "popularity",
                                    "missing": 1
                                },
                                "weight": 1
                            }
                        ],
                        "score_mode": "first",
                        "boost_mode": "replace"
                    }
                },
                {
                    "function_score": {
                        "query": {
                            "match_all": {}
                        },
                        "max_boost": 20,
                        "functions": [
                            {
                                "field_value_factor": {
                                    "modifier": "log1p",
                                    "field": "population",
                                    "missing": 1
                                },
                                "weight": 3
                            }
                        ],
                        "score_mode": "first",
                        "boost_mode": "replace"
                    }
                }
            ]
        }
    },
    "size": 20,
    "track_scores": true,
    "sort": [
        "_score"
    ]
}
```

</details>

