### PR TITLE
docker: move fs from /home/pelias to /code/pelias/api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@
 FROM pelias/baseimage
 USER pelias
 
-# Where the app is built and run inside the docker fs
-ENV WORK=/home/pelias
-WORKDIR ${WORK}
+# change working dir
+ENV WORKDIR /code/pelias/api
+RUN mkdir -p ${WORKDIR}
+WORKDIR ${WORKDIR}
 
 # copy package.json first to prevent npm install being rerun when only code changes
-COPY ./package.json ${WORK}
+COPY ./package.json ${WORKDIR}
 RUN npm install
 
-COPY . ${WORK}
+COPY . ${WORKDIR}
 
 # only allow containers to succeed if tests pass
 RUN npm test


### PR DESCRIPTION
this PR resolves https://github.com/pelias/docker/issues/318

the issue was caused by the code from this repo being copied to `/home/pelias` instead of the `/code/pelias/*` directories as used by other repos.

as a result the `/home/pelias` directory was only readable by the `pelias` user (1000), resulting in any user not sharing the UID 1000 to not be able to access files in the directory:

```bash
docker compose run api bash
[+] Building 0.0s (0/0)                                           docker:desktop-linux
[+] Building 0.0s (0/0)                                           docker:desktop-linux

I have no name!@4887bd97493c:/home/pelias$ pwd
/home/pelias

I have no name!@4887bd97493c:/home/pelias$ ls -lah
ls: cannot open directory '.': Permission denied
```

after this change the files live in `/code/pelias/api` and can be accessed:

```bash
docker compose run api bash
[+] Building 0.0s (0/0)                                           docker:desktop-linux
[+] Building 0.0s (0/0)                                           docker:desktop-linux

I have no name!@2156dd85f3b4:/code/pelias/api$ pwd
/code/pelias/api

I have no name!@2156dd85f3b4:/code/pelias/api$ ls -lah
total 376K
drwxr-xr-x   1 pelias pelias 4.0K Nov 28 11:14 .
drwxr-xr-x   1 pelias pelias 4.0K Nov 28 11:14 ..
-rw-r--r--   1 root   root    935 Nov  1  2021 app.js
-rw-r--r--   1 root   root   2.7K Jun 17  2019 autocomplete.md
drwxr-xr-x   2 root   root   4.0K Nov 11  2021 bin
drwxr-xr-x   3 root   root   4.0K Jul  8  2022 controller
-rw-r--r--   1 root   root    394 Nov 28 11:10 Dockerfile
-rw-r--r--   1 root   root    677 Oct  4  2018 .dockerignore
drwxr-xr-x   3 root   root   4.0K Nov  1  2021 .github
-rw-r--r--   1 root   root     59 Nov  1  2021 .gitignore
drwxr-xr-x   2 root   root   4.0K Jul  8  2022 helper
-rw-r--r--   1 root   root    755 Jul  8  2022 index.js
-rw-r--r--   1 root   root     30 Oct  4  2018 .jshintignore
-rw-r--r--   1 root   root    364 Nov  1  2021 .jshintrc
-rw-r--r--   1 root   root   1.1K Oct  4  2018 LICENSE
drwxr-xr-x   2 root   root   4.0K Jun 20  2022 middleware
drwxr-xr-x 301 pelias pelias  12K Nov 28 11:15 node_modules
-rw-r--r--   1 root   root     19 Oct  4  2018 .npmrc
-rw-r--r--   1 root   root    35K Aug 16  2021 out.clone
-rw-r--r--   1 root   root    45K Aug 16  2021 out.docs
-rw-r--r--   1 root   root   2.2K Nov 22 17:24 package.json
-rw-r--r--   1 pelias pelias 143K Nov 28 11:15 package-lock.json
drwxr-xr-x   2 root   root   4.0K Jul  3  2020 parser
-rw-r--r--   1 root   root    760 Aug 16  2021 pelias.docker.json
-rw-r--r--   1 root   root    696 Nov  1  2018 pelias.edge.json
-rw-r--r--   1 root   root    768 Jun 17  2019 pelias.tunnel.json
drwxr-xr-x   2 root   root   4.0K Feb  2  2022 public
drwxr-xr-x   3 root   root   4.0K May 10  2022 query
-rw-r--r--   1 root   root    14K Jul  8  2022 README.md
drwxr-xr-x   2 root   root   4.0K Nov 22 17:24 routes
drwxr-xr-x   2 root   root   4.0K Nov  7  2022 sanitizer
-rw-r--r--   1 root   root   2.5K Nov  1  2021 schema.js
drwxr-xr-x   3 root   root   4.0K Nov  1  2021 service
drwxr-xr-x   4 root   root   4.0K Nov  1  2021 test
```

I also tested and `./bin/start` can be executed successfully.