### PR TITLE
refactor controller/markdownToHtml.js module

### DIFF
--- a/controller/markdownToHtml.js
+++ b/controller/markdownToHtml.js
@@ -1,32 +1,29 @@
-var markdown = require('markdown').markdown;
-var fs = require('fs');
+const markdown = require('markdown').markdown;
+const fs = require('fs');
 
-function setup(peliasConfig, markdownFile){
+function setup(peliasConfig, markdownFile) {
 
-  const text = `
-  # Pelias API
-  ### Version: [${peliasConfig.version}](https://github.com/pelias/api/releases)
-  ${fs.readFileSync( markdownFile, 'utf8')}`
-  
+  // read markdown
+  const md = fs.readFileSync(markdownFile, 'utf8').trim();
+
+  // convert to HTML
   const html = `
-  <!DOCTYPE html>
-  <html lang="en">
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <title>Pelias Geocoder</title>
     <style>html { font-family:monospace; }</style>
   </head>
   <body>
-    ${markdown.toHTML(text)}
+    ${markdown.toHTML(md)}
   </body>
-  </html>`
+</html>`.trim();
 
-
-  function controller( req, res ) {
+  // send HTML
+  return function controller(req, res) {
     res.send(html);
-  }
-
-  return controller;
+  };
 }
 
 module.exports = setup;

--- a/controller/markdownToHtml.js
+++ b/controller/markdownToHtml.js
@@ -7,7 +7,7 @@ function setup(peliasConfig, markdownFile){
   var text = '# Pelias API\n';
   text += '### Version: [' + peliasConfig.version + '](https://github.com/pelias/api/releases)\n';
   text += fs.readFileSync( markdownFile, 'utf8');
-  var html = styleString + markdown.toHTML(text);
+  var html = '<html><body>'+styleString + markdown.toHTML(text)+'</body></html>';
 
   function controller( req, res ) {
     if (req.accepts('html')) {

--- a/controller/markdownToHtml.js
+++ b/controller/markdownToHtml.js
@@ -3,22 +3,27 @@ var fs = require('fs');
 
 function setup(peliasConfig, markdownFile){
 
-  var styleString = '<style>html{font-family:monospace}</style>';
-  var text = '# Pelias API\n';
-  text += '### Version: [' + peliasConfig.version + '](https://github.com/pelias/api/releases)\n';
-  text += fs.readFileSync( markdownFile, 'utf8');
-  var html = '<html><body>'+styleString + markdown.toHTML(text)+'</body></html>';
+  const text = `
+  # Pelias API
+  ### Version: [${peliasConfig.version}](https://github.com/pelias/api/releases)
+  ${fs.readFileSync( markdownFile, 'utf8')}`
+  
+  const html = `
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Pelias Geocoder</title>
+    <style>html { font-family:monospace; }</style>
+  </head>
+  <body>
+    ${markdown.toHTML(text)}
+  </body>
+  </html>`
+
 
   function controller( req, res ) {
-    if (req.accepts('html')) {
-      res.send(html);
-      return;
-    }
-    // default behaviour
-    res.json({
-      markdown: text,
-      html: html
-    });
+    res.send(html);
   }
 
   return controller;

--- a/public/apiDoc.md
+++ b/public/apiDoc.md
@@ -1,1 +1,4 @@
+# Pelias API
+### Version: [1.0](https://github.com/pelias/api/releases)
+
 ## [View our documentation on GitHub](https://github.com/pelias/documentation/)

--- a/public/attribution.md
+++ b/public/attribution.md
@@ -1,3 +1,6 @@
+# Pelias API
+### Version: [1.0](https://github.com/pelias/api/releases)
+
 ## Attribution
 * Geocoding by [Pelias](https://pelias.io).
 * Data from

--- a/test/unit/controller/index.js
+++ b/test/unit/controller/index.js
@@ -10,30 +10,11 @@ module.exports.tests.interface = function(test, common) {
   });
 };
 
-module.exports.tests.info_json = function(test, common) {
-  test('returns server info in json', function(t) {
-    var controller = setup({}, './public/attribution.md');
-    var req = {
-      accepts: function (format) {
-        t.equal(format, 'html', 'check for Accepts:html');
-        return false;
-      }
-    };
-    var res = { json: function( json ){
-      t.equal(typeof json, 'object', 'returns json');
-      t.assert(json.hasOwnProperty('markdown'), 'return object contains markdown property');
-      t.assert(json.hasOwnProperty('html'), 'return object contains html property');
-      t.end();
-    }};
-    controller( req, res );
-  });
-};
-
 module.exports.tests.info_html = function(test, common) {
   test('returns server info in html', function(t) {
     var filePath = './foo.md';
 
-    var style = '<style>html{font-family:monospace}</style>';
+    var style = '<style>html { font-family:monospace; }</style>';
     var mockText = 'this text should show up in the html content';
     var fsMock = {
       readFileSync: function (path, format) {
@@ -56,8 +37,8 @@ module.exports.tests.info_html = function(test, common) {
     };
     var res = { send: function( content ){
       t.equal(typeof content, 'string', 'returns string');
-      t.assert(content.indexOf(style) === 0, 'style set');
-      t.assert(content.indexOf(mockText) !== -1, 'file content added');
+      t.assert(content.includes(style), 'style set');
+      t.assert(content.includes(mockText), 'file content added');
       t.end();
     }};
     controller( req, res );


### PR DESCRIPTION
authored by @Dhananjay-JSR this PR replaces https://github.com/pelias/api/pull/1598.

this PR makes several fixes:
- reformat the output to serve valid HTML
- use [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to make the markdown and html code more legible.
- use a standard HTML5 boilerplate with a DOCTYPE, TITLE etc.
- remove the `styleString` variable and instead just write the style info inline in the `<head><style>`
- clean up the controller code, removing the content negotiation code which wasn't being used
- fix/clean up the unit test code.

Thanks to @Dhananjay-JSR for this contribution 🎉 

resloves https://github.com/pelias/api/issues/1597