### PR TITLE
Remove bounding box query type parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pelias-microservice-wrapper": "^1.10.0",
     "pelias-model": "^9.0.0",
     "pelias-parser": "2.2.0",
-    "pelias-query": "^11.3.0",
+    "pelias-query": "^11.4.0",
     "pelias-sorting": "^1.7.0",
     "predicates": "^2.0.0",
     "regenerate": "^1.4.0",

--- a/query/autocomplete_defaults.js
+++ b/query/autocomplete_defaults.js
@@ -15,8 +15,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'boundary:circle:radius': '50km',
   'boundary:circle:distance_type': 'plane',
 
-  'boundary:rect:type': 'indexed',
-
   'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 100,

--- a/query/reverse_defaults.js
+++ b/query/reverse_defaults.js
@@ -15,8 +15,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'boundary:circle:radius': '1km',
   'boundary:circle:distance_type': 'plane',
 
-  'boundary:rect:type': 'indexed',
-
   'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 1,

--- a/query/search_defaults.js
+++ b/query/search_defaults.js
@@ -14,8 +14,6 @@ module.exports = _.merge({}, peliasQuery.defaults, {
   'boundary:circle:radius': '50km',
   'boundary:circle:distance_type': 'plane',
 
-  'boundary:rect:type': 'indexed',
-
   'ngram:analyzer': 'peliasQuery',
   'ngram:field': 'name.default',
   'ngram:boost': 1,

--- a/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
+++ b/test/unit/fixture/autocomplete_linguistic_bbox_san_francisco.js
@@ -52,7 +52,6 @@ module.exports = {
       }],
       'filter': [{
         'geo_bounding_box': {
-          'type': 'indexed',
           'center_point': {
             'top': 37.83239,
             'right': -122.35698,

--- a/test/unit/fixture/search_linguistic_bbox.js
+++ b/test/unit/fixture/search_linguistic_bbox.js
@@ -34,7 +34,6 @@ module.exports = {
               'must': [
                 {
                   'geo_bounding_box': {
-                    'type': 'indexed',
                     'center_point': {
                       'top': 11.51,
                       'right': -61.84,

--- a/test/unit/fixture/search_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_linguistic_focus_bbox.js
@@ -34,7 +34,6 @@ module.exports = {
               'must': [
                 {
                   'geo_bounding_box': {
-                    'type': 'indexed',
                     'center_point': {
                       'top': 11.51,
                       'right': -61.84,

--- a/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_bbox.js
@@ -56,7 +56,6 @@ module.exports = {
       }],
       'filter': [{
         'geo_bounding_box': {
-          'type': 'indexed',
           'center_point': {
             'top': 11.51,
             'right': -61.84,

--- a/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
+++ b/test/unit/fixture/search_pelias_parser_linguistic_focus_bbox.js
@@ -78,7 +78,6 @@ module.exports = {
       }],
       'filter': [{
         'geo_bounding_box': {
-          'type': 'indexed',
           'center_point': {
             'top': 11.51,
             'right': -61.84,


### PR DESCRIPTION
The parameter has been deprecates in 7.14 as it is a no-op.

Requires pelias/query#140

### TODO
- [x] update `pelias-query` version in `package.json`
