### PR TITLE
autocomplete: extend additional name fields used in multimatch queries

### DIFF
--- a/query/view/helper.js
+++ b/query/view/helper.js
@@ -1,5 +1,5 @@
-function toMultiFields(baseField, suffix) {
-  return [baseField, toSingleField(baseField, suffix)];
+function toMultiFields(baseField, ...suffix) {
+  return [baseField].concat(suffix.map(suffix => toSingleField(baseField, suffix)));
 }
 
 function toSingleField(baseField, suffix) {

--- a/query/view/ngrams_strict.js
+++ b/query/view/ngrams_strict.js
@@ -1,5 +1,6 @@
 const peliasQuery = require('pelias-query');
 const toMultiFields = require('./helper').toMultiFields;
+const additionalNameFields = ['alt', 'abbr', 'code', 'org'];
 
 /**
   Ngrams view with the additional properties to enable:
@@ -16,7 +17,11 @@ module.exports = function( vs ){
   }
 
   vs.var('multi_match:ngrams_strict:input', vs.var('input:name').get());
-  vs.var('multi_match:ngrams_strict:fields', toMultiFields(vs.var('ngram:field').get(), vs.var('lang').get()));
+  vs.var('multi_match:ngrams_strict:fields', toMultiFields(
+    vs.var('ngram:field').get(),
+    vs.var('lang').get(),
+    ...additionalNameFields
+  ));
 
   vs.var('multi_match:ngrams_strict:analyzer', vs.var('ngram:analyzer').get());
   vs.var('multi_match:ngrams_strict:slop', vs.var('phrase:slop').get());

--- a/query/view/phrase_first_tokens_only.js
+++ b/query/view/phrase_first_tokens_only.js
@@ -1,5 +1,6 @@
 const peliasQuery = require('pelias-query');
 const toMultiFields = require('./helper').toMultiFields;
+const additionalNameFields = ['alt', 'abbr', 'code', 'org'];
 
 /**
   Phrase view which trims the 'input:name' and uses ALL BUT the last token.
@@ -18,7 +19,11 @@ module.exports = function( vs ){
 
   // set the 'input' variable to all but the last token
   vs.var(`multi_match:${view_name}:input`).set( tokens.join(' ') );
-  vs.var(`multi_match:${view_name}:fields`).set(toMultiFields(vs.var('phrase:field').get(), vs.var('lang').get()));
+  vs.var(`multi_match:${view_name}:fields`, toMultiFields(
+    vs.var('phrase:field').get(),
+    vs.var('lang').get(),
+    ...additionalNameFields
+  ));
 
   vs.var(`multi_match:${view_name}:analyzer`).set(vs.var('phrase:analyzer').get());
   vs.var(`multi_match:${view_name}:boost`).set(vs.var('phrase:boost').get());

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_boundary_gid.js
+++ b/test/unit/fixture/autocomplete_boundary_gid.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_custom_boosts.json
+++ b/test/unit/fixture/autocomplete_custom_boosts.json
@@ -6,7 +6,14 @@
         "must": [
           {
             "multi_match": {
-              "fields": ["phrase.default", "phrase.en"],
+              "fields": [
+                "phrase.default",
+                "phrase.en",
+                "phrase.alt",
+                "phrase.abbr",
+                "phrase.code",
+                "phrase.org"
+              ],
               "analyzer": "peliasQuery",
               "query": "foo",
               "boost": 1,

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_circle_san_francisco.js
@@ -6,7 +6,14 @@ module.exports = {
           'constant_score': {
             'filter': {
               'multi_match': {
-                'fields': ['name.default', 'name.en'],
+                'fields': [
+                  'name.default',
+                  'name.en',
+                  'name.alt',
+                  'name.abbr',
+                  'name.code',
+                  'name.org'
+                ],
                 'analyzer': 'peliasQuery',
                 'query': 'test',
                 'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_final_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_final_token.js
@@ -3,7 +3,14 @@ module.exports = {
     'bool': {
       'must': [{
         'multi_match': {
-          'fields': ['phrase.default', 'phrase.en'],
+          'fields': [
+            'phrase.default',
+            'phrase.en',
+            'phrase.alt',
+            'phrase.abbr',
+            'phrase.code',
+            'phrase.org'
+          ],
           'analyzer': 'peliasQuery',
           'query': 'one',
           'boost': 1,

--- a/test/unit/fixture/autocomplete_linguistic_focus.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
+++ b/test/unit/fixture/autocomplete_linguistic_focus_null_island.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens.js
@@ -3,7 +3,14 @@ module.exports = {
     'bool': {
       'must': [{
         'multi_match': {
-          'fields': ['phrase.default', 'phrase.en'],
+          'fields': [
+            'phrase.default',
+            'phrase.en',
+            'phrase.alt',
+            'phrase.abbr',
+            'phrase.code',
+            'phrase.org'
+          ],
           'analyzer': 'peliasQuery',
           'query': 'one two',
           'boost': 1,

--- a/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
+++ b/test/unit/fixture/autocomplete_linguistic_multiple_tokens_complete_numeric.js
@@ -3,7 +3,14 @@ module.exports = {
     'bool': {
       'must': [{
         'multi_match': {
-          'fields': ['phrase.default', 'phrase.en'],
+          'fields': [
+            'phrase.default',
+            'phrase.en',
+            'phrase.alt',
+            'phrase.abbr',
+            'phrase.code',
+            'phrase.org'
+          ],
           'analyzer': 'peliasQuery',
           'type': 'phrase',
           'slop': 3,
@@ -15,7 +22,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'three',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_one_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_one_char_token.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 't',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_only.js
+++ b/test/unit/fixture/autocomplete_linguistic_only.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_three_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_three_char_token.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'tes',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_two_char_token.js
+++ b/test/unit/fixture/autocomplete_linguistic_two_char_token.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'te',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_linguistic_with_admin.js
+++ b/test/unit/fixture/autocomplete_linguistic_with_admin.js
@@ -4,7 +4,14 @@ module.exports = {
       'must': [
         {
           'multi_match': {
-            'fields': ['phrase.default', 'phrase.en'],
+            'fields': [
+              'phrase.default',
+              'phrase.en',
+              'phrase.alt',
+              'phrase.abbr',
+              'phrase.code',
+              'phrase.org'
+            ],
             'analyzer': 'peliasQuery',
             'type': 'phrase',
             'slop': 3,

--- a/test/unit/fixture/autocomplete_single_character_street.js
+++ b/test/unit/fixture/autocomplete_single_character_street.js
@@ -3,7 +3,14 @@ module.exports = {
     'bool': {
       'must': [{
         'multi_match': {
-          'fields': ['phrase.default', 'phrase.en'],
+          'fields': [
+            'phrase.default',
+            'phrase.en',
+            'phrase.alt',
+            'phrase.abbr',
+            'phrase.code',
+            'phrase.org'
+          ],
           'analyzer': 'peliasQuery',
           'query': 'k road',
           'boost': 1,

--- a/test/unit/fixture/autocomplete_with_category_filtering.js
+++ b/test/unit/fixture/autocomplete_with_category_filtering.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_with_layer_filtering.js
+++ b/test/unit/fixture/autocomplete_with_layer_filtering.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,

--- a/test/unit/fixture/autocomplete_with_source_filtering.js
+++ b/test/unit/fixture/autocomplete_with_source_filtering.js
@@ -5,7 +5,14 @@ module.exports = {
         'constant_score': {
           'filter': {
             'multi_match': {
-              'fields': ['name.default', 'name.en'],
+              'fields': [
+                'name.default',
+                'name.en',
+                'name.alt',
+                'name.abbr',
+                'name.code',
+                'name.org'
+              ],
               'analyzer': 'peliasQuery',
               'query': 'test',
               'boost': 100,


### PR DESCRIPTION
this PR is an experiment with splitting up the `name.*` fields in order to avoid the negative effects of field norms due to field length, reported in https://github.com/pelias/openstreetmap/issues/507 and better explained in https://github.com/pelias/pelias/issues/862

in particular we see this issue in `OSM` and `WOF` due to those sources having more alt names than others, although it applies to all sources.

as discussed on our call today, it might be that https://github.com/pelias/openstreetmap/pull/435 exacerbated the issue (albeit unknown at the time) so reversing that method and moving back to multiple fields using a `multi_match` query should result in a significant reduction in the effects of the field norms issue on scoring.

although fairly arbitrary, I've identified 4 new fields to begin with:
- `alt` - this field will contain *all* alternative names, so the norms penalty will no longer apply to the primary name. this includes variants, colloquialisms & other alternatives
- `abbr` - abbreviations, ie. succulent representations of the primary name
- `code` - similar to above but distinct in the case of airports, stop IDs etc.
- `org` - brands, operators etc.

we may very well change these, maybe `abbr` and `code` can be merged, or `org` omitted, that's up for discussion.
the main difference is that we attempt to have only a single token indexed *per field*.