### PR TITLE
Require Node.js 12 or newer in `package.json` engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/pelias/api/issues"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@hapi/joi": "^16.0.1",


### PR DESCRIPTION
Node.js 10 has reached EOL, so this PR updates `package.json` to make it clear that this older version is no longer supported.

It's worth noting that the `engines` field is [only advisory](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#engines), so this won't break anything, but will cause `npm` to print a warning when running `npm install`.