### PR TITLE
Update 'npm-publish' action Ubuntu and Node versions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,13 +24,13 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install node.js 12.x
+      - name: Install Node.js
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}


### PR DESCRIPTION
It looks like Ubuntu 16 based Github Action runners are really going away, so this PR updates the Ubuntu version used for `npm-publish` to Ubuntu 20.

While there, I figured we might as well also update to Node.js 16