### PR TITLE
debug: code cleanup

### DIFF
--- a/helper/debug.js
+++ b/helper/debug.js
@@ -1,50 +1,34 @@
 const _ = require('lodash');
-const debugEnabled = (req) => _.get(req, 'clean.enableDebug') === true;
-const validMessage = (msg) => _.isString(msg) && !_.isEmpty(msg);
 
 class Debug {
   constructor(moduleName) {
     this.name = moduleName || 'unnamed module';
   }
 
-  getValueAndDest(req, args) {
-    if (args.length === 0) {
-      return { dest: req, value: undefined };
-    }
-
-    if (args.length === 1) {
-      return { dest: req, value: args[0] };
-    }
-
-    if (args.length === 2) {
-      return { dest: args[0], value: args[1] };
-    }
-
-    throw new Error('Too many arguments to function');
+  static isEnabled(req) {
+    return _.get(req, 'clean.enableDebug') === true;
   }
 
-  // two variants
-  // - push(req, value)
-  //    checks req.clean.enableDebug and if true, pushes values onto req.debug
-  // - push(req, dest, value)
-  //    checks req.clean.enableDebug and if true, pushes values onto dest.debug
-  push(req, ...args) {
-    if (!debugEnabled(req)) { return; }
+  static validMessage(msg) {
+    return _.isString(msg) && !_.isEmpty(msg);
+  }
 
-    const { value, dest } = this.getValueAndDest(req, args);
-    if (!_.isArray(dest.debug)) { dest.debug = []; }
+  push(req, value) {
+    if (!Debug.isEnabled(req)) { return; }
+
+    if (!_.isArray(req.debug)) { req.debug = []; }
 
     if (_.isFunction(value)) {
-      dest.debug.push({ [this.name]: value() });
+      req.debug.push({ [this.name]: value() });
     } else {
-      dest.debug.push({ [this.name]: value });
+      req.debug.push({ [this.name]: value });
     }
   }
 
   beginTimer(req, message) {
-    if (!debugEnabled(req)) { return; }
+    if (!Debug.isEnabled(req)) { return; }
 
-    if (validMessage(message)) {
+    if (Debug.validMessage(message)) {
       this.push(req, `Timer Began. ${message}`);
     } else {
       this.push(req, `Timer Began.`);
@@ -54,12 +38,12 @@ class Debug {
   }
 
   stopTimer(req, timer, message) {
-    if (!debugEnabled(req)) { return; }
+    if (!Debug.isEnabled(req)) { return; }
 
     // measure elapsed duration
     const elapsed = _.isFinite(timer) ? (Date.now() - timer) : -1;
 
-    if (validMessage(message)) {
+    if (Debug.validMessage(message)) {
       this.push(req, `Timer Stopped. ${elapsed} ms. ${message}`);
     } else {
       this.push(req, `Timer Stopped. ${elapsed} ms`);

--- a/helper/debug.js
+++ b/helper/debug.js
@@ -1,74 +1,70 @@
 const _ = require('lodash');
+const debugEnabled = (req) => _.get(req, 'clean.enableDebug') === true;
+const validMessage = (msg) => _.isString(msg) && !_.isEmpty(msg);
 
 class Debug {
-  constructor(moduleName){
+  constructor(moduleName) {
     this.name = moduleName || 'unnamed module';
   }
 
   getValueAndDest(req, args) {
     if (args.length === 0) {
-      return {dest: req, value: undefined};
-    } 
+      return { dest: req, value: undefined };
+    }
 
     if (args.length === 1) {
-      return {dest: req, value: args[0]};
-    } 
-    
+      return { dest: req, value: args[0] };
+    }
+
     if (args.length === 2) {
-      return {dest: args[0], value: args[1]};
+      return { dest: args[0], value: args[1] };
     }
 
     throw new Error('Too many arguments to function');
   }
 
   // two variants
-  // - push(req, value) 
+  // - push(req, value)
   //    checks req.clean.enableDebug and if true, pushes values onto req.debug
-  // - push(req, dest, value) 
+  // - push(req, dest, value)
   //    checks req.clean.enableDebug and if true, pushes values onto dest.debug
-  push(req, ...args){
+  push(req, ...args) {
+    if (!debugEnabled(req)) { return; }
+
     const { value, dest } = this.getValueAndDest(req, args);
-    
-    if (!req || _.isEmpty(req.clean) || !req.clean.enableDebug){
-      return;
-    }
-    dest.debug = dest.debug || [];
-    switch(typeof value) {
-      case 'function':
-        dest.debug.push({[this.name]: value()});
-        break;
-      default:
-        dest.debug.push({[this.name]: value});
+    if (!_.isArray(dest.debug)) { dest.debug = []; }
+
+    if (_.isFunction(value)) {
+      dest.debug.push({ [this.name]: value() });
+    } else {
+      dest.debug.push({ [this.name]: value });
     }
   }
 
-  beginTimer(req, debugMsg){
-     if (req && !_.isEmpty(req.clean) && req.clean.enableDebug){
-       // debugMsg is optional
-       this.push(req, () => {
-         if (debugMsg){
-           return `Timer Began. ${debugMsg}`;
-         } else {
-           return `Timer Began`;
-         }
-       });
-       return Date.now();
-     }
-   }
+  beginTimer(req, message) {
+    if (!debugEnabled(req)) { return; }
 
-  stopTimer(req, startTime, debugMsg){
-    if (req && !_.isEmpty(req.clean) && req.clean.enableDebug){
-      let timeElapsed = Date.now() - startTime;
-        this.push(req, () => {
-          if (debugMsg){
-            return `Timer Stopped. ${timeElapsed} ms. ${debugMsg}`;
-          } else {
-            return `Timer Stopped. ${timeElapsed} ms`;
-          }
-        });
-      }
+    if (validMessage(message)) {
+      this.push(req, `Timer Began. ${message}`);
+    } else {
+      this.push(req, `Timer Began.`);
     }
 
+    return Date.now();
+  }
+
+  stopTimer(req, timer, message) {
+    if (!debugEnabled(req)) { return; }
+
+    // measure elapsed duration
+    const elapsed = _.isFinite(timer) ? (Date.now() - timer) : -1;
+
+    if (validMessage(message)) {
+      this.push(req, `Timer Stopped. ${elapsed} ms. ${message}`);
+    } else {
+      this.push(req, `Timer Stopped. ${elapsed} ms`);
+    }
+  }
 }
 
 module.exports = Debug;

--- a/middleware/confidenceScoreFallback.js
+++ b/middleware/confidenceScoreFallback.js
@@ -199,8 +199,14 @@ function checkFallbackOccurred(req, hit) {
     );
   });
 
-  if (res) {
-    debugLog.push(req, hit, {'fallback rule matched': res});
+  // see: https://github.com/pelias/api/pull/1436
+  if (Debug.isEnabled(req) && res) {
+    if (!_.isArray(hit.debug)) { hit.debug = []; }
+    hit.debug.push({
+      'middleware:confidenceScoreFallback': {
+        'fallback rule matched': res
+      }
+    });
   }
 
   return !!res;

--- a/test/unit/helper/debug.js
+++ b/test/unit/helper/debug.js
@@ -96,25 +96,6 @@ module.exports.tests.debug = function(test, common) {
     t.end();
   });
 
-  test('Push messages to other object if enableDebug is true', (t) => {
-    const debugLog = new Debug('debugger');
-    const req = {
-      clean: {
-        enableDebug: true
-      }
-    };
-
-    const hit = {};
-    const expected_req = [
-      {
-        debugger: 'This should be pushed'
-      },
-    ];
-    debugLog.push(req, hit, 'This should be pushed');
-    t.deepEquals(hit.debug, expected_req);
-    t.end();
-  });
-
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
small cosmetic refactor:

- moved `debugEnabled()` functionality to a lambda, simplified usage
- for the `push` method, move the call to `getValueAndDest` below the enabled check as it was unused before then (perf+)
- a guard condition for `stopTimer` for the case where the unix time passed in is invalid (this will print `-1`).
- push strings instead of functions to `dest.debug`
- refactor `switch` statement with one `case` to an `if/else`
- formatting and whitespace fixes

In a second commit:

- remove the variadic function definition for `push()`, previously the function would accept either one, two or three arguments and in the case of three it would use the second argument as the destination of the 'push'. In practise this seems to have ~~never been used~~ only been used in one place and adds complexity to the code.

@orangejulius regarding the second commit, do you remember why this exists and why `confidenceScoreFallback.js` would be using the `Debug` helper to push onto `$hit` instead of `$req`? [edit] agh this https://github.com/pelias/api/pull/1436