### PR TITLE
Configure CI for NPM OIDC Tokens

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,19 +6,21 @@ jobs:
   npm-publish:
     needs: unit-tests
     if: github.ref == 'refs/heads/master' && needs.unit-tests.result == 'success'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Run semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          if [[ -n "$GH_TOKEN" && -n "$NPM_TOKEN" ]]; then
+          if [[ "${{ github.repository_owner }}" == "pelias" ]]; then
             curl "https://raw.githubusercontent.com/pelias/ci-tools/master/semantic-release.sh" | bash -
           fi
   build-docker-images:
@@ -26,7 +28,7 @@ jobs:
     # note: github actions won't run a job if you don't call one of the status check functions, so `always()` is called since it evalutes to `true`
     if: ${{ always() && needs.unit-tests.result == 'success' && (needs.npm-publish.result == 'success' || needs.npm-publish.result == 'skipped') }}
     needs: [unit-tests, npm-publish]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Docker images


### PR DESCRIPTION
Responding to the email "Classic npm tokens stop working December 9th" this PR migrates our classic tokens to 'OIDC' tokens.

There are two options for migration:

*Granular Access Tokens*
These are fairly similar to the classic tokens but have a maximum lifespan of 90 days, this sounds like an arduous chore.

*OIDC Trusted Pubishing*
https://docs.npmjs.com/trusted-publishers
This is only available for Github/Gitlab but lets you define the repo and workflow file that has permissions to publish.

What's requires are this change to every affected repo, plus going through the `npm` modules manually by an admin at a url such as https://www.npmjs.com/package/pelias-api/access and configuring them.

The configuration looks like this:

<img width="761" height="589" alt="Screenshot 2025-12-05 at 13 14 54" src="https://github.com/user-attachments/assets/9309062f-e874-4686-9dd2-a923475f26f4" />
<img width="771" height="427" alt="Screenshot 2025-12-05 at 13 15 01" src="https://github.com/user-attachments/assets/9efb6386-cefa-42d9-8234-21cdfbb3b1c1" />

