### PR TITLE
Remove cutoff_frequency, deprecated in es7.3.0, forbidden in es8

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
     "pelias-parser": "2.2.0",
-    "pelias-query": "^11.0.0",
+    "pelias-query": "^11.2.0",
     "pelias-sorting": "^1.7.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -20,13 +20,11 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 100,
-  'ngram:cutoff_frequency': 0.01,
 
   'phrase:analyzer': 'peliasQuery',
   'phrase:field': 'phrase.default',
   'phrase:boost': 1,
   'phrase:slop': 3,
-  'phrase:cutoff_frequency': 0.01,
 
   'focus:function': 'exp',
   'focus:offset': '0km',
@@ -40,22 +38,18 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:housenumber:analyzer': 'peliasHousenumber',
   'address:housenumber:field': 'address_parts.number',
   'address:housenumber:boost': 2,
-  'address:housenumber:cutoff_frequency': 0.01,
 
   'address:street:analyzer': 'peliasQuery',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 1,
-  'address:street:cutoff_frequency': 0.01,
 
   'address:cross_street:analyzer': 'peliasQuery',
   'address:cross_street:field': 'address_parts.cross_street',
   'address:cross_street:boost': 5,
-  'address:cross_street:cutoff_frequency': 0.01,
 
   'address:postcode:analyzer': 'peliasZip',
   'address:postcode:field': 'address_parts.zip',
   'address:postcode:boost': 2000,
-  'address:postcode:cutoff_frequency': 0.01,
 
   // generic multi_match config
   'multi_match:type': 'cross_fields',
@@ -63,14 +57,9 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'multi_match:first_tokens_only:type': 'phrase',
   'multi_match:boost_exact_matches:type': 'phrase',
 
-  // setting 'cutoff_frequency' will result in very common
-  // terms such as country not scoring at all
-  // 'multi_match:cutoff_frequency': 0.01,
-
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a.ngram',
   'admin:country_a:boost': 1,
-  'admin:country_a:cutoff_frequency': 0.01,
 
   // these options affect the `boundary.country` hard filter
   'multi_match:boundary_country:analyzer': 'standard',
@@ -79,32 +68,26 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country.ngram',
   'admin:country:boost': 1,
-  'admin:country:cutoff_frequency': 0.01,
 
   'admin:dependency:analyzer': 'peliasAdmin',
   'admin:dependency:field': 'parent.dependency.ngram',
   'admin:dependency:boost': 1,
-  'admin:dependency:cutoff_frequency': 0.01,
 
   'admin:region:analyzer': 'peliasAdmin',
   'admin:region:field': 'parent.region.ngram',
   'admin:region:boost': 1,
-  'admin:region:cutoff_frequency': 0.01,
 
   'admin:region_a:analyzer': 'peliasAdmin',
   'admin:region_a:field': 'parent.region_a.ngram',
   'admin:region_a:boost': 1,
-  'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:macroregion:analyzer': 'peliasAdmin',
   'admin:macroregion:field': 'parent.macroregion.ngram',
   'admin:macroregion:boost': 1,
-  'admin:macroregion:cutoff_frequency': 0.01,
 
   'admin:county:analyzer': 'peliasAdmin',
   'admin:county:field': 'parent.county.ngram',
   'admin:county:boost': 1,
-  'admin:county:cutoff_frequency': 0.01,
 
   'admin:macrocounty:analyzer': 'peliasAdmin',
   'admin:macrocounty:field': 'parent.macrocounty.ngram',
@@ -114,27 +97,22 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin.ngram',
   'admin:localadmin:boost': 1,
-  'admin:localadmin:cutoff_frequency': 0.01,
 
   'admin:locality:analyzer': 'peliasAdmin',
   'admin:locality:field': 'parent.locality.ngram',
   'admin:locality:boost': 1,
-  'admin:locality:cutoff_frequency': 0.01,
 
   'admin:locality_a:analyzer': 'peliasAdmin',
   'admin:locality_a:field': 'parent.locality_a.ngram',
   'admin:locality_a:boost': 1,
-  'admin:locality_a:cutoff_frequency': 0.01,
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
   'admin:neighbourhood:field': 'parent.neighbourhood.ngram',
   'admin:neighbourhood:boost': 1,
-  'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'admin:borough:analyzer': 'peliasAdmin',
   'admin:borough:field': 'parent.borough.ngram',
   'admin:borough:boost': 1,
-  'admin:borough:cutoff_frequency': 0.01,
 
   // an additional 'name' field to add to admin multi-match queries.
   // this is used to improve venue matching in cases where the we

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -92,7 +92,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:macrocounty:analyzer': 'peliasAdmin',
   'admin:macrocounty:field': 'parent.macrocounty.ngram',
   'admin:macrocounty:boost': 1,
-  'admin:macrocounty:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin.ngram',

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -19,7 +19,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 1,
-  'ngram:cutoff_frequency': 0.01,
   'ngram:minimum_should_match': '1<-1 3<-25%',
 
   'match:main:analyzer': 'peliasQuery',
@@ -43,28 +42,22 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'address:housenumber:analyzer': 'peliasHousenumber',
   'address:housenumber:field': 'address_parts.number',
   'address:housenumber:boost': 2,
-  'address:housenumber:cutoff_frequency': 0.01,
 
   'address:street:analyzer': 'peliasQuery',
   'address:street:field': 'address_parts.street',
   'address:street:boost': 5,
   'address:street:slop': 4,
-  'address:street:cutoff_frequency': 0.01,
 
   'address:postcode:analyzer': 'peliasZip',
   'address:postcode:field': 'address_parts.zip',
   'address:postcode:boost': 20,
-  'address:postcode:cutoff_frequency': 0.01,
 
   // multi match query views require 'type' to be specified
   'multi_match:type': 'best_fields',
-  // generic multi_match cutoff_frequency
-  'multi_match:cutoff_frequency': 0.01,
 
   'admin:country_a:analyzer': 'standard',
   'admin:country_a:field': 'parent.country_a',
   'admin:country_a:boost': 1,
-  'admin:country_a:cutoff_frequency': 0.01,
 
   // these config variables are used for the 'boundary.country' hard filter
   'multi_match:boundary_country:analyzer': 'standard',
@@ -73,42 +66,34 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'admin:country:analyzer': 'peliasAdmin',
   'admin:country:field': 'parent.country',
   'admin:country:boost': 1,
-  'admin:country:cutoff_frequency': 0.01,
 
   'admin:region:analyzer': 'peliasAdmin',
   'admin:region:field': 'parent.region',
   'admin:region:boost': 1,
-  'admin:region:cutoff_frequency': 0.01,
 
   'admin:region_a:analyzer': 'peliasAdmin',
   'admin:region_a:field': 'parent.region_a',
   'admin:region_a:boost': 1,
-  'admin:region_a:cutoff_frequency': 0.01,
 
   'admin:county:analyzer': 'peliasAdmin',
   'admin:county:field': 'parent.county',
   'admin:county:boost': 1,
-  'admin:county:cutoff_frequency': 0.01,
 
   'admin:localadmin:analyzer': 'peliasAdmin',
   'admin:localadmin:field': 'parent.localadmin',
   'admin:localadmin:boost': 1,
-  'admin:localadmin:cutoff_frequency': 0.01,
 
   'admin:locality:analyzer': 'peliasAdmin',
   'admin:locality:field': 'parent.locality',
   'admin:locality:boost': 1,
-  'admin:locality:cutoff_frequency': 0.01,
 
   'admin:borough:analyzer': 'peliasAdmin',
   'admin:borough:field': 'parent.borough',
   'admin:borough:boost': 1,
-  'admin:borough:cutoff_frequency': 0.01,
 
   'admin:neighbourhood:analyzer': 'peliasAdmin',
   'admin:neighbourhood:field': 'parent.neighbourhood',
   'admin:neighbourhood:boost': 1,
-  'admin:neighbourhood:cutoff_frequency': 0.01,
 
   'popularity:field': 'popularity',
   'popularity:modifier': 'log1p',

--- a/test/unit/fixture/search_pelias_parser_full_address.js
+++ b/test/unit/fixture/search_pelias_parser_full_address.js
@@ -60,7 +60,6 @@ module.exports = {
         'match': {
           'address_parts.number': {
             'query': '123',
-            'cutoff_frequency': 0.01,
             'boost': vs['address:housenumber:boost'],
             'analyzer': vs['address:housenumber:analyzer']
           }
@@ -69,7 +68,6 @@ module.exports = {
         'match': {
           'address_parts.street': {
             'query': 'main st',
-            'cutoff_frequency': 0.01,
             'boost': vs['address:street:boost'],
             'analyzer': vs['address:street:analyzer']
           }
@@ -78,7 +76,6 @@ module.exports = {
         'match': {
           'address_parts.zip': {
             'query': '10010',
-            'cutoff_frequency': 0.01,
             'boost': vs['address:postcode:boost'],
             'analyzer': vs['address:postcode:analyzer']
           }

--- a/test/unit/fixture/search_pelias_parser_regions_address.js
+++ b/test/unit/fixture/search_pelias_parser_regions_address.js
@@ -59,7 +59,6 @@ module.exports = {
         'match': {
           'address_parts.number': {
             'query': '1',
-            'cutoff_frequency': 0.01,
             'boost': vs['address:housenumber:boost'],
             'analyzer': vs['address:housenumber:analyzer']
           }
@@ -68,7 +67,6 @@ module.exports = {
         'match': {
           'address_parts.street': {
             'query': 'water st',
-            'cutoff_frequency': 0.01,
             'boost': vs['address:street:boost'],
             'analyzer': vs['address:street:analyzer']
           }


### PR DESCRIPTION
#### Here's the reason for this change :rocket:

In pursuit of eventually supporting es8, I've dropped some es6 only behavior in https://github.com/pelias/query/pull/134.

**It's a draft** because it depends on https://github.com/pelias/query/pull/134 being released first.

---
#### Here's what actually got changed :clap:
- integrates the updated version of pelias-query which drops `cutoff_frequency`.
- updates the tests.

---
#### Here's how others can test the changes :eyes:


Other than `npm test`, I've run the [north-america tests](https://github.com/michaelkirk-pelias/docker/tree/mkirk/remove-cutoff-freq).

Note: The north-america tests aren't all passing, but the ones that are failing are exactly the same as when I run from current master. I'm assuming (🤞) that the failures reflect changes in the input data since the tests were updated, as [hypothesized over here](https://github.com/pelias/docker/issues/304).

```
Aggregate test results
Pass: 233
Improvements: 18
Expected Failures: 28
Placeholders: 0
Regressions: 84
Total tests: 363
Took 7774ms
Test success rate 76.86%
```

[north-america integration test output before](https://github.com/pelias/api/files/12135110/test-main-4.out.txt)
[north-america test output after](https://github.com/pelias/api/files/12135111/test-remove-cutoff-freq.out.txt)
