### PR TITLE
Handle sources and layers param with address filter

### DIFF
--- a/sanitizer/_address_layer_filter.js
+++ b/sanitizer/_address_layer_filter.js
@@ -103,7 +103,6 @@ function _setup(tm) {
 
         // handle the case where 'sources' were explicitly specified
         else if (_.isArray(clean.sources)) {
-
           // we need to create a list of layers for the specified sources
           let sourceLayers = clean.sources.reduce((l, key) => l.concat(tm.layers_by_source[key] || []), []);
           sourceLayers = _.uniq(sourceLayers); // dedupe
@@ -114,8 +113,18 @@ function _setup(tm) {
             return messages;
           }
 
-          // target all layers for the sources specified except 'address'
-          clean.layers = sourceLayers.filter(item => item !== 'address'); // exclude 'address'
+          // create a list of all "possible layers": layers from the specified sources, minus address layer
+          const possibleLayers = sourceLayers.filter(item => item !== 'address');
+
+          // intersect the possible layers with any already specified layer preferences
+          if (_.isArray(clean.layers) && clean.layers.length > 1) {
+            // layers already exist, intersect
+            clean.layers = _.intersection(clean.layers, possibleLayers);
+          } else {
+            // no layers already, use all possible layers
+            clean.layers = possibleLayers;
+          }
+
           messages.warnings.push(ADDRESS_FILTER_WARNING);
         }
       }

--- a/test/unit/sanitizer/_address_layer_filter.js
+++ b/test/unit/sanitizer/_address_layer_filter.js
@@ -117,6 +117,26 @@ module.exports.tests.sanitize = function (test, common) {
     t.end();
   });
 
+  test('sanitize - exclude addresses when negative layers and sources are specified', (t) => {
+    // select all layers except venue to simulate value of clean.layers from targets sanitizer
+    const clean_layers = real_type_mapping.getCanonicalLayers().filter(layer => layer !== 'venue').sort();
+
+    let clean = { text: 'foo',
+      layers: clean_layers,
+      negative_layers: ['venue'],
+      positive_layers: [],
+      sources: ['openstreetmap', 'openaddresses','whosonfirst'],
+      negative_sources: ['geonames'],
+      positive_sources: []
+    };
+
+    const expected_layers = clean_layers.filter(layer => layer !== 'address').sort();
+
+    t.deepEqual(real_sanitizer.sanitize(null, clean), STD_MESSAGES);
+    t.deepEqual(clean.layers.sort(), expected_layers, 'layer list is reduced to exclude addresses');
+    t.end();
+  });
+
   test('sanitize - exclude addresses when negative layers other than address are specified', (t) => {
     // select all layers except venue to simulate value of clean.layers from targets sanitizer
     const clean_layers = real_type_mapping.getCanonicalLayers().filter(layer => layer !== 'venue').sort();


### PR DESCRIPTION
As reported in https://github.com/pelias/api/issues/1653, there is an issue when negative sources are specified in combination with negative layers. The end result is that the negative layers are ignored.

This issue was likely introduced in https://github.com/pelias/api/pull/1604 or https://github.com/pelias/api/pull/1525, the pull requests where we added the concept of negative sources and layers and subsequently improved them.

The change is split into two commits, a pure refactoring for clarity, and then the fix, which is quite short.

Fixes https://github.com/pelias/api/pull/1653
