### PR TITLE
Add categories support to reverse query.

### DIFF
--- a/sanitizer/reverse.js
+++ b/sanitizer/reverse.js
@@ -37,7 +37,8 @@ module.exports.middleware = (_api_pelias_config) => {
     geo_reverse: require('../sanitizer/_geo_reverse')(),
     boundary_country: require('../sanitizer/_boundary_country')(),
     request_language: require('../sanitizer/_request_language')(),
-    boundary_gid: require('../sanitizer/_boundary_gid')()
+    boundary_gid: require('../sanitizer/_boundary_gid')(),
+    categories: require('../sanitizer/_categories')()
   };
 
   // middleware


### PR DESCRIPTION
This patch adds the support for categories by passing a get parameter just like https://github.com/pelias/documentation/blob/master/place.md

I was wanted to know the categories on what I was doing a reverse lookup on, and in highly populated areas, some businesses share the same lon/lat.  It can often help by including the category type.

You can test it out by using doing the following queries:
/v1/reverse?categories&point.lat=26.3622924&point.lon=-80.1355797
/v1/reverse?categories=health&point.lat=26.3622924&point.lon=-80.1355797

Documentation will also be provided in another pull request on pelias/documentation.