### PR TITLE
add translations to debug view

### DIFF
--- a/middleware/changeLanguage.js
+++ b/middleware/changeLanguage.js
@@ -1,6 +1,8 @@
-var field = require('../helper/fieldValue');
-var logger = require( 'pelias-logger' ).get( 'api' );
+const field = require('../helper/fieldValue');
+const logger = require( 'pelias-logger' ).get( 'api' );
 const _ = require('lodash');
+const Debug = require('../helper/debug');
+const debugLog = new Debug('middleware:change_language');
 
 /**
 example response from language web service:
@@ -47,6 +49,12 @@ function setup(service, should_execute) {
         controller: 'language', //technically middleware, but this is consistent with other log lines
       });
 
+      debugLog.push(req, {
+        language: req.clean.lang.iso6391,
+        translations,
+        duration: Date.now() - start
+      });
+
       // otherwise, update all the docs with translations
       updateDocs(req, res, _.defaultTo(translations, []));
       next();
@@ -60,10 +68,10 @@ function setup(service, should_execute) {
 // update documents using a translation map
 function updateDocs( req, res, translations ){
   // this is the target language we will be translating to
-  var requestLanguage = req.clean.lang.iso6393;
+  const requestLanguage = req.clean.lang.iso6393;
 
   // iterate over response documents
-  res.data.forEach( function( doc, p ){
+  res.data.forEach(doc => {
 
     // update name.default to the request language (if available)
     if (req.clean.lang.defaulted === false) {
@@ -74,25 +82,25 @@ function updateDocs( req, res, translations ){
     if( !doc || !doc.parent ){ return; }
 
     // iterate over doc.parent.* attributes
-    for( var attr in doc.parent ){
+    for( const attr in doc.parent ){
 
       // match only attributes ending with '_id'
-      var match = attr.match(/^(.*)_id$/);
+      const match = attr.match(/^(.*)_id$/);
       if( !match ){ continue; }
 
       // adminKey is the property name without the '_id'
       // eg. for 'country_id', adminKey would be 'country'.
-      var adminKey = match[1];
-      var adminValues = doc.parent[adminKey];
+      const adminKey = match[1];
+      const adminValues = doc.parent[adminKey];
 
       // skip invalid/empty arrays
       if( !Array.isArray( adminValues ) || !adminValues.length ){ continue; }
 
       // iterate over adminValues (it's an array and can have more than one value)
-      for( var i in adminValues ){
+      for( const i in adminValues ){
 
         // find the corresponding key from the '_id' Array
-        var id = doc.parent[attr][i];
+        const id = doc.parent[attr][i];
         if( !id ){ continue; }
 
         // id not found in translation service response
@@ -120,17 +128,11 @@ function updateDocs( req, res, translations ){
   });
 }
 
-// boolean function to check if changing the language is required
-function isLanguageChangeRequired( req, res ){
-  return req && res && res.data && res.data.length &&
-         req.hasOwnProperty('language');
-}
-
 // update name.default with the corresponding translation if available
 function translateNameDefault(doc, lang) {
-    if (lang && _.has(doc, 'name.' + lang)) {
-        doc.name.default = field.getStringValue(doc.name[lang]);
-    }
+  if (lang && _.has(doc, 'name.' + lang)) {
+    doc.name.default = field.getStringValue(doc.name[lang]);
+  }
 }
 
 module.exports = setup;


### PR DESCRIPTION
There is currently no entry in the `?debug` info showing if/when a document has been translated via the language service (ie. placeholder).

This can make debugging quite frustrating, which is why i've added it here.

Interestingly, the response is quite verbose, possibly why it was never logged in the first place, but also indicates that we can probably optimise this operation.

```js
{
  '85633793': {
    id: 85633793,
    name: 'United States',
    abbr: 'USA',
    placetype: 'country',
    rank: { min: 19, max: 20 },
    population: 331449281,
    lineage: [ [Object] ],
    geom: {
      area: 1166.190125,
      bbox: '-124.848973,24.396308,-66.885444,49.384358',
      lat: 39.71614,
      lon: -96.999246
    },
    names: { eng: [Array] }
  },
  '85688513': {
    id: 85688513,
    name: 'Oregon',
    abbr: 'OR',
    placetype: 'region',
    rank: { min: 14, max: 15 },
    population: 4237256,
    lineage: [ [Object] ],
    geom: {
      area: 28.568535,
      bbox: '-124.703541,41.991794,-116.463262,46.299099',
      lat: 43.854178,
      lon: -120.526709
    },
    names: { eng: [Array] }
  },
  '85688623': {
    id: 85688623,
    name: 'Washington',
    abbr: 'WA',
    placetype: 'region',
    rank: { min: 14, max: 15 },
    population: 7705281,
    lineage: [ [Object] ],
    geom: {
      area: 22.010713,
      bbox: '-124.848974,45.543541,-116.91558,49.002494',
      lat: 47.372269,
      lon: -120.59234
    },
    names: { eng: [Array] }
  },
  '101715829': {
    id: 101715829,
    name: 'Portland',
    placetype: 'locality',
    rank: { min: 9, max: 10 },
    population: 583776,
    lineage: [ [Object] ],
    geom: {
      area: 0.04329,
      bbox: '-122.83675,45.432393,-122.472021,45.653272',
      lat: 45.533467,
      lon: -122.650095
    },
    names: { eng: [Array] }
  },
  '101730071': {
    id: 101730071,
    name: 'Vancouver',
    placetype: 'locality',
    rank: { min: 9, max: 10 },
    population: 161791,
    lineage: [ [Object] ],
    geom: {
      area: 0.015075,
      bbox: '-122.774511,45.576375,-122.464669,45.695422',
      lat: 45.632518,
      lon: -122.543137
    },
    names: { eng: [Array] }
  },
  '102081631': {
    id: 102081631,
    name: 'Multnomah County',
    abbr: 'MU',
    placetype: 'county',
    rank: { min: 12, max: 13 },
    population: 815428,
    lineage: [ [Object] ],
    geom: {
      area: 0.138938,
      bbox: '-122.929226,45.432712,-121.820394,45.728687',
      lat: 45.534259,
      lon: -122.600162
    },
    names: { eng: [Array] }
  },
  '102084251': {
    id: 102084251,
    name: 'Clark County',
    abbr: 'CR',
    placetype: 'county',
    rank: { min: 12, max: 13 },
    population: 503311,
    lineage: [ [Object] ],
    geom: {
      area: 0.196627,
      bbox: '-122.795963,45.543541,-122.24472,46.059632',
      lat: 45.778397,
      lon: -122.460187
    },
    names: { eng: [Array] }
  },
  '420548947': {
    id: 420548947,
    name: 'Portland',
    placetype: 'neighbourhood',
    rank: { min: 5, max: 6 },
    population: 200,
    lineage: [ [Object] ],
    geom: {
      bbox: '-122.688886,45.630838,-122.678886,45.640838',
      lat: 45.635838,
      lon: -122.683886
    },
    names: {}
  }
}
```