### PR TITLE
Do not deduplicate US States

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -40,6 +40,11 @@ function isLayerDifferent(item1, item2){
   return false;
 }
 
+function isUsState(item) {
+  if (!_.isArray(item.parent.country_a)) { return false; }
+  return item.parent.country_a[0] === 'USA' && item.layer === 'region';
+}
+
 /**
  * Compare the parent properties if they exist.
  * Returns false if the objects are the same, else true.
@@ -58,6 +63,13 @@ function isParentHierarchyDifferent(item1, item2){
   // if only one has parent info, we consider them the same
   // note: this really shouldn't happen as at least one parent should exist
   if( !isPojo1 || !isPojo2 ){ return false; }
+
+  // US states should not be deduplicated, except against other US states
+  if (isUsState(item1) || isUsState(item2)) {
+    if (!isUsState(item1) || !isUsState(item2)) {
+      return true;
+    }
+  }
 
   // special handling of postal codes, which we consider to be strictly
   // unique within a single country/dependency regardless of the rest of

--- a/test/unit/helper/diffPlaces.js
+++ b/test/unit/helper/diffPlaces.js
@@ -82,6 +82,46 @@ module.exports.tests.dedupe = function(test, common) {
     t.end();
   });
 
+  test('isParentHierarchyDifferent: do not dedupe US states', function(t) {
+    var item1 = {
+      layer: 'region',
+      parent: {
+        region_id: '123',
+        country_a: ['USA']
+      }
+    };
+    var item2 = {
+      layer: 'locality',
+      parent: {
+        region_id: '123',
+        locality_id: '456'
+      }
+    };
+
+    t.true(isDifferent(item1, item2), 'should be considered different');
+    t.end();
+  });
+
+  test('isParentHierarchyDifferent: do not dedupe US states, except against each other', function(t) {
+    var item1 = {
+      layer: 'region',
+      parent: {
+        region_id: '123',
+        country_a: ['USA']
+      }
+    };
+    var item2 = {
+      layer: 'region',
+      parent: {
+        region_id: '123',
+        country_a: ['USA']
+      }
+    };
+
+    t.false(isDifferent(item1, item2), 'should not be considered different');
+    t.end();
+  });
+
   test('isParentHierarchyDifferent: do compare parentage at higher levels than the highest item placetypes', function(t) {
     var item1 = {
       'layer': 'country',


### PR DESCRIPTION
It's common for US states to have either a county or city within them that shares a name (with minor possible differences).

For example:
- Arkansas City in Arkansas
- Hawaii County in Hawaii
- Iowa City in Iowa
- California City in California
- Utah County in Utah
- Nebraska City in Nebraska
- Idaho City _and_ Idaho County in Idaho (Idaho City is _not_ in Idaho County)
- Maryland City, in Maryland
- Minnesota City in Minnesota
- New York City in New York (of course!)

Our general deduplication logic considers admin records that are parented by a record sharing its name to be the same. This works well for places like Singapore, Berlin, and Tokyo, which all have a city (locality) that is conceptually the same as a region or country.

US states, however, are _not_ conceptually the same as any of these cities, and they should pretty much always show up in results.

This PR adds a check that the record is _not_ a US state before performing the general hierarchy checks. There's one exception: US states can dedupe against other US states, so that Geonames and WOF records can deduplicate themselves.

This PR allows us to merge https://github.com/pelias/api/pull/1371