### PR TITLE
refactor: remove `Debug` timer commands

### DIFF
--- a/controller/coarse_reverse.js
+++ b/controller/coarse_reverse.js
@@ -114,7 +114,7 @@ function setup(service, should_execute) {
     if (!should_execute(req, res)) {
       return next();
     }
-    const initialTime = debugLog.beginTimer(req);
+
     // return a warning to the caller that boundary.circle.radius will be ignored
     if (!_.isUndefined(req.clean['boundary.circle.radius'])) {
       req.warnings.push('boundary.circle.radius is not applicable for coarse reverse');
@@ -125,11 +125,7 @@ function setup(service, should_execute) {
     const effective_layers = getEffectiveLayers(req.clean.layers);
     debugLog.push(req, {effective_layers: effective_layers});
 
-    const centroid = {
-      lat: req.clean['point.lat'],
-      lon: req.clean['point.lon']
-    };
-
+    const start = Date.now();
     service(req, (err, results, metadata) => {
       // if there's an error, log it and bail
       if (err) {
@@ -160,7 +156,7 @@ function setup(service, should_execute) {
           res.data.push(doc);
         }
       }
-      debugLog.stopTimer(req, initialTime);
+      debugLog.push(req, { duration: Date.now() - start });
       return next();
 
     });

--- a/controller/libpostal.js
+++ b/controller/libpostal.js
@@ -68,8 +68,7 @@ function setup(libpostalService, should_execute) {
       return next();
     }
 
-    const initialTime = debugLog.beginTimer(req);
-
+    const start = Date.now();
     libpostalService(req, (err, response) => {
 
       if (err) {
@@ -101,15 +100,14 @@ function setup(libpostalService, should_execute) {
           req.clean.parsed_text.country = iso3166.convertISO2ToISO3(req.clean.parsed_text.country);
         }
 
-        debugLog.push(req, {parsed_text: req.clean.parsed_text});
-
+        debugLog.push(req, {
+          parsed_text: req.clean.parsed_text,
+          duration: Date.now() - start
+        });
       }
 
-      debugLog.stopTimer(req, initialTime);
       return next();
-
     });
-
   }
 
   return controller;

--- a/controller/placeholder.js
+++ b/controller/placeholder.js
@@ -252,9 +252,8 @@ function setup(placeholderService, do_geometric_filters_apply, should_execute) {
     if (!should_execute(req, res)) {
       return next();
     }
-    const initialTime = debugLog.beginTimer(req);
+    
     const start = Date.now();
-
     placeholderService(req, (err, results) => {
       logger.info('placeholder', {
         response_time: Date.now() - start,
@@ -305,7 +304,9 @@ function setup(placeholderService, do_geometric_filters_apply, should_execute) {
         debugLog.push(req, (results || []));
       }
 
-      debugLog.stopTimer(req, initialTime);
+      debugLog.push(req, {
+        duration: Date.now() - start
+      });
       return next();
     });
 

--- a/controller/structured_libpostal.js
+++ b/controller/structured_libpostal.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const Debug = require('../helper/debug');
 const debugLog = new Debug('controller:libpostal');
-const logger = require('pelias-logger').get('api');
 
 // Find field in libpostal response 
 function findField(response, field, replacementField) {
@@ -24,8 +23,7 @@ function setup(libpostalService, should_execute) {
       return next();
     }
 
-    const initialTime = debugLog.beginTimer(req);
-
+    const start = Date.now();
     libpostalService(req, (err, response) => {
       if (err) {
         // push err.message or err onto req.errors
@@ -69,11 +67,12 @@ function setup(libpostalService, should_execute) {
         // the address field no longer means anything since it's been parsed, so remove it
         delete req.clean.parsed_text.address;
 
-        debugLog.push(req, {parsed_text: response});
-
+        debugLog.push(req, {
+          parsed_text: response,
+          duration: Date.now() - start
+        });
       }
-
-      debugLog.stopTimer(req, initialTime);
+      
       return next();
 
     });

--- a/helper/debug.js
+++ b/helper/debug.js
@@ -24,31 +24,6 @@ class Debug {
       req.debug.push({ [this.name]: value });
     }
   }
-
-  beginTimer(req, message) {
-    if (!Debug.isEnabled(req)) { return; }
-
-    if (Debug.validMessage(message)) {
-      this.push(req, `Timer Began. ${message}`);
-    } else {
-      this.push(req, `Timer Began.`);
-    }
-
-    return Date.now();
-  }
-
-  stopTimer(req, timer, message) {
-    if (!Debug.isEnabled(req)) { return; }
-
-    // measure elapsed duration
-    const elapsed = _.isFinite(timer) ? (Date.now() - timer) : -1;
-
-    if (Debug.validMessage(message)) {
-      this.push(req, `Timer Stopped. ${elapsed} ms. ${message}`);
-    } else {
-      this.push(req, `Timer Stopped. ${elapsed} ms`);
-    }
-  }
 }
 
 module.exports = Debug;

--- a/middleware/interpolate.js
+++ b/middleware/interpolate.js
@@ -62,9 +62,8 @@ function setup(service, should_execute, interpolationConfiguration) {
     const street_results = _.get(res, 'data', []).filter(result => result.layer === 'street');
 
     // perform interpolations asynchronously for all relevant hits
-    const initialTime = debugLog.beginTimer(req);
 
-    const startTime = Date.now();
+    const start = Date.now();
     const logInfo = {
       controller: 'interpolation', //technically middleware, but stay consistent with other log lines
       street_count: street_results.length,
@@ -148,9 +147,11 @@ function setup(service, should_execute, interpolationConfiguration) {
 
 
       // log and continue
-      logInfo.total_response_time = Date.now() - startTime;
+      logInfo.total_response_time = Date.now() - start;
       logger.info('interpolation', logInfo);
-      debugLog.stopTimer(req, initialTime);
+      debugLog.push(req, {
+        duration: Date.now() - start
+      });
       next();
     });
   };

--- a/test/unit/controller/placeholder.js
+++ b/test/unit/controller/placeholder.js
@@ -197,7 +197,7 @@ module.exports.tests.success = (test, common) => {
     const logger = mock_logger();
 
     const placeholder_service = (req, callback) => {
-      t.deepEqual(req, { param1: 'param1 value', clean: { enableDebug: true }, debug: [ { 'controller:placeholder': 'Timer Began.' } ] });
+      t.deepEqual(req, { param1: 'param1 value', clean: { enableDebug: true }});
       callback(null, response);
     };
 
@@ -300,9 +300,8 @@ module.exports.tests.success = (test, common) => {
       t.deepEquals(res, expected_res);
       t.ok(logger.isDebugMessage('[controller:placeholder] [result_count:2]'));
 
-      t.equal(req.debug[0]['controller:placeholder'], 'Timer Began.');
-      t.deepEqual(req.debug[1]['controller:placeholder'], response);
-      t.match(req.debug[2]['controller:placeholder'], /Timer Stopped. \d+ ms/);
+      t.deepEqual(req.debug[0]['controller:placeholder'], response);
+      t.true(req.debug[1]['controller:placeholder'].hasOwnProperty('duration'));
 
       t.end();
     });

--- a/test/unit/helper/debug.js
+++ b/test/unit/helper/debug.js
@@ -21,18 +21,6 @@ module.exports.tests.debug = function(test, common) {
     t.end();
   });
 
-  test('don\'t start timer if enableDebug is false', (t) => {
-    const debugLog = new Debug('debugger');
-    const req = {
-      clean: {
-        enableDebug: false
-      }
-    };
-    debugLog.beginTimer(req, 'This should not be pushed');
-    t.deepEquals(req.debug, undefined);
-    t.end();
-  });
-
   test('don\'t push debug message if req.clean is empty', (t) => {
     const debugLog = new Debug('debugger');
     const req = {
@@ -53,13 +41,9 @@ module.exports.tests.debug = function(test, common) {
     const expected_req = [
       {
         debugger: 'This should be pushed'
-      },
-      {
-        debugger: 'Timer Began. Timer 1'
       }
     ];
     debugLog.push(req, 'This should be pushed');
-    debugLog.beginTimer(req, 'Timer 1');
     t.deepEquals(req.debug, expected_req);
     t.end();
   });
@@ -80,22 +64,6 @@ module.exports.tests.debug = function(test, common) {
     t.deepEquals(req.debug, expected_req);
     t.end();
   });
-
-  test('Timer should return number of milliseconds', (t) => {
-    const debugLog = new Debug('debugger');
-    const req = {
-      clean: {
-        enableDebug: true
-      }
-    };
-    const timer = debugLog.beginTimer(req);
-    debugLog.stopTimer(req, timer);
-    // Checks that there is a debug message
-    // that matches the pattern "Timer Stopped. [number] ms"
-    t.deepEquals(req.debug[1].debugger.match(/Timer Stopped\. \d+ ms/i).length, 1);
-    t.end();
-  });
-
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
the `Debug` class has `beginTimer` and `stopTimer` methods which produce a lot of noise in the debug view.

this PR removes the methods and replaces them with standard js date commands, standardizes the timer under the key 'duration' and combines the timer with other debug lines where possible.

<img width="444" height="301" alt="Screenshot 2025-12-03 at 11 26 51" src="https://github.com/user-attachments/assets/7650508a-234f-4058-81ab-d137a2040b9a" />
