### PR TITLE
Pin to an exact pelias-parser version (2.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
-    "pelias-parser": "^2.0.0",
+    "pelias-parser": "2.1.0",
     "pelias-query": "^11.0.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",


### PR DESCRIPTION
Historically we've specified most Pelias NPM dependency versions using the caret (`^`) range, but because the Pelias Parser can cause differences in acceptance-test results for any change (minor or even bug fix), we've kept that dependency in particular pinned to a specific version so we can control upgrades more carefully.

Recently, we were on a [hotfix branch](https://github.com/pelias/api/pull/1531) of the parser, but while switching back , we switched to [using a caret range](https://github.com/pelias/api/pull/1565).

While manually bumping the version on a frequent basis is a bit annoying, it helps avoid any chance that unexpected or untested parser changes will find their way into the API releases.

This change brings us back to a pin of the current latest version of the Pelias Parser.