### PR TITLE
request params with a key but no value should be considered unset

### DIFF
--- a/controller/predicates/hasRequestParameter.js
+++ b/controller/predicates/hasRequestParameter.js
@@ -3,13 +3,15 @@ const Debug = require('../../helper/debug');
 const debugLog = new Debug('controller:predicates:has_request_parameter');
 const stackTraceLine = require('../../helper/stackTraceLine');
 
-// returns true IFF req.clean has a key with the supplied name
+// returns true IFF req.clean has a key with the supplied name AND a non-empty value
 module.exports = (parameter) => (req, res) => {
-  const has_request_parameter = _.has(req, ['clean', parameter]);
+  const value = _.get(req, ['clean', parameter]);
+  const has_request_parameter = _.isNumber(value) || !_.isEmpty(value);
 
   debugLog.push(req, () => ({
     reply: {[parameter]: has_request_parameter},
     stack_trace: stackTraceLine()
   }));
+
   return has_request_parameter;
 };

--- a/test/unit/controller/predicates/hasRequestParameter.js
+++ b/test/unit/controller/predicates/hasRequestParameter.js
@@ -12,7 +12,7 @@ module.exports.tests.interface = (test, common) => {
 
 module.exports.tests.true_conditions = (test, common) => {
   test('request with specified parameter should return true', t => {
-    [[], {}, 'string value', 17].forEach(val => {
+    [['foo'], {foo: 'bar'}, 'string value', 0, 17].forEach(val => {
       const req = {
         clean: {
           'parameter name': val
@@ -20,6 +20,25 @@ module.exports.tests.true_conditions = (test, common) => {
       };
 
       t.ok(hasRequestParameter('parameter name')(req));
+
+    });
+
+    t.end();
+
+  });
+
+};
+
+module.exports.tests.empty_values = (test, common) => {
+  test('request with specified parameter, but empty value, should true', t => {
+    [[], {}, '', null, undefined].forEach(val => {
+      const req = {
+        clean: {
+          'parameter name': val
+        }
+      };
+
+      t.notOk(hasRequestParameter('parameter name')(req));
 
     });
 


### PR DESCRIPTION
Regarding https://github.com/pelias/api/issues/1405#issuecomment-571228959 this PR changes the behaviour of the `hasRequestParameter` predicate.

Prior to this change it would return `true` when a query param *key* existed regardless of the *value*.

This PR modifies this behaviour so that the *value* must also be non-empty.

note: I believe the only place this has any consequence is for `?categories` as it's the only 'empty param' we currently support.

I'm not sure why the tests cover `Number` and `Object`, but I just maintained what we currently had 🤷‍♂️ .