### PR TITLE
fix for markdown path resolving when used as a library

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -206,10 +206,10 @@ function addRoutes(app, peliasConfig) {
 
   var routers = {
     index: createRouter([
-      controllers.markdownToHtml(peliasConfig.api, './public/apiDoc.md')
+      controllers.markdownToHtml(peliasConfig.api, path.join(__dirname, '../public/apiDoc.md'))
     ]),
     attribution: createRouter([
-      controllers.markdownToHtml(peliasConfig.api, './public/attribution.md')
+      controllers.markdownToHtml(peliasConfig.api, path.join(__dirname, '../public/attribution.md'))
     ]),
     search: createRouter([
       sanitizers.search.middleware(peliasConfig.api),


### PR DESCRIPTION
these two paths were being resolved by their relative position to the [CWD](https://en.wikipedia.org/wiki/Working_directory) rather than by their absolute path (using `path.join`), as per the other statements in this file.