### PR TITLE
simplified dedupe + preserve order

### DIFF
--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -850,8 +850,82 @@ module.exports.tests.priority = function(test, common) {
     };
 
     dedupe(req, res, () => {
-      t.equal(res.data.length, 1, 'results are deduped');
-      t.equal(res.data[0].source_id, 'A');
+      t.deepEqual(res.data.map(v => v.source_id), ['A']);
+      t.end();
+    });
+  });
+
+  test('A B C->A position substitution', function (t) {
+    var req = {
+      clean: {
+        text: 'A B C',
+        size: 10
+      }
+    };
+    var res = {
+      data: [
+        {
+          'source': 'example',
+          'source_id': 'A',
+          'layer': 'test',
+          'name': { 'default': ['name2'] }
+        }, {
+          'source': 'example',
+          'source_id': 'B',
+          'layer': 'test',
+          'name': { 'default': ['name1'] }
+        }, {
+          'source': 'example',
+          'source_id': 'C',
+          'layer': 'test',
+          'name': { 'default': ['name2'] },
+          'address_parts': { 'zip': '10000' }
+        }
+      ]
+    };
+
+    dedupe(req, res, () => {
+      t.deepEqual(res.data.map(v => v.source_id), ['C','B']);
+      t.end();
+    });
+  });
+
+  test('A->B C D->A position substitution', function (t) {
+    var req = {
+      clean: {
+        text: 'A B C',
+        size: 10
+      }
+    };
+    var res = {
+      data: [
+        {
+          'source': 'example',
+          'source_id': 'A',
+          'layer': 'test',
+          'name': { 'default': ['name1'] }
+        }, {
+          'source': 'example',
+          'source_id': 'B',
+          'layer': 'test',
+          'name': { 'default': ['name1'] }
+        }, {
+          'source': 'example',
+          'source_id': 'C',
+          'layer': 'test',
+          'name': { 'default': ['name2'] }
+        }, {
+          'source': 'example',
+          'source_id': 'D',
+          'layer': 'test',
+          'name': { 'default': ['name1'] },
+          'address_parts': { 'zip': '10000' }
+        }
+      ]
+    };
+
+    dedupe(req, res, () => {
+      t.deepEqual(res.data.map(v => v.source_id), ['D', 'C']);
       t.end();
     });
   });


### PR DESCRIPTION
an extension to https://github.com/pelias/api/pull/1607 which preserves ordering of synonymous records (ie. the lower ordinal position is inherited by the superior record).