### PR TITLE
Language specific label formats

### DIFF
--- a/middleware/assignLabels.js
+++ b/middleware/assignLabels.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const defaultLabelGenerator = require('pelias-labels');
 
 function setup(labelGenerator) {
@@ -16,7 +18,7 @@ function assignLabel(req, res, next, labelGenerator) {
   }
 
   res.data.forEach(function (result) {
-    result.label = labelGenerator(result);
+    result.label = labelGenerator(result, _.get(req, 'clean.lang.iso6393'));
   });
 
   next();

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",
     "pelias-config": "^5.0.1",
-    "pelias-labels": "^1.16.1",
+    "pelias-labels": "^1.19.0",
     "pelias-logger": "^1.2.0",
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",


### PR DESCRIPTION
This PR includes the required API changes to use our new language specific label formats from https://github.com/pelias/labels/pull/52 and https://github.com/pelias/labels/pull/51.

The code changes required to enable this is just one line, but for now this PR also includes a change to point the `pelias-labels` package to a branch. We shouldn't merge this PR until https://github.com/pelias/labels/pull/52 is merged and released. 

We also might want to add a quick test or two that the language values make it into the label generator.