### PR TITLE
Return 502 response code for service timeouts instead of 400

### DIFF
--- a/middleware/sendJSON.js
+++ b/middleware/sendJSON.js
@@ -2,13 +2,15 @@ const _ = require('lodash');
 const es = require('elasticsearch');
 const logger = require( 'pelias-logger' ).get( 'api' );
 const PeliasParameterError = require('../sanitizer/PeliasParameterError');
+const PeliasTimeoutError = require('../sanitizer/PeliasTimeoutError');
 
 function isParameterError(error) {
   return error instanceof PeliasParameterError;
 }
 
 function isTimeoutError(error) {
-  return error instanceof es.errors.RequestTimeout;
+  return error instanceof PeliasTimeoutError ||
+         error instanceof es.errors.RequestTimeout;
 }
 
 function isElasticsearchError(error) {

--- a/sanitizer/PeliasParameterError.js
+++ b/sanitizer/PeliasParameterError.js
@@ -3,9 +3,7 @@ class PeliasParameterError extends Error {
     super(message);
   }
 
-  // syntax had to be changed due to jshint bug
-  // https://github.com/jshint/jshint/issues/3358
-  ['toString']() {
+  toString() {
     return this.message;
   }
 

--- a/sanitizer/PeliasTimeoutError.js
+++ b/sanitizer/PeliasTimeoutError.js
@@ -1,0 +1,18 @@
+// Error subclass for timeouts contacting Pelias services
+class PeliasTimeoutError extends Error {
+  constructor(message = '') {
+    super(message);
+  }
+
+  // syntax had to be changed due to jshint bug
+  // https://github.com/jshint/jshint/issues/3358
+  ['toString']() {
+    return this.message;
+  }
+
+  toJSON() {
+    return this.message;
+  }
+}
+
+module.exports = PeliasTimeoutError;

--- a/sanitizer/PeliasTimeoutError.js
+++ b/sanitizer/PeliasTimeoutError.js
@@ -4,9 +4,7 @@ class PeliasTimeoutError extends Error {
     super(message);
   }
 
-  // syntax had to be changed due to jshint bug
-  // https://github.com/jshint/jshint/issues/3358
-  ['toString']() {
+  toString() {
     return this.message;
   }
 

--- a/sanitizer/sanitizeAll.js
+++ b/sanitizer/sanitizeAll.js
@@ -21,25 +21,25 @@ function sanitize( req, sanitizers ){
       req.errors = req.errors.concat( sanity.errors );
     }
 
-    // all errors must be returned as PeliasParameterError object to trigger HTTP 400 errors
-    req.errors = req.errors.map(function(error) {
-      // replace any existing Error objects with the right class
-      // preserve the message and stack trace
-      if (error instanceof Error) {
-        const new_error = new PeliasParameterError(error.message);
-        new_error.stack = error.stack;
-        return new_error;
-      } else {
-        return new PeliasParameterError(error);
-      }
-    });
-
     // if warnings occurred then set them
     // on the req object.
     if( sanity.warnings.length ){
       req.warnings = req.warnings.concat( sanity.warnings );
     }
   }
+
+  // all errors must be returned as PeliasParameterError object to trigger HTTP 400 errors
+  req.errors = req.errors.map(function(error) {
+    // replace any existing Error objects with the right class
+    // preserve the message and stack trace
+    if (error instanceof Error) {
+      const new_error = new PeliasParameterError(error.message);
+      new_error.stack = error.stack;
+      return new_error;
+    } else {
+      return new PeliasParameterError(error);
+    }
+  });
 }
 
 // Adds to goodParameters every acceptable parameter passed through API call

--- a/sanitizer/sanitizeAll.js
+++ b/sanitizer/sanitizeAll.js
@@ -1,4 +1,13 @@
 const PeliasParameterError = require('./PeliasParameterError');
+const PeliasTimeoutError = require('../sanitizer/PeliasTimeoutError');
+
+function getCorrectErrorType(message) {
+  if (message.includes( 'Timeout')) {
+    return new PeliasTimeoutError(message);
+  } else {
+    return new PeliasParameterError(message);
+  }
+}
 
 function sanitize( req, sanitizers ){
   // init an object to store clean (sanitized) input parameters if not initialized
@@ -28,16 +37,16 @@ function sanitize( req, sanitizers ){
     }
   }
 
-  // all errors must be returned as PeliasParameterError object to trigger HTTP 400 errors
+  // all errors must be classified as Timeout or Parameter errors to trigger the correct HTTP response code
   req.errors = req.errors.map(function(error) {
     // replace any existing Error objects with the right class
     // preserve the message and stack trace
     if (error instanceof Error) {
-      const new_error = new PeliasParameterError(error.message);
+      const new_error = getCorrectErrorType(error.message);
       new_error.stack = error.stack;
       return new_error;
     } else {
-      return new PeliasParameterError(error);
+      return getCorrectErrorType(error);
     }
   });
 }

--- a/test/unit/middleware/sendJSON.js
+++ b/test/unit/middleware/sendJSON.js
@@ -1,5 +1,6 @@
 const es = require('elasticsearch');
 const middleware = require('../../../middleware/sendJSON');
+const PeliasTimeoutError = require('../../../sanitizer/PeliasTimeoutError');
 
 module.exports.tests = {};
 
@@ -197,6 +198,24 @@ module.exports.tests.search_phase_execution_exception = function(test, common) {
     res.status = function( code ){
       return { json: function( body ){
         t.equal( code, 500, 'Internal Server Error' );
+        t.deepEqual( body, res.body, 'body set' );
+        t.end();
+      }};
+    };
+
+    middleware(null, res);
+  });
+};
+
+module.exports.tests.service_timeout_exception = function(test, common) {
+  test('service timeout exception', function(t) {
+    var res = { body: { geocoding: {
+      errors: [ new PeliasTimeoutError('Timeout: could not reach Placeholder service') ]
+    }}};
+
+    res.status = function( code ){
+      return { json: function( body ){
+        t.equal( code, 502, 'Bad Gateway' );
         t.deepEqual( body, res.body, 'body set' );
         t.end();
       }};

--- a/test/unit/middleware/sendJSON.js
+++ b/test/unit/middleware/sendJSON.js
@@ -1,5 +1,5 @@
-var es = require('elasticsearch'),
-    middleware = require('../../../middleware/sendJSON');
+const es = require('elasticsearch');
+const middleware = require('../../../middleware/sendJSON');
 
 module.exports.tests = {};
 

--- a/test/unit/sanitizer/sanitizeAll.js
+++ b/test/unit/sanitizer/sanitizeAll.js
@@ -1,5 +1,6 @@
 var sanitizeAll = require('../../../sanitizer/sanitizeAll');
 const PeliasParameterError = require('../../../sanitizer/PeliasParameterError');
+const PeliasTimeoutError = require('../../../sanitizer/PeliasTimeoutError');
 
 module.exports.tests = {};
 
@@ -97,7 +98,7 @@ module.exports.tests.all = function(test, common) {
     t.end();
   });
 
-  test('Error objects should be converted to correct type', function(t) {
+  test('Normal error objects should be converted to PeliasParameterError type', function(t) {
     var req = {};
     var sanitizers = {
       'first': {
@@ -125,6 +126,33 @@ module.exports.tests.all = function(test, common) {
 
   });
 
+  test('Timeout error should be converted to PeliasTimeoutError type', function(t) {
+    var req = {};
+    const error_message = 'Timeout: could not reach Placeholder service';
+    var sanitizers = {
+      'first': {
+        sanitize: function(){
+          req.clean.a = 'first sanitizer';
+          return {
+            errors: [new Error(error_message)],
+            warnings: []
+          };
+        }
+      }
+    };
+
+    var expected_req = {
+      clean: {
+        a: 'first sanitizer'
+      },
+      errors: [ new PeliasTimeoutError(error_message) ],
+      warnings: []
+    };
+
+    sanitizeAll.runAllChecks(req, sanitizers);
+    t.deepEquals(req, expected_req);
+    t.end();
+  });
 
   test('req.query should be passed to individual sanitizers when available', function(t) {
     var req = {


### PR DESCRIPTION
Pelias has always had a bit of trouble selecting the right HTTP response code in the face of various error states.

Up until #1231 in 2018, we reported almost all timeouts from slow Elasticsearch queries as HTTP 400 errors, not something in the more appropriate 5XX range. This suggests to consumers of the Pelias API that they made a mistake in calling Pelias, instead of the reality that Pelias was just being slow.

Even after that change, it turns out we were _still_ classifying timeouts to other Pelias services (like Placeholder or Interpolation) as 400 errors instead of 5XX. All the Pelias services are generally very fast, so this was not nearly as much of an issue, but timeouts do happen.

This PR adds additional handling to detect timeout errors and give them their own subclass of `Error` that can be treated appropriately everywhere. Timeouts waiting for any Pelias service will now return HTTP 502 errors just like a timeout waiting for Elasticsearch.

_There's a bit of code cleanup included in this PR. It's all a no-op and the main functional change can be found in 95bda7b8_