### PR TITLE
Allow the `address_layer_filter` performance optimization to work with negative layers

### DIFF
--- a/sanitizer/_targets.js
+++ b/sanitizer/_targets.js
@@ -65,19 +65,21 @@ function _setup( paramName, targetMap ) {
         );
       });
 
+      // calculate the "effective" list of positive and negative targets, by expanding aliases
+      const effective_positive_targets = expandAliases(positive_targets, opts.targetMap);
+      const effective_negative_targets = expandAliases(negative_targets, opts.targetMap);
+
+      const all_targets = allTargets(opts.targetMap);
+
       // for calculating the final list of targets use either:
       // - the list of positive targets, if there are any
       // - otherwise, the list of all possible targets
       const starting_positive_targets = positive_targets.length ?
-        positive_targets :
-        allTargets(opts.targetMap);
-
-      // calculate the "effective" list of positive and negative targets, by expanding aliases
-      const effective_positive_targets = expandAliases(starting_positive_targets, opts.targetMap);
-      const effective_negative_targets = expandAliases(negative_targets, opts.targetMap);
+        effective_positive_targets :
+        all_targets;
 
       // the final list of targets is the positive list, with the negative list excluded
-      const final_targets = effective_positive_targets.filter((t) => !effective_negative_targets.includes(t));
+      const final_targets = starting_positive_targets.filter((t) => !effective_negative_targets.includes(t));
 
       if (final_targets.length === 0) {
         messages.errors.push(

--- a/sanitizer/_targets.js
+++ b/sanitizer/_targets.js
@@ -14,6 +14,10 @@ function expandAliases(targets, targetMap) {
   return [...new Set(expanded)];
 }
 
+function allTargets(targetMap) {
+  return [...new Set(Object.values(targetMap).flat())];
+}
+
 function _setup( paramName, targetMap ) {
   const opts = {
     paramName: paramName,
@@ -66,7 +70,7 @@ function _setup( paramName, targetMap ) {
       // - otherwise, the list of all possible targets
       const starting_positive_targets = positive_targets.length ?
         positive_targets :
-        Object.keys(opts.targetMap);
+        allTargets(opts.targetMap);
 
       // calculate the "effective" list of positive and negative targets, by expanding aliases
       const effective_positive_targets = expandAliases(starting_positive_targets, opts.targetMap);

--- a/test/unit/sanitizer/_layers.js
+++ b/test/unit/sanitizer/_layers.js
@@ -158,6 +158,8 @@ module.exports.tests.sanitize_layers = function(test, common) {
     const expected_layers = type_mapping.getCanonicalLayers().filter(layer => layer !== 'venue').sort();
 
     t.deepEqual(clean.layers.sort(), expected_layers, 'all layers except negative layer selected');
+    t.deepEqual(clean.negative_layers, ['venue'], 'venue marked as negative layer');
+    t.deepEqual(clean.positive_layers, [], 'no positive layers marked as selected');
     t.end();
   });
 


### PR DESCRIPTION
In https://github.com/pelias/api/pull/1525 we introduced the concept of negative sources and layers.

In that PR there was special care taken to make sure we didn't break certain performance enhancing features where we filter out addresses. But even with all that care it looks like we broke it anyway!

This PR fixes that issue and allows performance enhancing filters on layers work as intended.

The core of the bug was that the `clean.positive_layers` property, which is intended to be set _only_ to the list of layers the API parameters explicitly opt into, was instead being set to the list of all layers, minus the layers that the parameter didn't opt into.

For example, a query with param `layers=-venue` should result in `clean.positive_layers: [], `clean.negative_layers: ['venue']`, and `clean.layers` temporarily set to all layers except `venue`.

Subsequent middleware can then look at `clean.positive_layers` to decide if any layers can/should be removed from `clean.layers`. For example, in some situations we've decided it's ok to remove `address` from `clean.layers`, since `clean.positive_layers` does not explicitly opt into the address layer.

Fixes https://github.com/pelias/api/issues/1601