### PR TITLE
Add original place id when postalcode is overridden

### DIFF
--- a/middleware/normalizeParentIds.js
+++ b/middleware/normalizeParentIds.js
@@ -37,6 +37,8 @@ function normalizeParentIds(place) {
         // The default values via lodash _.get is used only when the value is `undefined`, in our case it may be null.
         let source = _.get(place, `${placeType}_source[0]`) || 'whosonfirst';
 
+        const layer = _.get(place, `${placeType}_layer[0]`, placeType);
+
         const placetype_ids = _.get(place, `${placeType}_gid[0]`, null);
 
         // looking forward to the day we can remove all geonames specific hacks, but until then...
@@ -46,7 +48,7 @@ function normalizeParentIds(place) {
           source = place.source;
         }
         
-        place[`${placeType}_gid`] = [ makeNewId(source, placeType, placetype_ids) ];
+        place[`${placeType}_gid`] = [ makeNewId(source, layer, placetype_ids) ];
       }
     });
   }

--- a/middleware/renamePlacenames.js
+++ b/middleware/renamePlacenames.js
@@ -5,7 +5,7 @@ const PARENT_PROPS = require('../helper/placeTypes');
 const ADDRESS_PROPS = [
   { name: 'unit',   newName: 'unit' },
   { name: 'number', newName: 'housenumber' },
-  { name: 'zip',    newName: 'postalcode', transform: (value) => { return [value]; } },
+  { name: 'zip',    newName: 'postalcode', transform: (value) => { return [value]; }, addOriginalId: true },
   { name: 'street', newName: 'street' }
 ];
 
@@ -62,6 +62,12 @@ function renameAddressProperty(place, prop) {
   }
   else {
     place[prop.newName] = place.address_parts[prop.name];
+  }
+
+  if (prop.addOriginalId) {
+    place[`${prop.newName}_gid`] = [place.source_id];
+    place[`${prop.newName}_source`] = [place.source];
+    place[`${prop.newName}_layer`] = [place.layer];
   }
 }
 

--- a/test/unit/middleware/normalizeParentIds.js
+++ b/test/unit/middleware/normalizeParentIds.js
@@ -329,6 +329,59 @@ module.exports.tests.interface = function(test, common) {
     });
 
   });
+  
+  test('address zip may override postalcode parent hierarchy', function(t) {
+    var input = {
+      data: [{
+        'address_parts': { 'number': '815', 'street': 'Tennessee Street', 'zip': '94107.0' },
+        'parent': {
+          'country_id': [ '85633793' ],
+          'country': [ 'United States' ],
+          'country_a': [ 'USA' ],
+          'postalcode': [ '94107' ],
+          'postalcode_id': [ '554784675' ],
+        },
+        'source': 'openaddresses',
+        'source_id': 'us/ca/san_francisco:819b088d2837cf5d',
+        'layer': 'address',
+        'country': [ 'United States' ],
+        'country_a': [ 'USA' ],
+        'country_gid': ['85633793'],
+        'postalcode': [ '94107.0' ],
+        'postalcode_gid': [ 'us/ca/san_francisco:819b088d2837cf5d:819b088d2837cf5d' ],
+        'postalcode_source': [ 'openaddresses' ],
+        'postalcode_layer': [ 'address' ],
+      }]
+    };
+
+    var expected = {
+      data: [{
+        'address_parts': { 'number': '815', 'street': 'Tennessee Street', 'zip': '94107.0' },
+        'parent': {
+          'country_id': [ '85633793' ],
+          'country': [ 'United States' ],
+          'country_a': [ 'USA' ],
+          'postalcode': [ '94107' ],
+          'postalcode_id': [ '554784675' ],
+        },
+        'source': 'openaddresses',
+        'source_id': 'us/ca/san_francisco:819b088d2837cf5d',
+        'layer': 'address',
+        'country': [ 'United States' ],
+        'country_a': [ 'USA' ],
+        'country_gid': [ 'whosonfirst:country:85633793' ],
+        'postalcode': [ '94107.0' ],
+        'postalcode_gid': [ 'openaddresses:address:us/ca/san_francisco:819b088d2837cf5d:819b088d2837cf5d' ],
+        'postalcode_source': [ 'openaddresses' ],
+        'postalcode_layer': [ 'address' ],
+      }]
+    };
+
+    normalizer({}, input, function () {
+      t.deepEqual(input, expected);
+      t.end();
+    });
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

Addresses from OpenAddresses can override parent place name (such as `postalcode`). When this happens, we don't know where the postalcode came from, especially if there was one from another source (like WOF).

Also, since postalcodes are part of an document's parents, not having a gid makes the API less consistent.

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

In `renamePlacenames` middleware, I added an option that allows us to add/override the postalcode gid. Thanks to this, we will know where the data comes from.

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->

You can try with [`815 Tennessee St, San Francisco, CA 94107, États-Unis`](https://pelias.github.io/compare/#/v1/autocomplete?text=815+Tennessee+St%2C+San+Francisco%2C+CA+94107%2C+USA) where the `postalcode_gid` will be `openaddresses:address:us/ca/san_francisco:819b088d2837cf5d`

```json
{
  "id": "us/ca/san_francisco:819b088d2837cf5d",
  "gid": "openaddresses:address:us/ca/san_francisco:819b088d2837cf5d",
  "layer": "address",
  "source": "openaddresses",
  "source_id": "us/ca/san_francisco:819b088d2837cf5d",
  "country_code": "US",
  "name": "815 Tennessee Street",
  "housenumber": "815",
  "street": "Tennessee Street",
  "postalcode": "94107",
  "postalcode_gid": "openaddresses:address:us/ca/san_francisco:819b088d2837cf5d",
  "accuracy": "point",
  "country": "États-Unis",
  "country_gid": "whosonfirst:country:85633793",
  "country_a": "USA",
  "region": "Californie",
  "region_gid": "whosonfirst:region:85688637",
  "region_a": "CA",
  "county": "San Francisco",
  "county_gid": "whosonfirst:county:102087579",
  "county_a": "SF",
  "locality": "San Francisco",
  "locality_gid": "whosonfirst:locality:85922583",
  "locality_a": "SF",
  "neighbourhood": "Dogpatch",
  "neighbourhood_gid": "whosonfirst:neighbourhood:85882179",
  "continent": "Amérique du Nord",
  "continent_gid": "whosonfirst:continent:102191575",
  "label": "815 Tennessee Street, San Francisco, CA, USA"
}
```

Maybe when the postalcode is already present in the parent object we may not override it with OA data ?

Feel free the close the PR if this is not valuable for the project :smile: 