### PR TITLE
update pelias/sorting module to fix numeric sorting bug

### DIFF
--- a/middleware/interpolate.js
+++ b/middleware/interpolate.js
@@ -2,7 +2,6 @@ const async = require('async');
 const logger = require( 'pelias-logger' ).get( 'api' );
 const source_mapping = require('../helper/type_mapping').source_mapping;
 const _ = require('lodash');
-const stable = require('stable');
 const Debug = require('../helper/debug');
 const debugLog = new Debug('middleware:interpolate');
 
@@ -140,7 +139,7 @@ function setup(service, should_execute, interpolationConfiguration) {
 
       // sort the results to ensure that addresses show up higher than street centroids
       if (_.has(res, 'data')) {
-        res.data = stable(res.data, (a, b) => {
+        res.data.sort((a, b) => {
           if (a.layer === 'address' && b.layer !== 'address') { return -1; }
           if (a.layer !== 'address' && b.layer === 'address') { return 1; }
           return 0;

--- a/middleware/sortResponseData.js
+++ b/middleware/sortResponseData.js
@@ -1,6 +1,4 @@
 const _ = require('lodash');
-const stable = require('stable');
-
 const logger = require('pelias-logger').get('api');
 
 function setup(comparator, should_execute) {
@@ -14,7 +12,7 @@ function setup(comparator, should_execute) {
     const presort_order = res.data.map(_.property('_id'));
 
     // stable operates on array in place
-    stable.inplace(res.data, comparator(req.clean));
+    res.data.sort(comparator(req.clean));
 
     // capture the post-sort order
     const postsort_order = res.data.map(_.property('_id'));

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "remove-accents": "^0.4.2",
     "require-all": "^3.0.0",
     "retry": "^0.12.0",
-    "stable": "^0.1.8",
     "stats-lite": "^2.0.4",
     "through2": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pelias-model": "^9.0.0",
     "pelias-parser": "2.2.0",
     "pelias-query": "^11.0.0",
-    "pelias-sorting": "^1.2.0",
+    "pelias-sorting": "^1.7.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",
     "remove-accents": "^0.4.2",

--- a/test/unit/middleware/sortResponseData.js
+++ b/test/unit/middleware/sortResponseData.js
@@ -103,12 +103,7 @@ module.exports.tests.general_tests = (test, common) => {
 module.exports.tests.successful_sort = (test, common) => {
   test('comparator should be sort res.data', (t) => {
     const logger = mock_logger();
-
-    const comparator = () => {
-      return (a, b) => {
-        return a._id > b._id;
-      };
-    };
+    const comparator = () => (a, b) => (a._id > b._id) ? +1 : -1;
 
     const sortResponseData = proxyquire('../../../middleware/sortResponseData', {
       'pelias-logger': logger
@@ -130,9 +125,9 @@ module.exports.tests.successful_sort = (test, common) => {
     };
 
     sort(req, res, () => {
-      t.deepEquals(res.data.shift(), { _id: 1 });
-      t.deepEquals(res.data.shift(), { _id: 2 });
-      t.deepEquals(res.data.shift(), { _id: 3 });
+      t.deepEquals(res.data[0], { _id: 1 });
+      t.deepEquals(res.data[1], { _id: 2 });
+      t.deepEquals(res.data[2], { _id: 3 });
 
       t.ok(logger.isDebugMessage(
         'req.clean: {"field":"value"}, pre-sort: [3,2,1], post-sort: [1,2,3]'));


### PR DESCRIPTION
this PR fixes a subtle sorting bug: https://github.com/pelias/sorting/pull/26

in particular, a user noted that the query `Acton, ME, USA` returned the result for `Meeker County` above that of `Maine`, which is now resolved.