### PR TITLE
trace uncaught exceptions in tests

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -4,4 +4,4 @@
 # see https://github.com/pelias/pelias/issues/744
 set -euo pipefail
 
-PELIAS_CONFIG=./test/test-pelias-config.json node test/unit/run.js | npx tap-dot
+PELIAS_CONFIG=./test/test-pelias-config.json node --trace-uncaught test/unit/run.js | npx tap-dot


### PR DESCRIPTION
When running the unit tests, it's possible to get an error without a stack trace.

I suspect the cause is [pelias/mock-logger throwing strings instead of Errors](https://github.com/pelias/mock-logger/blob/master/index.js#L54).

This flag ensures that the correct stack traces are written to the terminal to aid in debugging.