### PR TITLE
Fix minor errors in deduplication debug output

### DIFF
--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -9,7 +9,7 @@ const field = require('../helper/fieldValue');
 const formatLog = (hit) => {
   const name = field.getStringValue(_.get(hit, 'name.default'));
   const zip = field.getStringValue(_.get(hit, 'address_parts.zip'));
-  return [name, zip, hit.id].join(' ');
+  return [name, zip, hit._id].join(' ');
 };
 
 /**

--- a/middleware/dedupe.js
+++ b/middleware/dedupe.js
@@ -9,7 +9,7 @@ const field = require('../helper/fieldValue');
 const formatLog = (hit) => {
   const name = field.getStringValue(_.get(hit, 'name.default'));
   const zip = field.getStringValue(_.get(hit, 'address_parts.zip'));
-  return [name, zip, hit._id].join(' ');
+  return [name, zip, hit._id].filter(Boolean).join(' ');
 };
 
 /**


### PR DESCRIPTION
Yesterday I was investigating some deduplication related behavior, and noticed there was a small error in some deduplication related debug output: the `GID` of the relevant records was not being displayed in debug output because of a reference to an incorrect field.

Deduplication is pretty complicated and confusing, so hopefully someday we can add even more ways to gain insight into what the deduplication logic is doing, but for now this at least fixes a small issue in what we already have. :)