### PR TITLE
Fix category sanitizer for new call format

### DIFF
--- a/sanitizer/_categories.js
+++ b/sanitizer/_categories.js
@@ -7,7 +7,7 @@ const WARNINGS = {
 };
 
 // validate inputs, convert types and apply defaults
-function _sanitize (raw, clean, validator) {
+function _sanitize (raw, clean, req, validator) {
   validator = validator || allValidValidator;
 
   // error & warning messages

--- a/sanitizer/_geonames_deprecation.js
+++ b/sanitizer/_geonames_deprecation.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
 
 const coarse_reverse_message ='coarse /reverse does not support geonames. See https://github.com/pelias/pelias/issues/675 for more info';
 
-function _sanitize( raw, clean, opts ) {
+function _sanitize( raw, clean ) {
   // error & warning messages
   const messages = { errors: [], warnings: [] };
 

--- a/test/unit/sanitizer/_categories.js
+++ b/test/unit/sanitizer/_categories.js
@@ -89,7 +89,7 @@ module.exports.tests.valid_categories = function(test, common) {
       clean: { }
     };
 
-    var messages = sanitizer.sanitize(req.query, req.clean, validCategories);
+    var messages = sanitizer.sanitize(req.query, req.clean, req, validCategories);
 
     t.deepEqual(req.clean.categories, ['food'], 'categories should contain food');
     t.deepEqual(messages.errors, [], 'no error returned');
@@ -110,7 +110,7 @@ module.exports.tests.valid_categories = function(test, common) {
     };
     var expectedCategories = ['food', 'health'];
 
-    var messages = sanitizer.sanitize(req.query, req.clean, validCategories);
+    var messages = sanitizer.sanitize(req.query, req.clean, req, validCategories);
 
     t.deepEqual(req.clean.categories, expectedCategories,
                 'clean.categories should be an array with proper values');
@@ -145,7 +145,7 @@ module.exports.tests.invalid_categories = function(test, common) {
       ]
     };
 
-    var messages = sanitizer.sanitize(req.query, req.clean, validCategories);
+    var messages = sanitizer.sanitize(req.query, req.clean, req, validCategories);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
     t.deepEqual(req.clean.categories, [], 'empty categories array should be defined');
@@ -166,7 +166,7 @@ module.exports.tests.invalid_categories = function(test, common) {
       ]
     };
 
-    var messages = sanitizer.sanitize(req.query, req.clean, validCategories);
+    var messages = sanitizer.sanitize(req.query, req.clean, req, validCategories);
 
     t.deepEqual(messages, expected_messages, 'error with message returned');
     t.deepEqual(req.clean.categories, [], 'empty categories array should be defined');


### PR DESCRIPTION
It turns out the changes to the parameters for sanitizer functions in #1583 wasn't _quite_ backwards compatible.

## What broke?

The `categories` parameter sanitizer supports taking a 3rd parameter that defines how to determine valid categories. If there's only two parameters, it uses a default function that always returns true.

We intentionally haven't documented the categories parameter because it's not really done, and the categories mapping is not finalized. As a result almost no one uses it.

However, if they did use it, and passed in a category, they could cause the API to generate a 500 error.

This is no problem to fix, just expect the 3rd parameter to be the `req` object, and the 4th parameter, if we ever even use it, is now that category validation function.

## Aside: commentary on the categories sanitizer code and parameter

Realistically, the design here probably isn't useful, I'm not sure how we'd want to pass in a validation function in practice. I thought a lot about removing this code.

There's also some nearby code from https://github.com/pelias/api/pull/1401 that is effectively a second categories sanitizer _just_ for the place endpoint. If we ever take action on https://github.com/pelias/api/issues/1405 we'd probably end up rewriting all of this 🤷

## Thoughts on testing

Finally, I checked through all the other sanitizers to see if any might be affected similarly to this one. I don't think so, but I did clean up one unused parameter to another little used sanitizer.

I'm trying to think of an easy way for us to have caught this error. It showed up in the acceptance tests, but only for the little-used place endpoint tests, which we basically ignore.

It didn't cause any unit tests to fail, and the `ciao` tests (if we ran them regularly), wouldn't have currently caught it.

What should we add to our testing to catch stuff like this?