### PR TITLE
debug: clone debug params to ensure they are not mutated before being rendered

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -152,7 +152,7 @@ function setup( peliasConfig, esclient, query, should_execute ){
         }
         logger.debug('[ES response]', docs);
         if (req.clean.enableElasticDebug) {
-          debugLog.push(req, {ES_response: {docs, meta, data}});
+          debugLog.push(req, { ES_response: _.cloneDeep({ docs, meta, data }) });
         }
         next();
       });


### PR DESCRIPTION
When debugging a query today I noticed that the output of `geocoding.debug[x]["controller:search"]["ES_response"].docs` doesn't accurately reflect what is returned from elasticsearch.

It turns out that the objects are being mutated in subsequent steps and the output is deferred until after that, so what we're seeing is not the state of the object at ES response time so much as the state of the objects at the end of the request lifecycle.

This PR simply makes a deep copy of the objects so we render the debug as it was at that moment in time.

The code is wrapped in `if( req.clean.enableElasticDebug )` so I'm not concerned about the perf impact.