### PR TITLE
Allow sending `track_total_hits` with ES query

### DIFF
--- a/controller/search.js
+++ b/controller/search.js
@@ -59,6 +59,10 @@ function setup( peliasConfig, esclient, query, should_execute ){
       cmd.explain = true;
     }
 
+    if (_.get(apiConfig, 'trackTotalHits') === true) {
+      cmd.track_total_hits = true;
+    }
+
     // support for the 'clean.exposeInternalDebugTools' config flag
     let debugUrl;
     if (_.get(req, 'clean.exposeInternalDebugTools') === true) {


### PR DESCRIPTION
A few versions ago, Elasticsearch introduced an optimization where they only approximate the total hit count for a query (max of 10,000).

It's of course nice to get better performance, but having hit count information is also super useful to examine queries for our own optimization.

This change allows us to enable the [`track_total_hits`](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search#operation-search-track_total_hits) flag on ES queries, with the similar `api.trackTotalHits` boolean in `pelias.json`.