### PR TITLE
Support any casing for GID sources and layers

### DIFF
--- a/helper/decode_gid.js
+++ b/helper/decode_gid.js
@@ -10,10 +10,13 @@ function decodeGID(gid) {
     return;
   }
 
+  const source = parts[0].toLowerCase();
+  const layer = parts[1].toLowerCase();
+
   // empty strings and other invalid values are expected to be handled by the caller
   return {
-    source: parts[0],
-    layer: parts[1],
+    source: source,
+    layer: layer,
     id: parts.slice(2).join(':'),
   };
 }

--- a/test/unit/sanitizer/_ids.js
+++ b/test/unit/sanitizer/_ids.js
@@ -155,6 +155,22 @@ test('ids: valid short input (openaddresses)', function(t) {
     t.deepEqual( clean.ids, expected_ids, 'osm has node: or way: in id field');
     t.end();
   });
+
+  test('ids: valid capitalized input (Openstreetmap)', function(t) {
+    var raw = { ids: 'Openstreetmap:venue:node:500' };
+    var clean = {};
+    var expected_ids = [{
+      source: 'openstreetmap',
+      layer: 'venue',
+      id: 'node:500',
+    }];
+
+    var messages = sanitizer.sanitize( raw, clean );
+
+    t.deepEqual( messages.errors, [], ' no errors - should be the same as lowercase');
+    t.deepEqual( clean.ids, expected_ids, 'osm has node: or way: in id field');
+    t.end();
+  });
 };
 
 module.exports.tests.multiple_ids = function(test, common) {


### PR DESCRIPTION
We have always supported any combination of uppercase or lowercase for the `sources` and `layers` parameters.

However, the `ids` parameter to the `/v1/place` endpoint has required that the GID be written in lowercase.

While it seems odd that anyone would ever send Pelias a GID in any format except what Pelias generates, apparently this does happen.

Lowercasing the source and layer components (but not the ID part) of a GID seems like a nice thing to do, so we might as well.