### PR TITLE
pelias-parser: print parser solutions in API debug output

### DIFF
--- a/sanitizer/sanitizeAll.js
+++ b/sanitizer/sanitizeAll.js
@@ -37,7 +37,7 @@ function sanitize( req, sanitizers ){
   const params = req.query || {};
 
   for (let s in sanitizers) {
-    var sanity = sanitizers[s].sanitize( params, req.clean );
+    var sanity = sanitizers[s].sanitize( params, req.clean, req );
 
     // if errors occurred then set them
     // on the req object.


### PR DESCRIPTION
The `pelias-parser` CLI has a nice debug output of all the solutions generated, however this isn't available via the API debug view, this is annoying since it requires copy->pasting the input across to the terminal to inspect the parser behaviour.

In the past I thought we couldn't really take advantage of the `Debug` functionality in the `sanitizer/*` modules because we don't have access to `req` like we do in the `middleware/*` modules.

The minor change I made to `sanitizer/sanitizeAll.js` in this PR exposes the `req` param to all sanitisers in a backward compatible way.

The rest of this PR is an implementation of that workflow where we use the same logic from the parser CLI to print a concise summary of each solution.

<img width="524" alt="Screenshot 2021-11-15 at 14 00 44" src="https://user-images.githubusercontent.com/738069/141786339-bfac04bd-a5e2-4213-b1f0-1b72bd5832b1.png"> 