### PR TITLE
structured: make string replacements case insensitive

### DIFF
--- a/controller/structured_libpostal.js
+++ b/controller/structured_libpostal.js
@@ -49,14 +49,14 @@ function setup(libpostalService, should_execute) {
           req.clean.parsed_text.housenumber = house_number_field.value;
 
           // remove the first instance of the number and trim whitespace
-          req.clean.parsed_text.street = _.trim(_.replace(req.clean.parsed_text.address, req.clean.parsed_text.housenumber, ''));
+          req.clean.parsed_text.street = _.trim(replaceIgnoreCase(req.clean.parsed_text.address, req.clean.parsed_text.housenumber, ''));
 
           // If libpostal have parsed unit then add it for search
           const unit_field = findField(response, 'unit');
           if(unit_field) {
             req.clean.parsed_text.unit = unit_field.value;
             // Removing unit from street and trim
-            req.clean.parsed_text.street = _.trim(_.replace(req.clean.parsed_text.street, req.clean.parsed_text.unit, ''));
+            req.clean.parsed_text.street = _.trim(replaceIgnoreCase(req.clean.parsed_text.street, req.clean.parsed_text.unit, ''));
           }
 
         } else {
@@ -81,6 +81,11 @@ function setup(libpostalService, should_execute) {
   }
 
   return controller;
+}
+
+function replaceIgnoreCase(str, match, replacement) {
+  if (!_.isString(str) || !str.length) { return ''; }
+  return str.replace(new RegExp(_.escapeRegExp(match), 'i'), replacement);
 }
 
 module.exports = setup;

--- a/test/unit/controller/structured_libpostal.js
+++ b/test/unit/controller/structured_libpostal.js
@@ -340,6 +340,143 @@ module.exports.tests.success_conditions = (test, common) => {
 
   });
 
+  test('as above, case insensitive', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          label: 'road',
+          value: 'the street'
+        },
+        {
+          label: 'house_number',
+          value: '22'
+        },
+        {
+          label: 'unit',
+          value: '1 th'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        parsed_text: {
+          address: 'the street 22 1 TH'
+        }
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          parsed_text: {
+            street: 'the street',
+            housenumber: '22',
+            unit: '1 th'
+          }
+        },
+        errors: []
+      }, 'req should have been modified');
+
+      t.end();
+
+    });
+
+  });
+
+  test('service returning house_number and road should set req.clean.parsed_text.street', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          label: 'road',
+          value: 'kinkerstraat'
+        },
+        {
+          label: 'house_number',
+          value: '175f'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        parsed_text: {
+          address: 'kinkerstraat 175f'
+        }
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          parsed_text: {
+            street: 'kinkerstraat',
+            housenumber: '175f'
+          }
+        },
+        errors: []
+      }, 'req should have been modified');
+
+      t.end();
+
+    });
+
+  });
+
+  test('as above, case insensitive', t => {
+    const service = (req, callback) => {
+      const response = [
+        {
+          label: 'road',
+          value: 'kinkerstraat'
+        },
+        {
+          label: 'house_number',
+          value: '175f'
+        }
+      ];
+
+      callback(null, response);
+    };
+
+    const controller = libpostal(service, () => true);
+
+    const req = {
+      clean: {
+        parsed_text: {
+          address: 'kinkerstraat 175F'
+        }
+      },
+      errors: []
+    };
+
+    controller(req, undefined, () => {
+      t.deepEquals(req, {
+        clean: {
+          parsed_text: {
+            street: 'kinkerstraat',
+            housenumber: '175f'
+          }
+        },
+        errors: []
+      }, 'req should have been modified');
+
+      t.end();
+
+    });
+
+  });
+
   // test('service returning valid response should convert and append', t => {
   //   const service = (req, callback) => {
   //     const response = [


### PR DESCRIPTION
I noticed today that a `/v1/search/structured` query returned different results based on the casing of the unit number:

`/v1/search/structured?address=kinkerstraat+175f`
```
"parsed_text": [{
  "housenumber": "175f",
  "street": "kinkerstraat"
},
```

`/v1/search/structured?address=kinkerstraat+175F`
```
"parsed_text": [{
  "housenumber": "175f",
  "street": "kinkerstraat 175F"
},
```

This PR resolves the issue by converting some string replacement logic to be case-insensitive.