### PR TITLE
unicode: fix bug preventing unicode normalization in some cases

### DIFF
--- a/sanitizer/_text.js
+++ b/sanitizer/_text.js
@@ -15,7 +15,7 @@ function _sanitize( raw, clean ){
   let text = unicode.normalize(raw.text);
 
   // remove superfluous whitespace and quotes
-  text = _.trim(_.trim(raw.text), QUOTES);
+  text = _.trim(_.trim(text), QUOTES);
 
   // validate input 'text'
   if( !_.isString(text) || _.isEmpty(text) ){

--- a/test/unit/sanitizer/_text.js
+++ b/test/unit/sanitizer/_text.js
@@ -154,6 +154,17 @@ it again and again until we reach our destination.` };
     t.deepEquals(messages.warnings, [`param 'text' truncated to 140 characters`]);
     t.end();
   });
+
+  test('strips emoji', (t) => {
+    const raw = { text: 'abc' + '👩‍❤️‍👩'.repeat(200) };
+    const clean = {};
+    const messages = sanitizer.sanitize(raw, clean);
+
+    t.equals(clean.text, 'abc');
+    t.deepEquals(messages.errors, [], 'no errors');
+    t.deepEquals(messages.warnings, []);
+    t.end();
+  });
 };
 
 module.exports.all = (tape, common) => {

--- a/test/unit/sanitizer/_text_pelias_parser.js
+++ b/test/unit/sanitizer/_text_pelias_parser.js
@@ -20,7 +20,7 @@ module.exports.tests.text_parser = function (test, common) {
   });
 
   let cases = [];
-  
+
   // USA queries
   cases.push(['soho, new york, NY', {
     subject: 'soho',
@@ -322,7 +322,7 @@ module.exports.tests.text_parser = function (test, common) {
   cases.push(['New York', { subject: 'New York' }, true]);
   cases.push(['New York N', { subject: 'New York' }, true]);
   cases.push(['New York NY', { subject: 'New York' }, true]);
-  
+
   cases.push(['B', { subject: 'B' }, true]);
   cases.push(['Be', { subject: 'Be' }, true]);
   cases.push(['Ber', { subject: 'Ber' }, true]);
@@ -431,6 +431,17 @@ it again and again until we reach our destination.` };
     t.equals(clean.text.length, 140);
     t.deepEquals(messages.errors, [], 'no errors');
     t.deepEquals(messages.warnings, [`param 'text' truncated to 140 characters`]);
+    t.end();
+  });
+
+  test('strips emoji', (t) => {
+    const raw = { text: 'abc' + '👩‍❤️‍👩'.repeat(200) };
+    const clean = {};
+    const messages = sanitizer.sanitize(raw, clean);
+
+    t.equals(clean.text, 'abc');
+    t.deepEquals(messages.errors, [], 'no errors');
+    t.deepEquals(messages.warnings, []);
     t.end();
   });
 };


### PR DESCRIPTION
I just caught a very subtle bug which has been in the codebase for 2 years now.

This easily confused variable name caused the effects of the `unicode.normalize(raw.text)` line above to be ignored 😱 

We didn't notice this because it's implemented correctly in `sanitizer/_text_pelias_parser.js` but incorrectly in `sanitizer/_text.js`.

You can see that for the `/v1/search` endpoint it's possible to still send emoji to `libpostal`:

<img width="305" alt="Screenshot 2021-11-02 at 10 32 11" src="https://user-images.githubusercontent.com/738069/139821489-4088a4cf-66c8-40c2-9731-673cad2324e1.png">

I suspect that we have been falling back to using the `pelias` parser more often than needed because in these cases its more likely that `libpostal` will reject the string containing emoji.
