### PR TITLE
do not dedupe disparate unit numbers at same address

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -157,6 +157,7 @@ function isAddressDifferent(item1, item2){
   if( !isPojo1 || !isPojo2 ){ return false; }
 
   // else both have address info
+  if( isPropertyDifferent(address1, address2, 'unit') ){ return true; }
   if( isPropertyDifferent(address1, address2, 'number') ){ return true; }
   if( isPropertyDifferent(address1, address2, 'street') ){ return true; }
 

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -438,6 +438,45 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('same address, different unit number', function (t) {
+    var item1 = {
+      'address_parts': {
+        'unit': '1',
+        'number': '10',
+        'street': 'Main Street'
+      }
+    };
+    var item2 = {
+      'address_parts': {
+        'unit': '2',
+        'number': '10',
+        'street': 'Main Street'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
+  test('same address, different one missing unit number', function (t) {
+    var item1 = {
+      'address_parts': {
+        'number': '10',
+        'street': 'Main Street'
+      }
+    };
+    var item2 = {
+      'address_parts': {
+        'unit': '2',
+        'number': '10',
+        'street': 'Main Street'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be different');
+    t.end();
+  });
+
   test('completely empty objects', function(t) {
     var item1 = {};
     var item2 = {};


### PR DESCRIPTION
as mentioned in https://github.com/pelias/openaddresses/pull/504 the current deduplication behaviour considers all units at the same address to be duplicate, therefore 'squashing them' into a single response.

this PR modifies this behaviour so that each individual unit number at an address returns a row in the results.

I'm opening this as DRAFT for now since @orangejulius mentioned in https://github.com/pelias/openaddresses/pull/504#issuecomment-1054461416 that we might consider alternatives, I wanted to have a PR open to remind us.