### PR TITLE
Upgrade to pelias-parser-2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
-    "pelias-parser": "2.1.0",
+    "pelias-parser": "2.2.0",
     "pelias-query": "^11.0.0",
     "pelias-sorting": "^1.2.0",
     "predicates": "^2.0.0",


### PR DESCRIPTION
This includes a new Parser circuit breaker that should prevent the parser from taking huge amounts of time or memory to parse very complex (but usually nonsensical) inputs.

See https://github.com/pelias/parser/pull/157 for more info.