### PR TITLE
Prefer country over locality when deduping

### DIFF
--- a/helper/diffPlaces.js
+++ b/helper/diffPlaces.js
@@ -10,8 +10,8 @@ const codec = require('pelias-model').codec;
 // when performing inter-layer deduping, layers coming earlier in this list take
 // preference to those appearing later.
 const layerPreferences = [
-  'locality',
   'country',
+  'locality',
   'localadmin',
   'county',
   'region',

--- a/test/unit/middleware/dedupe.js
+++ b/test/unit/middleware/dedupe.js
@@ -519,7 +519,7 @@ module.exports.tests.priority = function(test, common) {
     var expectedCount = 1;
     dedupe(req, res, function () {
       t.equal(res.data.length, expectedCount, 'results have fewer items than before');
-      t.deepEqual(res.data[0].layer, 'locality', 'locality result won');
+      t.deepEqual(res.data[0].layer, 'country', 'country result won');
       t.end();
     });
   });


### PR DESCRIPTION
This is a simple change to prefer country records over localities when we are deduplicating two matching records.

Note that this doesn't change _when_ deduplication will occur, just which record we prefer when doing so and having identified two records as duplicates.

It mostly affects city-states and small countries like Singapore, Hong-Kong, etc. Some not-quite-city-states like Luxembourg are also affected.

It's a bit of a stylistic change, in these cases either the country or locality is _technically_ correct.

Some things this fixes:
- Previously, Mexico City and Mexico were both deduplicated to Mexico City. Thus there was nothing you could type in to get Mexico the country. Now, you'll get the country until you type 'Mexico C'. This is still not ideal, we really should not deduplicate those two records, but for now this is at least better.
- We've found there are some junk locality records out there that match country names, and this conveniently removes all of them.