### PR TITLE
improve unit number sorting for `fallback.housenumber` queries (`/v1/search`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
     "pelias-parser": "2.2.0",
-    "pelias-query": "^11.2.0",
+    "pelias-query": "^11.3.0",
     "pelias-sorting": "^1.7.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",

--- a/test/unit/fixture/search_fallback.js
+++ b/test/unit/fixture/search_fallback.js
@@ -187,6 +187,13 @@ module.exports = {
                 'should': [
                   {
                     'match_phrase': {
+                      'phrase.default': {
+                        'query': 'number value'
+                      }
+                    }
+                  },
+                  {
+                    'match_phrase': {
                       'address_parts.zip': {
                         'query': 'postalcode value'
                       }


### PR DESCRIPTION
Issue as described in https://github.com/pelias/pelias/issues/810
ref: https://github.com/pelias/query/pull/139

This PR resolves a long-standing issue with `/v1/search` where exact matches of unit numbers are not given priority in the sorting.

This is accomplished by adding a 'should' condition to all `fallback.address` queries which uses the original housenumber as parsed by libpostal (including *both* alpha an numeric tokens) to match against the `phrase.default` field, increasing its score slightly compared to the other matches.

The reason this is required is because the existing `match_phrase` `address_parts.number` query uses a tokenizer which strips non-numeric tokens.

<img width="1091" alt="Screenshot 2025-01-21 at 22 23 16" src="https://github.com/user-attachments/assets/78f959d8-6339-47e0-9c8b-d008341a1a19" />

resolves https://github.com/pelias/pelias/issues/810

Some caveats which are worth noting but not an issue in practice:
- If the parse contains the housenumber `1` (for instance) and the document `name.default` contains that token in *any position* (ie. `8 1 street`) then it will get a boost. This is likely not an issue as the `address_parts.street` *must* match.
- If the parse contains the housenumber `1` (for instance) and the document `name.default` contains that token *multiple times* (ie. `1/1 main street`) then it will get multiple boosts. This is likely not an issue but worth keeping an eye on.
- If the parse contains the housenumber `1 F` (for instance) and the document `name.default` contains the token `1F` then it will get no boost. This is something we might be able to improve.

https://pelias.github.io/compare/#/v1/search?text=kinkerstraat+175F&debug=1
