### PR TITLE
Allow custom layers by removing the restriction for non-coarse layers

### DIFF
--- a/query/reverse.js
+++ b/query/reverse.js
@@ -39,8 +39,7 @@ function generateQuery( clean ){
 
   // layers
   if( _.isArray(clean.layers) && !_.isEmpty(clean.layers) ) {
-    // only include non-coarse layers
-    vs.var( 'layers', _.intersection(clean.layers, ['address', 'street', 'venue']));
+    vs.var( 'layers', clean.layers);
   }
 
   // focus point to score by distance

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -5,7 +5,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
 
   'size': 1,
   'track_scores': true,
-  'layers': ['venue', 'address', 'street'],
 
   'centroid:field': 'center_point',
 

--- a/test/unit/query/reverse.js
+++ b/test/unit/query/reverse.js
@@ -209,27 +209,6 @@ module.exports.tests.layers = (test, common) => {
 
   });
 
-  test('non-empty array clean.layers should only set non-coarse layers in vs', t => {
-    const clean = {
-      layers: all_layers
-    };
-
-    const query = proxyquire('../../../query/reverse', {
-      'pelias-query': {
-        layout: {
-          FilteredBooleanQuery: MockQuery
-        },
-        view: views,
-        Vars: require('pelias-query').Vars
-      },
-      './reverse_defaults': {}
-    })(clean);
-
-    t.deepEquals(query.body.vs.var('layers').toString(), ['address', 'venue', 'street']);
-    t.end();
-
-  });
-
 };
 
 module.exports.tests.focus_point = (test, common) => {


### PR DESCRIPTION
:wave: 
We are working the custom sources and layers which are now supported by the Pelias, which is very good and we are excited about that.
We have data from different sources and we have defined the layers which suits our needs and fit nicely with our data.

---
#### Here's the reason for this change :rocket:
We are testing the custom sources and layers. It works with the `/autocomplete`, but it doesn't works with the `/reverse` endpoint. 
We have tried to search on this topic and found other issues and discussion regarding this issue.
Specially this one https://github.com/pelias/api/issues/1161, which pointed us towards the `reverse.js`
We see that the restriction has been added to support only the non-coarse layers in the `/reverse` endpoint in the following commit https://github.com/pelias/api/commit/10b1d282010053e4ddece83e6351aa0f9a148a3e. We have not been able to figure out why it was necessary. @trescube If you remember anything about that change from 2017 please help us.

---
#### Here's what actually got changed :clap:
We have removed that restriction and make the `/reverse` endpoint to support all the layers like other endpoints.
We have tested the API after that change and it works fine.
