### PR TITLE
`address_search_using_ids`: add `macrocounty` as synonym for locality

### DIFF
--- a/query/address_search_using_ids.js
+++ b/query/address_search_using_ids.js
@@ -131,6 +131,12 @@ function generateQuery( clean, res ){
   // find the first granularity band for which there are results
   const granularity_band = granularity_bands.find(band => anyResultsAtGranularityBand(results, band));
 
+  // special case: if locality is present in the band, also include macrocounty
+  // this is used to cover the Greater Syndey Area
+  if (granularity_band && granularity_band.includes('locality')) {
+    granularity_band.push('macrocounty');
+  }
+
   // if there's a granularity band, accumulate the ids from each layer in the band
   // into an object mapping layer->ids of those layers
   if (granularity_band) {

--- a/test/unit/query/address_search_using_ids.js
+++ b/test/unit/query/address_search_using_ids.js
@@ -287,14 +287,15 @@ module.exports.tests.granularity_bands = (test, common) => {
     const generatedQuery = generateQuery(clean, res);
 
     t.deepEquals(generatedQuery.body.vs.var('input:layers').$, {
-      neighbourhood: [1, 11],
-      borough: [2, 12],
-      locality: [3, 13],
-      localadmin: [4, 14],
-      region: [7, 17],
-      macroregion: [8, 18],
-      dependency: [9, 19],
-      country: [10, 20]
+      neighbourhood: [ 1, 11 ],
+      borough: [ 2, 12 ],
+      locality: [ 3, 13 ],
+      localadmin: [ 4, 14 ],
+      region: [ 7, 17 ],
+      macroregion: [ 8, 18 ],
+      dependency: [ 9, 19 ],
+      country: [ 10, 20 ],
+      macrocounty: [ 6, 16 ]
     });
 
     t.end();
@@ -339,7 +340,8 @@ module.exports.tests.granularity_bands = (test, common) => {
       region: [],
       macroregion: [],
       dependency: [],
-      country: []
+      country: [],
+      macrocounty: []
     });
 
     t.end();
@@ -607,6 +609,85 @@ module.exports.tests.boundary_filters = (test, common) => {
 
   });
 
+};
+
+module.exports.tests.sydney_macrocounty = (test, common) => {
+  test('Refering to Greater Sydney area (macrocounty) rather than Sydney Metro Area (locality)', (t) => {
+    const logger = mock_logger();
+
+    const clean = {
+      text: '300 Burns Bay Road, Sydney, AU',
+      parsed_text: {
+        housenumber: '300',
+        street: 'burns bay road',
+        city: 'sydney',
+        country: 'AUS'
+      }
+    };
+    const res = {
+      data: [
+        {
+          layer: 'continent',
+          source_id: '102191583'
+        },
+        {
+          layer: 'country',
+          source_id: '85632793'
+        },
+        {
+          layer: 'county',
+          source_id: '102049151'
+        },
+        {
+          layer: 'empire',
+          source_id: '136253039'
+        },
+        {
+          layer: 'localadmin',
+          source_id: '404226357'
+        },
+        {
+          layer: 'locality',
+          source_id: '101932003'
+        },
+        {
+          layer: 'macrocounty',
+          source_id: '1376953385'
+        },
+        {
+          layer: 'region',
+          source_id: '85681545'
+        }
+      ]
+    };
+
+    const generateQuery = proxyquire('../../../query/address_search_using_ids', {
+      'pelias-logger': logger,
+      'pelias-query': {
+        layout: {
+          AddressesUsingIdsQuery: MockQuery
+        },
+        view: views,
+        Vars: require('pelias-query').Vars
+      }
+    });
+
+    const generatedQuery = generateQuery(clean, res);
+
+    t.deepEquals(generatedQuery.body.vs.var('input:layers').$, {
+      neighbourhood: [],
+      borough: [],
+      locality: [ '101932003' ],
+      localadmin: [ '404226357' ],
+      region: [ '85681545' ],
+      macroregion: [],
+      dependency: [],
+      country: [ '85632793' ],
+      macrocounty: [ '1376953385' ]
+    });
+
+    t.end();
+  });
 };
 
 module.exports.all = (tape, common) => {


### PR DESCRIPTION
This PR adds `macrocountry` as an alias for `locality` when using `address_search_using_ids` queries (ie. search with placeholder).

The major benefit of this change is that queries in Australia which include a token such "Sydney" will be expanded to include results from the Greater Sydney Area rather than only Sydney Central.

For example, [`300 Burns Bay Road, Sydney, AU`](https://pelias.github.io/compare/#/v1/search?text=300+burns+bay+road%2C+sydney%2C+AU&debug=1)

<img width="1142" height="489" alt="520126322-f19e0c06-f3d1-4549-b3c0-794547cdba6a" src="https://github.com/user-attachments/assets/f23924df-e74f-4093-ae9b-551281174051" />

This will additionally improve all other Australian cities and will affect any other countries using `macrocounty`, which at time of writing includes France, UK, Taiwan & French Guiana:

<img width="779" height="460" alt="Screenshot 2025-12-02 at 09 48 28" src="https://github.com/user-attachments/assets/c632113e-746b-481b-a0de-2e60edee91e7" />

This will now allow the `address_search_using_ids` queries to match for the larger `macrocounty` area instead of the smaller `locality` layer, this should be fine in all other cases, most notably it might potentially expand a little far in France, let's keep an eye on this, for example the token "Lyon" which previously only matched the smaller area, now matches the wider area, although this includes the airport...

<img width="663" height="601" alt="520148267-bf819746-9ec0-4733-b1c1-53c2a029068c" src="https://github.com/user-attachments/assets/c0492aed-0d96-470c-a22a-f29124ddb1c5" />

Finally worth noting the original work, as mentioned in the code comments in this file are designed to prevent the inverse from happening in the USA, this functionality has been maintained:

<img width="1138" height="406" alt="520129592-582f6698-798e-46dc-b6c6-91d10baf4f82" src="https://github.com/user-attachments/assets/3837672d-0680-4b22-9e5d-fa580204a755" />
