### PR TITLE
do not replace `geonames` `name.default` with value from `whosonfirst`

### DIFF
--- a/middleware/changeLanguage.js
+++ b/middleware/changeLanguage.js
@@ -1,6 +1,10 @@
-var field = require('../helper/fieldValue');
-var logger = require( 'pelias-logger' ).get( 'api' );
+const field = require('../helper/fieldValue');
+const logger = require( 'pelias-logger' ).get( 'api' );
 const _ = require('lodash');
+
+// note: responses from the language service are (at time of writing)
+// all from the 'whosonfirst' source.
+const LANG_SERVICE_SOURCE = 'whosonfirst';
 
 /**
 example response from language web service:
@@ -112,7 +116,7 @@ function updateDocs( req, res, translations ){
 
         // if the record is an admin record we also translate
         // the 'name.default' property.
-        if( adminKey === doc.layer ){
+        if( adminKey === doc.layer && doc.source === LANG_SERVICE_SOURCE ){
           doc.name.default = translations[id].names[ requestLanguage ][0];
         }
       }

--- a/test/unit/middleware/changeLanguage.js
+++ b/test/unit/middleware/changeLanguage.js
@@ -144,6 +144,7 @@ module.exports.tests.success_conditions = (test, common) => {
       data: [
         // doc with 2 layer names that will be changed
         {
+          source: 'whosonfirst',
           name: {
             default: 'original name for 1st result'
           },
@@ -161,6 +162,7 @@ module.exports.tests.success_conditions = (test, common) => {
         {},
         // doc with only 1 layer name that will be changed and no default name change
         {
+          source: 'whosonfirst',
           name: {
             default: 'original name for 2nd result'
           },
@@ -184,6 +186,7 @@ module.exports.tests.success_conditions = (test, common) => {
         },
         // doc with name that will be translated
         {
+          source: 'whosonfirst',
           name: {
             default: 'original name for 4th result',
             'requested language': 'translated name'
@@ -197,12 +200,25 @@ module.exports.tests.success_conditions = (test, common) => {
         },
         // doc with name that will be translated
         {
+          source: 'whosonfirst',
           name: {
             default: 'original name for 5th result',
             'random language': 'translated name'
           },
           // note that this is address!
           layer: 'address',
+          parent: {
+            layer1_id: ['1'],
+            layer1: ['original name for layer1']
+          }
+        },
+        // geonames record will have parents translated but not default name
+        {
+          source: 'geonames',
+          name: {
+            default: 'geonames name'
+          },
+          layer: 'locality',
           parent: {
             layer1_id: ['1'],
             layer1: ['original name for layer1']
@@ -221,6 +237,7 @@ module.exports.tests.success_conditions = (test, common) => {
       t.deepEquals(res, {
         data: [
           {
+            source: 'whosonfirst',
             name: {
               default: 'replacement name for layer1'
             },
@@ -235,6 +252,7 @@ module.exports.tests.success_conditions = (test, common) => {
           undefined,
           {},
           {
+            source: 'whosonfirst',
             name: {
               default: 'original name for 2nd result'
             },
@@ -253,6 +271,7 @@ module.exports.tests.success_conditions = (test, common) => {
             }
           },
           {
+            source: 'whosonfirst',
             name: {
               default: 'translated name',
               'requested language': 'translated name'
@@ -264,11 +283,23 @@ module.exports.tests.success_conditions = (test, common) => {
             }
           },
           {
+            source: 'whosonfirst',
             name: {
               default: 'original name for 5th result',
               'random language': 'translated name'
             },
             layer: 'address',
+            parent: {
+              layer1_id: ['1'],
+              layer1: ['replacement name for layer1']
+            }
+          },
+          {
+            source: 'geonames',
+            name: {
+              default: 'geonames name'
+            },
+            layer: 'locality',
             parent: {
               layer1_id: ['1'],
               layer1: ['replacement name for layer1']


### PR DESCRIPTION
this took me a while to track down... 😱 

the [Geonames record](https://www.geonames.org/1717511/province-of-cebu.html) for 'Province of Cebu' is being returned as ['Cebu City'](https://pelias.github.io/compare/#/v1/autocomplete?size=1&text=cebu).

after much digging I found this line which assumes that it's safe to replace the `name.default` value from a placeholder response at the same layer, however this isn't the case when the sources differ, or in fact for any sources which aren't `whosonfirst`.