### PR TITLE
Support HTTP connections to Pelias services

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pelias-config": "^5.0.1",
     "pelias-labels": "^1.16.1",
     "pelias-logger": "^1.2.0",
-    "pelias-microservice-wrapper": "^1.7.0",
+    "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
     "pelias-parser": "pelias/parser#remove-unit-type",
     "pelias-query": "^11.0.0",


### PR DESCRIPTION
While the recommended configuration for Pelias has used HTTP communication between services, there are many valid reasons to put each service behind HTTPS.

Because of Node.js's interesting decision to have completely separate and incompatible http and https modules, this has not been a supported configuration out of the box.

However, adding this support is not difficult, and that's what's been done here. Both HTTP and HTTPS service URLs should work seamlessly now.

This support comes from upgrading `pelias-microservice-wrapper` to version `1.10.0`.

Fixes https://github.com/pelias/pelias/issues/839