### PR TITLE
Use GitHub Actions variable for Ubuntu version

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ${{ vars.UBUNTU_VERSION }}
         node-version:
           - 12.x
           - 14.x

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-    runs-on: ubuntu-20.04
+    runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Node.js
@@ -26,7 +26,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ubuntu-20.04
+    runs-on: ${{ vars.UBUNTU_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker images


### PR DESCRIPTION
This is a new approach to managing our Ubuntu version for CI where the version comes from a Github Actions variable instead of being hardcoded.

Hopefully this makes it easier for us to change the version in one go across all our repositories instead of having to make dozens of commits that are similar.

The variable's value is currently set to ubuntu-22.04, so this also handles https://github.com/pelias/pelias/issues/951

https://github.com/organizations/pelias/settings/variables/actions