### PR TITLE
Pin `remove-accents` to 0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "pelias-sorting": "^1.7.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",
-    "remove-accents": "^0.4.2",
+    "remove-accents": "0.4.2",
     "require-all": "^3.0.0",
     "retry": "^0.12.0",
     "stats-lite": "^2.0.4",


### PR DESCRIPTION
A unit test has been failing because this dependency added normalization to the German [Eszet](https://en.wikipedia.org/wiki/%C3%9F) character.

From a issue thread it sounds like we are going to encourage the maintainers to back out that change, but until then pin to a specific known-good version so that our unit tests pass :)

Fixes https://github.com/pelias/api/issues/1644
Connects https://github.com/tyxla/remove-accents/issues/12