### PR TITLE
feat(parser): upgrade pelias-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
-    "pelias-parser": "pelias/parser#remove-unit-type",
+    "pelias-parser": "^2.0.0",
     "pelias-query": "^11.0.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",


### PR DESCRIPTION
As discussed in https://github.com/pelias/api/issues/1550, this PR takes us off a branch of `pelias-parser` and gets us back on the latest published version.

BREAKING CHANGE: upgrades to a new major version of pelias/parser which reverts unit number parsing functionality due to OOM errors.

Additional changes in pelias/parser being brought in:
- https://github.com/pelias/parser/pull/138
- https://github.com/pelias/parser/pull/141
- https://github.com/pelias/parser/pull/142
- https://github.com/pelias/parser/pull/143
- https://github.com/pelias/parser/pull/126

Original commit to pin pelias-parser to a branch:
https://github.com/pelias/api/commit/4061a2fb3b90d1949b5fbc74ac2ab3344a529e2d