### PR TITLE
Support filtering against `dependency_a` when using `boundary.country` parameter

### DIFF
--- a/query/autocomplete.js
+++ b/query/autocomplete.js
@@ -60,7 +60,7 @@ query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.boundary_rect );
 query.filter( peliasQuery.view.boundary_circle );
-query.filter( peliasQuery.view.boundary_country );
+query.filter( peliasQuery.view.leaf.multi_match('boundary_country') );
 query.filter( peliasQuery.view.categories );
 query.filter( peliasQuery.view.boundary_gid );
 query.filter( views.focus_point_filter );
@@ -88,7 +88,7 @@ function generateQuery( clean ){
   // boundary country
   if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country'].join(' ')
+      'multi_match:boundary_country:input': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -72,6 +72,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:country_a:boost': 1,
   'admin:country_a:cutoff_frequency': 0.01,
 
+  // these options affect the `boundary.country` hard filter
+  'multi_match:boundary_country:analyzer': 'standard',
+  'multi_match:boundary_country:fields': ['parent.country_a', 'parent.dependency_a'],
+
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country.ngram',
   'admin:country:boost': 1,

--- a/query/search.js
+++ b/query/search.js
@@ -15,7 +15,7 @@ fallbackQuery.score( peliasQuery.view.population_only_function );
 // --------------------------------
 
 // non-scoring hard filters
-fallbackQuery.filter( peliasQuery.view.boundary_country );
+fallbackQuery.filter( peliasQuery.view.leaf.multi_match('boundary_country') );
 fallbackQuery.filter( peliasQuery.view.boundary_circle );
 fallbackQuery.filter( peliasQuery.view.boundary_rect );
 fallbackQuery.filter( peliasQuery.view.sources );
@@ -97,7 +97,7 @@ function generateQuery( clean ){
   // boundary country
   if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country'].join(' ')
+      'multi_match:boundary_country:input': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -66,6 +66,10 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:country_a:boost': 1,
   'admin:country_a:cutoff_frequency': 0.01,
 
+  // these config variables are used for the 'boundary.country' hard filter
+  'multi_match:boundary_country:analyzer': 'standard',
+  'multi_match:boundary_country:fields': ['parent.country_a', 'parent.dependency_a'],
+
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country',
   'admin:country:boost': 1,

--- a/query/search_pelias_parser.js
+++ b/query/search_pelias_parser.js
@@ -44,7 +44,7 @@ query.filter( peliasQuery.view.boundary_rect );
 query.filter( peliasQuery.view.sources );
 query.filter( peliasQuery.view.layers );
 query.filter( peliasQuery.view.categories );
-query.filter( peliasQuery.view.boundary_country );
+query.filter( peliasQuery.view.leaf.multi_match('boundary_country') );
 query.filter( peliasQuery.view.boundary_gid );
 
 // --------------------------------
@@ -123,7 +123,7 @@ function generateQuery( clean ){
   // boundary country
   if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country'].join(' ')
+      'multi_match:boundary_country:input': clean['boundary.country'].join(' ')
     });
   }
 

--- a/query/structured_geocoding.js
+++ b/query/structured_geocoding.js
@@ -15,7 +15,7 @@ structuredQuery.score( peliasQuery.view.population_only_function );
 // --------------------------------
 
 // non-scoring hard filters
-structuredQuery.filter( peliasQuery.view.boundary_country );
+structuredQuery.filter( peliasQuery.view.leaf.multi_match('boundary_country') );
 structuredQuery.filter( peliasQuery.view.boundary_circle );
 structuredQuery.filter( peliasQuery.view.boundary_rect );
 structuredQuery.filter( peliasQuery.view.sources );
@@ -87,7 +87,7 @@ function generateQuery( clean ){
   // boundary country
   if( _.isArray(clean['boundary.country']) && !_.isEmpty(clean['boundary.country']) ){
     vs.set({
-      'boundary:country': clean['boundary.country'].join(' ')
+      'multi_match:boundary_country:input': clean['boundary.country'].join(' ')
     });
   }
 

--- a/test/unit/fixture/autocomplete_boundary_country.js
+++ b/test/unit/fixture/autocomplete_boundary_country.js
@@ -51,12 +51,12 @@ module.exports = {
         }
       }],
       'filter': [{
-        'match': {
-          'parent.country_a.ngram': {
+          'multi_match': {
+            'type': 'best_fields',
+            'fields': ['parent.country_a', 'parent.dependency_a'],
             'analyzer': 'standard',
             'query': 'ABC'
           }
-        }
       }]
     }
   },

--- a/test/unit/fixture/search_boundary_country.js
+++ b/test/unit/fixture/search_boundary_country.js
@@ -33,11 +33,11 @@ module.exports = {
             'bool': {
               'must': [
                 {
-                  'match': {
-                    'parent.country_a': {
-                      'analyzer': 'standard',
-                      'query': 'ABC'
-                    }
+                  'multi_match': {
+                    'type': 'best_fields',
+                    'fields': ['parent.country_a', 'parent.dependency_a'],
+                    'analyzer': 'standard',
+                    'query': 'ABC'
                   }
                 },
                 {

--- a/test/unit/fixture/search_boundary_country_multi.js
+++ b/test/unit/fixture/search_boundary_country_multi.js
@@ -33,11 +33,11 @@ module.exports = {
             'bool': {
               'must': [
                 {
-                  'match': {
-                    'parent.country_a': {
-                      'analyzer': 'standard',
-                      'query': 'ABC DEF'
-                    }
+                  'multi_match': {
+                    'type': 'best_fields',
+                    'fields': ['parent.country_a', 'parent.dependency_a'],
+                    'analyzer': 'standard',
+                    'query': 'ABC DEF'
                   }
                 },
                 {

--- a/test/unit/fixture/search_pelias_parser_boundary_country.js
+++ b/test/unit/fixture/search_pelias_parser_boundary_country.js
@@ -65,11 +65,11 @@ module.exports = {
           }
         },
         {
-          'match': {
-            'parent.country_a': {
-              'analyzer': 'standard',
-              'query': 'ABC'
-            }
+          'multi_match': {
+            'type': 'best_fields',
+            'fields': ['parent.country_a', 'parent.dependency_a'],
+            'analyzer': 'standard',
+            'query': 'ABC'
           }
         }
       ]

--- a/test/unit/query/structured_geocoding.js
+++ b/test/unit/query/structured_geocoding.js
@@ -14,7 +14,10 @@ const views = {
   sources: 'sources view',
   layers: 'layers view',
   categories: 'categories view',
-  boundary_gid: 'boundary_gid view'
+  boundary_gid: 'boundary_gid view',
+  leaf: {
+    multi_match: () => 'multi_match leaf view'
+  }
 };
 
 module.exports.tests = {};
@@ -76,7 +79,7 @@ module.exports.tests.query = (test, common) => {
     ]);
 
     t.deepEquals(query.body.filter_functions, [
-      'boundary_country view',
+      'multi_match leaf view',
       'boundary_circle view',
       'boundary_rect view',
       'sources view',
@@ -592,7 +595,7 @@ module.exports.tests.boundary_country = (test, common) => {
       }
     })(clean);
 
-    t.equals(query.body.vs.var('boundary:country').toString(), 'boundary country value');
+    t.equals(query.body.vs.var('multi_match:boundary_country:input').toString(), 'boundary country value');
 
     t.end();
 


### PR DESCRIPTION
The `boundary.country` parameter is supported on all major Pelias API endpoints and adds a hard filter based on a given 2 or 3 character country code.

The behavior is pretty straightforward, but the underlying data model for country-like parents is not quite so simple.

While _most_ records have a `parent.country_a` property with the country code of a parent, a few have `parent.dependency_a`. This includes places like US territories outside the 50 states, the French Overseas Territories, and various others that have their own country codes but may not be a completely sovereign country of their own.

In practice however, this distinction isn't _super_ useful to most people. See the `country_code` parameter we added in https://github.com/pelias/api/pull/1541 for another case where it's helpful to provide an interface that glosses over some of the details.

## Functionality

This PR makes the `boundary.country` param look for a matching country code in _either_ the `parent.dependency_a` property or `parent.country_a`, using an Elasticsearch [`multi_match`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html) query. Previously only `parent.country_a` was considered.

There's really nothing tricky to it, the `multi_match` query allows either field to contain the desired country code.

As a side note, I realized that our autocomplete queries were using the `parent.country_a.ngram` field due to our work in https://github.com/pelias/api/pull/1264. While this should make little practical difference it's technically not needed, as the `boundary.country` param doesn't need to consider partial inputs. As a side effect this PR fixes that ever so slight departure from the ideal.

## A note on implementation

As it stands, this PR includes a departure from the previous implementation, which used a `boundary.country` specific [view in the pelias-query library](https://github.com/pelias/query/blob/2c8fa8ce9662b64b59766a509a04f942098918b8/view/boundary_country.js#L1-L21).

Instead, the generic `multi_match` view is used, and all the Pelias API specific logic is contained here. It also means there's no need to release a companion PR to `pelias-query`. In the past we've found the dance of developing PRs to API and `pelias-query` in parallel to be a bit of extra work, and this pattern would eliminate that need. I'd love to see us moving towards having all the Pelias-specific query logic here in the API, while `pelias-query` contains only or mostly Elasticsearch-specific stuff.

That said it does mean that the way this filter parameter works is now different from most of the others, so it's worth discussing if that's ok with us.

## Still to come

The `/v1/reverse` endpoint technically supports `boundary.country` as well (though the use case is fairly [limited](https://github.com/pelias/documentation/blob/master/reverse.md#filter-by-country)). This will come in a subsequent PR as the "coarse" part of the reverse endpoint doesn't support `boundary.country` at all. It might make sense to have further discussion there, including the possibility of removing the `boundary.country` param from the reverse endpoint.