### PR TITLE
autocomplete: add macrocounty to list of potential admin matching fields

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -106,6 +106,11 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:county:boost': 1,
   'admin:county:cutoff_frequency': 0.01,
 
+  'admin:macrocounty:analyzer': 'peliasAdmin',
+  'admin:macrocounty:field': 'parent.macrocounty.ngram',
+  'admin:macrocounty:boost': 1,
+  'admin:macrocounty:cutoff_frequency': 0.01,
+
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin.ngram',
   'admin:localadmin:boost': 1,

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -20,6 +20,7 @@ module.exports = {
                 'parent.dependency.ngram^1',
                 'parent.macroregion.ngram^1',
                 'parent.region.ngram^1',
+                'parent.macrocounty.ngram^1',
                 'parent.county.ngram^1',
                 'parent.localadmin.ngram^1',
                 'parent.locality.ngram^1',

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -19,6 +19,7 @@ module.exports = {
               'parent.dependency.ngram^1',
               'parent.macroregion.ngram^1',
               'parent.region.ngram^1',
+              'parent.macrocounty.ngram^1',
               'parent.county.ngram^1',
               'parent.localadmin.ngram^1',
               'parent.locality.ngram^1',

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -17,6 +17,7 @@ module.exports = {
             'parent.dependency.ngram^1',
             'parent.macroregion.ngram^1',
             'parent.region.ngram^1',
+            'parent.macrocounty.ngram^1',
             'parent.county.ngram^1',
             'parent.localadmin.ngram^1',
             'parent.locality.ngram^1',


### PR DESCRIPTION
The query "2 Macquarie Street, Sydney" does not currently return [either of these two results](https://pelias.github.io/compare/#/v1/autocomplete?text=2+Macquarie+Street+Parramatta&debug=1) despite [Parramatta](https://en.wikipedia.org/wiki/Parramatta) being a suburb within the greater Metro Sydney Area.

The reason for this is that the [Metro Area is rather large](https://en.wikipedia.org/wiki/Regions_of_Sydney) and so WOF has designated it as a 'macrocounty'.

We're currently not targeting `macrocounty` in the list of fields which are queried for the 'admin portion' of an autocomplete query:

<img width="365" alt="Screenshot 2021-08-12 at 11 04 39" src="https://user-images.githubusercontent.com/738069/129169940-6e478161-3806-4085-b56e-dfc8962d3dfa.png">

With this PR we add `macrocounty` to the existing list:

<img width="401" alt="Screenshot 2021-08-12 at 10 59 36" src="https://user-images.githubusercontent.com/738069/129169901-6d2ffb19-905b-4872-99fe-01fb1a62e8ec.png">

The [macrocounty placetype](https://spelunker.whosonfirst.org/placetypes/macrocounty/) is seldom used, it only has 477 places at time of writing, so this likely won't have any adverse effects.

@Joxit I noticed on that link above that there's a bunch in France, would this change be beneficial/detrimental for you?

- https://pelias.github.io/compare/#/v1/autocomplete?text=2+Macquarie+Street+Sydney&debug=1
- https://pelias.github.io/compare/#/v1/autocomplete?text=2+Macquarie+Street+Parramatta&debug=1