### PR TITLE
deduplication: improved deduplication of postalcodes

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -59,6 +59,14 @@ function isParentHierarchyDifferent(item1, item2){
   // note: this really shouldn't happen as at least one parent should exist
   if( !isPojo1 || !isPojo2 ){ return false; }
 
+  // special handling of postal codes, which we consider to be strictly
+  // unique within a single country/dependency regardless of the rest of
+  // the hierarchy (ie. we ignore other parent properties)
+  if( item1.layer === 'postalcode' && item2.layer === 'postalcode' ) {
+    parent1 = _.pick(parent1, ['country_id', 'dependency_id']);
+    parent2 = _.pick(parent2, ['country_id', 'dependency_id']);
+  }
+
   // get a numerical placetype 'rank' to use for comparing parent levels
   // note: a rank of Infinity is returned if the item layer is not listed
   // in the $placeTypes array.
@@ -88,7 +96,7 @@ function isParentHierarchyDifferent(item1, item2){
     if (rank > maxRank){ return false; }
 
     // ensure the parent ids are the same for all placetypes
-    return isPropertyDifferent( item1.parent, item2.parent, `${placeType}_id` );
+    return isPropertyDifferent( parent1, parent2, `${placeType}_id` );
   });
 }
 
@@ -215,9 +223,9 @@ function isPropertyDifferent(item1, item2, prop ){
  * ...
  * 11: locality
  * 13: neighbourhood
- * 
+ *
  * note: Infinity is returned if layer not found in array, this is in
- * order to ensure that a high value is returned rather than the 
+ * order to ensure that a high value is returned rather than the
  * default '-1' value returned for misses when using findIndex().
  */
 function getPlaceTypeRank(item) {
@@ -226,7 +234,7 @@ function getPlaceTypeRank(item) {
 }
 
 /**
- * apply unicode normalization, lowercase characters and remove 
+ * apply unicode normalization, lowercase characters and remove
  * diacritics and some punctuation.
  */
 function normalizeString(str){

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -127,6 +127,130 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  // postalcodes with same name and country_a but differing hierarchies should be considered same
+  test('isParentHierarchyDifferent: postalcodes with same country_a', function(t) {
+    var item1 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '456',
+        'postalcode_id': '12345',
+        'country_id': '555',
+        'country_a': 'USA'
+      }
+    };
+    var item2 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '789',
+        'postalcode_id': '67890',
+        'country_id': '555',
+        'country_a': 'USA'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered different');
+    t.end();
+  });
+
+  // postalcodes with same name and dependency_a but differing hierarchies should be considered same
+  test('isParentHierarchyDifferent: postalcodes with same dependency_a', function(t) {
+    var item1 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '456',
+        'postalcode_id': '12345',
+        'dependency_id': '555',
+        'dependency_a': 'PRI'
+      }
+    };
+    var item2 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '789',
+        'postalcode_id': '67890',
+        'dependency_id': '555',
+        'dependency_a': 'PRI'
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered different');
+    t.end();
+  });
+
+  // postalcodes with same name but differing country_a should still be considered different
+  test('isParentHierarchyDifferent: postalcodes with same name, different country_a', function(t) {
+    var item1 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '456',
+        'postalcode_id': '12345',
+        'country_id': '555',
+        'country_a': 'USA'
+      }
+    };
+    var item2 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '789',
+        'postalcode_id': '67890',
+        'country_id': '444',
+        'country_a': 'NZL'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  // postalcodes with differing name but same country_a should still be considered different
+  test('isParentHierarchyDifferent: postalcodes with different name, same country_a', function(t) {
+    var item1 = {
+      name: {
+        default: '10010'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '456',
+        'postalcode_id': '12345',
+        'country_id': '555',
+        'country_a': 'USA'
+      }
+    };
+    var item2 = {
+      name: {
+        default: '90210'
+      },
+      layer: 'postalcode',
+      parent: {
+        'locality_id': '789',
+        'postalcode_id': '67890',
+        'country_id': '555',
+        'country_a': 'USA'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
   test('catch diff name', function(t) {
     var item1 = {
       'name': {


### PR DESCRIPTION
this fairly simple PR ensures that postalcodes are considered unique within their country/dependency.