### PR TITLE
add `applyOverrides` middleware to place endpoint

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -331,6 +331,7 @@ function addRoutes(app, peliasConfig) {
       middleware.requestLanguage,
       controllers.place(peliasConfig.api, esclient),
       middleware.expandDocument(peliasConfig.api, esclient),
+      middleware.applyOverrides(),
       middleware.accuracy(),
       middleware.localNamingConventions(),
       middleware.mapFields(),


### PR DESCRIPTION
the rarely used `applyOverrides` middleware was added in https://github.com/pelias/api/pull/1494 but wasn't added to the `/v1/place` endpoint.

this PR ensures that the middleware is run for all endpoints.