### PR TITLE
Use only phrase.default field in search endpoint

### DIFF
--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -22,6 +22,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:cutoff_frequency': 0.01,
   'ngram:minimum_should_match': '1<-1 3<-25%',
 
+  'match:main:analyzer': 'peliasQuery',
+  'match:main:field': 'phrase.default',
+  'match:main:minimum_should_match': '1<-1 3<-25%',
+
   'match_phrase:main:analyzer': 'peliasPhrase',
   'match_phrase:main:field': 'phrase.default',
   'match_phrase:main:boost': 1,

--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -18,7 +18,7 @@ var adminFields = placeTypes.concat(['region_a']);
 var query = new peliasQuery.layout.FilteredBooleanQuery();
 
 // mandatory matches
-query.score( peliasQuery.view.ngrams, 'must' );
+query.score( peliasQuery.view.leaf.match('main'), 'must' );
 
 // scoring boost
 const phrase_view = peliasQuery.view.leaf.match_phrase('main');
@@ -59,6 +59,7 @@ function generateQuery( clean ){
 
   // input text
   vs.var( 'input:name', clean.text );
+  vs.var( 'match:main:input', clean.text );
   vs.var( 'match_phrase:main:input', clean.text );
 
   // sources

--- a/query/text_parser_pelias.js
+++ b/query/text_parser_pelias.js
@@ -18,6 +18,7 @@ function addParsedVariablesToQueryVariables(clean, vs) {
   // name
   if (!_.isEmpty(clean.parsed_text.subject)) {
     vs.var('input:name', clean.parsed_text.subject);
+    vs.var('match:main:input', clean.parsed_text.subject);
     vs.var('match_phrase:main:input', clean.parsed_text.subject);
   }
 

--- a/test/unit/fixture/search_pelias_parser_boundary_country.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_country.js
@@ -4,10 +4,8 @@ module.exports = {
       'must': [
         {
           'match': {
-            'name.default': {
+            'phrase.default': {
               'query': 'test',
-              'cutoff_frequency': 0.01,
-              'boost': 1,
               'minimum_should_match': '1<-1 3<-25%',
               'analyzer': 'peliasQuery'
             }

--- a/test/unit/fixture/search_pelias_parser_boundary_gid.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_gid.js
@@ -4,12 +4,10 @@ module.exports = {
       'must': [
         {
           'match': {
-            'name.default': {
+            'phrase.default': {
               'query': 'test',
-              'boost': 1,
               'minimum_should_match': '1<-1 3<-25%',
-              'analyzer': 'peliasQuery',
-              'cutoff_frequency': 0.01
+              'analyzer': 'peliasQuery'
             }
           }
         }

--- a/test/unit/fixture/search_pelias_parser_full_address.js
+++ b/test/unit/fixture/search_pelias_parser_full_address.js
@@ -5,12 +5,10 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': '123 main st',
-            'cutoff_frequency': 0.01,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery',
-            'boost': 1
           }
         }
       }],

--- a/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_null_island.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_pelias_parser_linguistic_only.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_only.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_pelias_parser_partial_address.js
+++ b/test/unit/fixture/search_pelias_parser_partial_address.js
@@ -5,12 +5,10 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'soho grand',
-            'cutoff_frequency': 0.01,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery',
-            'boost': 1
           }
         }
       }],

--- a/test/unit/fixture/search_pelias_parser_regions_address.js
+++ b/test/unit/fixture/search_pelias_parser_regions_address.js
@@ -5,12 +5,10 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': '1 water st',
-            'cutoff_frequency': 0.01,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery',
-            'boost': 1
           }
         }
       }],

--- a/test/unit/fixture/search_pelias_parser_with_category_filtering.js
+++ b/test/unit/fixture/search_pelias_parser_with_category_filtering.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_pelias_parser_with_source_filtering.js
+++ b/test/unit/fixture/search_pelias_parser_with_source_filtering.js
@@ -3,10 +3,8 @@ module.exports = {
     'bool': {
       'must': [{
         'match': {
-          'name.default': {
+          'phrase.default': {
             'query': 'test',
-            'cutoff_frequency': 0.01,
-            'boost': 1,
             'minimum_should_match': '1<-1 3<-25%',
             'analyzer': 'peliasQuery'
           }

--- a/test/unit/fixture/search_with_custom_boosts.json
+++ b/test/unit/fixture/search_with_custom_boosts.json
@@ -5,10 +5,8 @@
       "bool": {
         "must": [{
           "match": {
-            "name.default": {
+            "phrase.default": {
               "query": "test",
-              "boost": 1,
-              "cutoff_frequency": 0.01,
               "minimum_should_match": "1<-1 3<-25%",
               "analyzer": "peliasQuery"
             }


### PR DESCRIPTION
This avoids use of the expensive `name.default` field, which includes partial tokens (ngrams)

This change is extremely beneficial to performance of search queries, especially those that are "gibberish".

In particular, it avoids the huge number of document matches that come from searching for addresses with the housenumber `1`. With the `name.default` field in use, all records with a token that _starts with_ 1 would be returned. That's generally not what we want for the search endpoint.