### PR TITLE
Allow custom minSize, maxSize and defaultSize values

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The API recognizes the following properties under the top-level `api` key in you
 |`accessLog`|*no*||name of the format to use for access logs; may be any one of the [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
 |`exposeInternalDebugTools`|*no*|true|Exposes several debugging tools, such as the ability to enable Elasticsearch explain mode, that may come at a performance cost or expose sensitive infrastructure details. Not recommended if the Pelias API is open to the public.
+|`minSize`|*no*|1|Allows to overwrite the minimal amount for the parameter size
+|`maxSize`|*no*|40|Allows to overwrite the maximal amount for the parameter size
+|`defaultSize`|*no*|10|Allows to overwrite the default amount for the parameter size. Must be greater than or equal to `minSize` and smaller than or equal to `maxSize`
 
 A good starting configuration file includes this section (fill in the service and Elasticsearch hosts as needed):
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ The API recognizes the following properties under the top-level `api` key in you
 |`accessLog`|*no*||name of the format to use for access logs; may be any one of the [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
 |`exposeInternalDebugTools`|*no*|true|Exposes several debugging tools, such as the ability to enable Elasticsearch explain mode, that may come at a performance cost or expose sensitive infrastructure details. Not recommended if the Pelias API is open to the public.
-|`minSize`|*no*|1|Allows to overwrite the minimal amount for the parameter size
-|`maxSize`|*no*|40|Allows to overwrite the maximal amount for the parameter size
-|`defaultSize`|*no*|10|Allows to overwrite the default amount for the parameter size. Must be greater than or equal to `minSize` and smaller than or equal to `maxSize`
+|`minSize`|*no*|1| Allows configuring the minimum number of results a query can request.
+|`maxSize`|*no*|40| Allows configuring the maximum number of results a query can request.
+|`defaultSize`|*no*|10| Allows configuring the number of results a query will request when a size wasn't specified. Must be greater than or equal to `minSize` and smaller than or equal to `maxSize`.
 
 A good starting configuration file includes this section (fill in the service and Elasticsearch hosts as needed):
 

--- a/sanitizer/_size.js
+++ b/sanitizer/_size.js
@@ -18,33 +18,33 @@ const DEFAULT_SIZE = default_size_init;
 
 
 // validate inputs, convert types and apply defaults
-function _setup(size_min, size_max, size_def) {
+function _setup( size_min, size_max, size_def ){
 
   // allow caller to inject custom min/max/default values
-  if (!_.isFinite(size_min)) { size_min = MIN_SIZE; }
-  if (!_.isFinite(size_max)) { size_max = MAX_SIZE; }
-  if (!_.isFinite(size_def)) { size_def = DEFAULT_SIZE; }
+  if( !_.isFinite( size_min ) ){ size_min = MIN_SIZE; }
+  if( !_.isFinite( size_max ) ){ size_max = MAX_SIZE; }
+  if( !_.isFinite( size_def ) ){ size_def = DEFAULT_SIZE; }
 
   return {
-    sanitize: function _sanitize(raw, clean) {
+    sanitize: function _sanitize( raw, clean ){
 
       // error & warning messages
       var messages = { errors: [], warnings: [] };
 
       // coercions
-      clean.size = parseInt(raw.size, 10);
+      clean.size = parseInt( raw.size, 10 );
 
       // invalid numeric input
-      if (isNaN(clean.size)) {
+      if( isNaN( clean.size ) ){
         clean.size = size_def;
       }
       // ensure size falls within defined range
-      else if (clean.size > size_max) {
+      else if( clean.size > size_max ){
         // set the max size
         messages.warnings.push('out-of-range integer \'size\', using MAX_SIZE');
         clean.size = size_max;
       }
-      else if (clean.size < size_min) {
+      else if( clean.size < size_min ){
         // set the min size
         messages.warnings.push('out-of-range integer \'size\', using MIN_SIZE');
         clean.size = size_min;

--- a/sanitizer/_size.js
+++ b/sanitizer/_size.js
@@ -1,36 +1,40 @@
 const _ = require('lodash');
-const MIN_SIZE = 1;
-const MAX_SIZE = 40;
-const DEFAULT_SIZE = 10;
+const peliasConfig = require('pelias-config').generate().api;
+//Allow custom min, max and default sizes
+const MIN_SIZE = peliasConfig.minSize || 1;
+const MAX_SIZE = peliasConfig.maxSize || 40;
+//If max_size is smaller than default => default=max
+const DEFAULT_SIZE = peliasConfig.defaultSize || (MAX_SIZE < 10) ? MAX_SIZE : 10;
+
 
 // validate inputs, convert types and apply defaults
-function _setup( size_min, size_max, size_def ){
+function _setup(size_min, size_max, size_def) {
 
   // allow caller to inject custom min/max/default values
-  if( !_.isFinite( size_min ) ){ size_min = MIN_SIZE; }
-  if( !_.isFinite( size_max ) ){ size_max = MAX_SIZE; }
-  if( !_.isFinite( size_def ) ){ size_def = DEFAULT_SIZE; }
+  if (!_.isFinite(size_min)) { size_min = MIN_SIZE; }
+  if (!_.isFinite(size_max)) { size_max = MAX_SIZE; }
+  if (!_.isFinite(size_def)) { size_def = DEFAULT_SIZE; }
 
   return {
-    sanitize: function _sanitize( raw, clean ){
+    sanitize: function _sanitize(raw, clean) {
 
       // error & warning messages
       var messages = { errors: [], warnings: [] };
 
       // coercions
-      clean.size = parseInt( raw.size, 10 );
+      clean.size = parseInt(raw.size, 10);
 
       // invalid numeric input
-      if( isNaN( clean.size ) ){
+      if (isNaN(clean.size)) {
         clean.size = size_def;
       }
       // ensure size falls within defined range
-      else if( clean.size > size_max ){
+      else if (clean.size > size_max) {
         // set the max size
         messages.warnings.push('out-of-range integer \'size\', using MAX_SIZE');
         clean.size = size_max;
       }
-      else if( clean.size < size_min ){
+      else if (clean.size < size_min) {
         // set the min size
         messages.warnings.push('out-of-range integer \'size\', using MIN_SIZE');
         clean.size = size_min;

--- a/sanitizer/_size.js
+++ b/sanitizer/_size.js
@@ -3,8 +3,22 @@ const peliasConfig = require('pelias-config').generate().api;
 //Allow custom min, max and default sizes
 const MIN_SIZE = peliasConfig.minSize || 1;
 const MAX_SIZE = peliasConfig.maxSize || 40;
-//If max_size is smaller than default => default=max
-const DEFAULT_SIZE = peliasConfig.defaultSize || (MAX_SIZE < 10) ? MAX_SIZE : 10;
+let default_size_init;
+if (peliasConfig.DEFAULT_SIZE) {
+  //Cant be smaller/bigger than min/max due to validation in schema.js
+  default_size_init = peliasConfig.DEFAULT_SIZE;
+}
+else if (MIN_SIZE > 10) {
+  default_size_init = MIN_SIZE;
+}
+else if (MAX_SIZE < 10) {
+  default_size_init = MAX_SIZE;
+}
+else {
+  default_size_init = 10;
+}
+const DEFAULT_SIZE =default_size_init;
+
 
 
 // validate inputs, convert types and apply defaults
@@ -13,7 +27,7 @@ function _setup(size_min, size_max, size_def) {
   // allow caller to inject custom min/max/default values
   if (!_.isFinite(size_min)) { size_min = MIN_SIZE; }
   if (!_.isFinite(size_max)) { size_max = MAX_SIZE; }
-  if (!_.isFinite(size_def)) { size_def = DEFAULT_SIZE; }
+  if (!_.isFinite(size_def)) { size_def = default_size_init; }
 
   return {
     sanitize: function _sanitize(raw, clean) {

--- a/sanitizer/_size.js
+++ b/sanitizer/_size.js
@@ -1,21 +1,10 @@
 const _ = require('lodash');
-const peliasConfig = require('pelias-config').generate().api;
-//Allow custom min, max and default sizes
-const MIN_SIZE = peliasConfig.minSize || 1;
-const MAX_SIZE = peliasConfig.maxSize || 40;
-let default_size_init = 10;
-if (peliasConfig.DEFAULT_SIZE && peliasConfig.DEFAULT_SIZE >= MIN_SIZE && peliasConfig.DEFAULT_SIZE <= MAX_SIZE) {
-  default_size_init = peliasConfig.DEFAULT_SIZE;
-}
-else if (MIN_SIZE > 10) {
-  default_size_init = MIN_SIZE;
-}
-else if (MAX_SIZE < 10) {
-  default_size_init = MAX_SIZE;
-}
-const DEFAULT_SIZE = default_size_init;
+const peliasConfig = require('pelias-config').generate();
 
-
+// Allow custom min, max and default sizes
+const MIN_SIZE = _.get(peliasConfig, 'api.minSize', 1);
+const MAX_SIZE = _.get(peliasConfig, 'api.maxSize', 40);
+const DEFAULT_SIZE = _.clamp(_.get(peliasConfig, 'api.defaultSize', 10), MIN_SIZE, MAX_SIZE);
 
 // validate inputs, convert types and apply defaults
 function _setup( size_min, size_max, size_def ){

--- a/sanitizer/_size.js
+++ b/sanitizer/_size.js
@@ -3,9 +3,8 @@ const peliasConfig = require('pelias-config').generate().api;
 //Allow custom min, max and default sizes
 const MIN_SIZE = peliasConfig.minSize || 1;
 const MAX_SIZE = peliasConfig.maxSize || 40;
-let default_size_init;
-if (peliasConfig.DEFAULT_SIZE) {
-  //Cant be smaller/bigger than min/max due to validation in schema.js
+let default_size_init = 10;
+if (peliasConfig.DEFAULT_SIZE && peliasConfig.DEFAULT_SIZE >= MIN_SIZE && peliasConfig.DEFAULT_SIZE <= MAX_SIZE) {
   default_size_init = peliasConfig.DEFAULT_SIZE;
 }
 else if (MIN_SIZE > 10) {
@@ -14,10 +13,7 @@ else if (MIN_SIZE > 10) {
 else if (MAX_SIZE < 10) {
   default_size_init = MAX_SIZE;
 }
-else {
-  default_size_init = 10;
-}
-const DEFAULT_SIZE =default_size_init;
+const DEFAULT_SIZE = default_size_init;
 
 
 
@@ -27,7 +23,7 @@ function _setup(size_min, size_max, size_def) {
   // allow caller to inject custom min/max/default values
   if (!_.isFinite(size_min)) { size_min = MIN_SIZE; }
   if (!_.isFinite(size_max)) { size_max = MAX_SIZE; }
-  if (!_.isFinite(size_def)) { size_def = default_size_init; }
+  if (!_.isFinite(size_def)) { size_def = DEFAULT_SIZE; }
 
   return {
     sanitize: function _sanitize(raw, clean) {

--- a/schema.js
+++ b/schema.js
@@ -31,8 +31,7 @@ module.exports = Joi.object().keys({
     }),
     minSize: Joi.number().integer().min(1).max(Joi.ref('maxSize')).default(1),
     maxSize: Joi.number().integer().min(1).default(40),
-    defaultSize: Joi.number().min(1).max(Joi.ref('maxSize')).min(Joi.ref('minSize')).default(10),
-    //Cant be smaller/bigger than the min/max values. Newline for the linter
+    defaultSize: Joi.number().min(Joi.ref('minSize')).max(Joi.ref('maxSize')).default(10),
     localization: Joi.object().keys({
       flipNumberAndStreetCountries: Joi.array().items(Joi.string().regex(/^[A-Z]{3}$/))
     }).unknown(false),

--- a/schema.js
+++ b/schema.js
@@ -31,7 +31,7 @@ module.exports = Joi.object().keys({
     }),
     minSize: Joi.number().integer().min(1).max(Joi.ref('maxSize')).default(1),
     maxSize: Joi.number().integer().min(1).default(40),
-    defaultSize: Joi.number().min(1).max(Joi.ref('maxSize')).min(Joi.ref('minSize')).default(10), 
+    defaultSize: Joi.number().min(1).max(Joi.ref('maxSize')).min(Joi.ref('minSize')).default(10),
     //Cant be smaller/bigger than the min/max values. Newline for the linter
     localization: Joi.object().keys({
       flipNumberAndStreetCountries: Joi.array().items(Joi.string().regex(/^[A-Z]{3}$/))
@@ -61,8 +61,8 @@ module.exports = Joi.object().keys({
       }).unknown(false)
     }).unknown(false).default({}), // default api.services to an empty object
     defaultParameters: Joi.object().keys({
-      'focus.point.lat': Joi.number(),
-      'focus.point.lon': Joi.number(),
+        'focus.point.lat': Joi.number(),
+        'focus.point.lon': Joi.number(),
     }).unknown(true).default({})
 
   }).unknown(true),

--- a/schema.js
+++ b/schema.js
@@ -13,6 +13,9 @@ const Joi = require('@hapi/joi');
 // * api.relativeScores (boolean)
 // * api.exposeInternalDebugTools (boolean)
 // * api.localization (flipNumberAndStreetCountries is array of 3 character strings)
+// * api.maxSize (int)
+// * api.minSize (int)
+// * api.defaultSize (int)
 module.exports = Joi.object().keys({
   api: Joi.object().required().keys({
     version: Joi.string(),
@@ -26,6 +29,10 @@ module.exports = Joi.object().keys({
       layer: Joi.object(),
       source: Joi.object()
     }),
+    minSize: Joi.number().min(1).max(Joi.ref('maxSize')).default(1),
+    maxSize: Joi.number().min(1).default(40),
+    defaultSize: Joi.number().min(1).max(Joi.ref('maxSize')).min(Joi.ref('minSize')).default(10), 
+    //Cant be smaller/bigger than the min/max values. Newline for the linter
     localization: Joi.object().keys({
       flipNumberAndStreetCountries: Joi.array().items(Joi.string().regex(/^[A-Z]{3}$/))
     }).unknown(false),
@@ -54,8 +61,8 @@ module.exports = Joi.object().keys({
       }).unknown(false)
     }).unknown(false).default({}), // default api.services to an empty object
     defaultParameters: Joi.object().keys({
-        'focus.point.lat': Joi.number(),
-        'focus.point.lon': Joi.number(),
+      'focus.point.lat': Joi.number(),
+      'focus.point.lon': Joi.number(),
     }).unknown(true).default({})
 
   }).unknown(true),

--- a/schema.js
+++ b/schema.js
@@ -29,8 +29,8 @@ module.exports = Joi.object().keys({
       layer: Joi.object(),
       source: Joi.object()
     }),
-    minSize: Joi.number().min(1).max(Joi.ref('maxSize')).default(1),
-    maxSize: Joi.number().min(1).default(40),
+    minSize: Joi.number().integer().min(1).max(Joi.ref('maxSize')).default(1),
+    maxSize: Joi.number().integer().min(1).default(40),
     defaultSize: Joi.number().min(1).max(Joi.ref('maxSize')).min(Joi.ref('minSize')).default(10), 
     //Cant be smaller/bigger than the min/max values. Newline for the linter
     localization: Joi.object().keys({

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -1,4 +1,3 @@
-const Joi = require('@hapi/joi');
 const schema = require('../../schema');
 const _ = require('lodash');
 

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -1066,7 +1066,7 @@ module.exports.all = (tape, common) => {
     return tape('configValidation: ' + name, testFunction);
   }
 
-  for (var testCase in module.exports.tests) {
+  for( var testCase in module.exports.tests ){
     module.exports.tests[testCase](test, common);
   }
 };

--- a/test/unit/schema.js
+++ b/test/unit/schema.js
@@ -34,7 +34,10 @@ module.exports.tests.completely_valid = (test, common) => {
         defaultParameters: {
           'focus.point.lat': 19,
           'focus.point.lon': 91
-        }
+        },
+        minSize: 1,
+        maxSize: 40,
+        defaultSize: 10
       },
       esclient: {
         requestTimeout: 17
@@ -517,6 +520,92 @@ module.exports.tests.api_validation = (test, common) => {
 
   });
 
+  test('config with non-integer maxSize should throw an error', (t) => {
+    var config = {
+      api: {
+        version: 'version value',
+        indexName: 'index name value',
+        host: 'host value',
+        maxSize: 'ab'
+      },
+      esclient: {
+        requestTimeout: 17
+      },
+    };
+
+    const result = schema.validate(config);
+
+    t.equals(result.error.details.length, 1);
+    t.equals(result.error.details[0].message, '"api.maxSize" must be a number');
+    t.end();
+
+ });
+
+ test('config with a negative minSize should throw an error', (t) => {
+  var config = {
+    api: {
+      version: 'version value',
+      indexName: 'index name value',
+      host: 'host value',
+      minSize: -1
+    },
+    esclient: {
+      requestTimeout: 17
+    },
+  };
+
+  const result = schema.validate(config);
+
+  t.equals(result.error.details.length, 1);
+  t.equals(result.error.details[0].message, '"api.minSize" must be larger than or equal to 1');
+  t.end();
+
+});
+
+test('config with a bigger defaultSize than maxSize should throw an error', (t) => {
+  var config = {
+    api: {
+      version: 'version value',
+      indexName: 'index name value',
+      host: 'host value',
+      maxSize: 5,
+      defaultSize: 6
+    },
+    esclient: {
+      requestTimeout: 17
+    },
+  };
+
+  const result = schema.validate(config);
+
+  t.equals(result.error.details.length, 1);
+  t.equals(result.error.details[0].message, '"api.defaultSize" must be less than or equal to ref:maxSize');
+  t.end();
+
+});
+
+test('config with a bigger minSize than maxSize should throw an error', (t) => {
+  var config = {
+    api: {
+      version: 'version value',
+      indexName: 'index name value',
+      host: 'host value',
+      maxSize: 5,
+      minSize: 6
+    },
+    esclient: {
+      requestTimeout: 17
+    },
+  };
+
+  const result = schema.validate(config);
+
+  t.equals(result.error.details.length, 1);
+  t.equals(result.error.details[0].message, '"api.minSize" must be less than or equal to ref:maxSize');
+  t.end();
+
+});
+
 
 };
 
@@ -977,7 +1066,7 @@ module.exports.all = (tape, common) => {
     return tape('configValidation: ' + name, testFunction);
   }
 
-  for( var testCase in module.exports.tests ){
+  for (var testCase in module.exports.tests) {
     module.exports.tests[testCase](test, common);
   }
 };


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
Closes #1649 

---
#### Here's what actually got changed :clap:
Allows users to modify their max/max/defaultSize in the pelias.json. If no values are given it will defaults to the original ones (1,40,10) so this PR should be backwards compatible.

---
#### Here's how others can test the changes :eyes:
Spin up an instance, set some custom values in the pelias.json 
(eg: 
```json
"api": {
    "services": {
      "pip": {
        "url": "http://localhost:4200"
      },
      "libpostal": {
        "url": "http://localhost:4400"
      },
      "placeholder": {
        "url": "http://localhost:4100"
      },
      "interpolation": {
        "url": "http://localhost:4300"
      }
    },
    "minSize": 2,
    "maxSize": 5,
    "defaultSize": 5
  },
  ```
) and play around with the `size` parameter (eg. `size=6` should throw a warning).
There are also a few tests to verify that everything runs as expected :)