### PR TITLE
correct `config.schema.indexName` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ The API recognizes the following properties under the top-level `api` key in you
 |`targets.layers_by_source` <br> `targets.source_aliases` <br> `targets.layer_aliases`|no | |custom values for which `sources` and `layers` the API accepts (See more info in the [Custom sources and layers](#custom-sources-and-layers) section below). We recommend using the `targets.auto_discover:true` configuration instead of setting these manually.
 |`customBoosts` | no | `{}` | Allows configuring boosts for specific sources and layers, in order to influence result order. See [Configurable Boosts](#custom-boosts) below for details |
 |`autocomplete.exclude_address_length` | no | 0 | As a performance optimization, this optional filter excludes results from the 'address' layer for any queries where the character length of the 'subject' portion of the parsed_text is equal to or less than this many characters in length. Addresses are usually the bulk of the records in Elasticsearch, and searching across all of them for very short text inputs can be slow, with little benefit. Consider setting this to 1 or 2 if you have several million addresses in Pelias. |
-|`indexName`|*no*|*pelias*|name of the Elasticsearch index to be used when building queries|
 |`attributionURL`|no| (autodetected)|The full URL to use for the attribution link returned in all Pelias responses. Pelias will attempt to autodetect this host, but it will often be incorrect if, for example, there is a proxy between Pelias and its users. This parameter allows setting a specific URL to avoid any such issues|
 |`accessLog`|*no*||name of the format to use for access logs; may be any one of the [predefined values](https://github.com/expressjs/morgan#predefined-formats) in the `morgan` package. Defaults to `"common"`; if set to `false`, or an otherwise falsy value, disables access-logging entirely.|
 |`relativeScores`|*no*|true|if set to true, confidence scores will be normalized, realistically at this point setting this to false is not tested or desirable
@@ -76,6 +75,12 @@ The API recognizes the following properties under the top-level `api` key in you
 |`minSize`|*no*|1| Allows configuring the minimum number of results a query can request.
 |`maxSize`|*no*|40| Allows configuring the maximum number of results a query can request.
 |`defaultSize`|*no*|10| Allows configuring the number of results a query will request when a size wasn't specified. Must be greater than or equal to `minSize` and smaller than or equal to `maxSize`.
+
+The API recognizes the following properties under the top-level `schema` key in your `pelias.json` config file:
+
+|parameter|required|default|description|
+|---|---|---|---|
+|`indexName`|*no*|*pelias*|name of the Elasticsearch index to be used when building queries|
 
 A good starting configuration file includes this section (fill in the service and Elasticsearch hosts as needed):
 


### PR DESCRIPTION
The `indexName` configuration is parented by `schema`, not by `api`.

ref: https://github.com/pelias/config/blob/4a52a15a85767407591deaabd78b4e87f09f74f7/config/defaults.json#L73
related: https://github.com/pelias/schema/pull/507#discussion_r1989007224