### PR TITLE
Add support to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
-    "pelias-parser": "pelias/parser#remove-unit-type",
+    "pelias-parser": "pelias/parser#remove-unit-type-updated",
     "pelias-query": "^11.0.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -72,6 +72,8 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:country_a:boost': 1,
   'admin:country_a:cutoff_frequency': 0.01,
 
+  'admin:dependency_a:field': 'parent.dependency_a',
+
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country.ngram',
   'admin:country:boost': 1,

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -62,6 +62,8 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:country_a:boost': 1,
   'admin:country_a:cutoff_frequency': 0.01,
 
+  'admin:dependency_a:field': 'parent.dependency_a',
+
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country',
   'admin:country:boost': 1,


### PR DESCRIPTION
I noticed that dependencies were often seen as countries, but it is not possible to use the `boundary.country` parameter to filter searches for documents that are located in dependencies.

Now the view `boundary_country` uses a `multi_match` query to match both `country_a` and `dependency_a`.

`npm install` is failing because the branch `pelias/parser#remove-unit-type` does not exists. So I sync my branch with `origin/parser-remove-unit-type-updated`
 
needs pelias/query#129