### PR TITLE
update lodash to newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "geolib": "^3.0.0",
     "iso-639-3": "^1.0.0",
     "locale": "^0.1.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.12",
     "markdown": "^0.5.0",
     "morgan": "^1.8.2",
     "pelias-compare": "^0.1.16",


### PR DESCRIPTION

#### Here's the reason for this change :rocket:
The project current uses `lodash@^4.17.4`, which is vulnerable to Prototype Pollution (see this [advisory link](https://github.com/advisories/GHSA-jf85-cpcp-j695)). The vulnerability has been patched in `4.17.12`.

---
#### Here's what actually got changed :clap:

dependency on lodash has been updated to `^4.17.12`

---
#### Here's how others can test the changes :eyes:

I ran the test suite and nothing seems to have broken from this update, so nothing to see here! 