### PR TITLE
autocomplete: adjust popularity field weight

### DIFF
--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -138,7 +138,7 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',
   'popularity:max_boost': 20,
-  'popularity:weight': 1,
+  'popularity:weight': 2,
 
   'population:field': 'population',
   'population:modifier': 'log1p',

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -29,7 +29,7 @@
                     "field": "popularity",
                     "missing": 1
                   },
-                  "weight": 1
+                  "weight": 2
                 }
               ],
               "score_mode": "first",

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -33,7 +33,7 @@ module.exports = {
                   'field': 'popularity',
                   'missing': 1
                 },
-                'weight': 1
+                'weight': 2
               }
             ],
             'score_mode': 'first',

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -25,7 +25,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -51,7 +51,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -51,7 +51,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -53,7 +53,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -40,7 +40,7 @@ module.exports = {
                 'field': 'popularity',
                 'missing': 1
               },
-              'weight': 1
+              'weight': 2
             }]
           }
         }, {

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -50,7 +50,7 @@ module.exports = {
                   'field': 'popularity',
                   'missing': 1
                 },
-                'weight': 1
+                'weight': 2
               }
             ],
             'score_mode': 'first',

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -48,7 +48,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       }, {

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -29,7 +29,7 @@ module.exports = {
               'field': 'popularity',
               'missing': 1
             },
-            'weight': 1
+            'weight': 2
           }]
         }
       },{


### PR DESCRIPTION
I'm curious as to what effect changing the `popularity:weight` for autocomplete from `1->2` would have for:

- https://pelias.github.io/compare/#/v1/autocomplete?text=statue+of+liberty
- https://pelias.github.io/compare/#/v1/autocomplete?text=statue+of+liberty+nyc